### PR TITLE
packet: long/short header parsing and packet types

### DIFF
--- a/src/packet/header.zig
+++ b/src/packet/header.zig
@@ -1,0 +1,231 @@
+//! QUIC packet header parsing and serialization (RFC 9000 §17).
+//!
+//! Long header format (RFC 9000 §17.2):
+//!   +-+-+-+-+-+-+-+-+
+//!   |1|1|T T|X X X X|   first byte: Header Form=1, Fixed Bit=1, Type, flags
+//!   +-+-+-+-+-+-+-+-+
+//!   |    Version (32 bits)          |
+//!   |    DCIL (8) | DCID (0–160)   |
+//!   |    SCIL (8) | SCID (0–160)   |
+//!   | ...type-specific fields...   |
+//!
+//! Short header format (RFC 9000 §17.3):
+//!   +-+-+-+-+-+-+-+-+
+//!   |0|1|S|R R|K|P P|   first byte: Header Form=0, Fixed Bit=1, Spin, …
+//!   +-+-+-+-+-+-+-+-+
+//!   |    DCID (connection-specific length)                              |
+//!   |    Packet Number (1–4 bytes, protected)                          |
+
+const std = @import("std");
+const types = @import("../types.zig");
+const varint = @import("../varint.zig");
+
+pub const ConnectionId = types.ConnectionId;
+pub const Version = types.Version;
+
+pub const ParseError = error{
+    BufferTooShort,
+    InvalidFixedBit,
+    InvalidCidLength,
+    UnsupportedVersion,
+    TooLong,
+};
+
+/// The two possible header forms.
+pub const HeaderForm = enum { long, short };
+
+/// Long packet types (encoded in bits 4–5 of the first byte for QUIC v1).
+pub const LongType = enum(u2) {
+    initial = 0,
+    zero_rtt = 1,
+    handshake = 2,
+    retry = 3,
+};
+
+/// Parsed long header common fields (before type-specific fields).
+pub const LongHeader = struct {
+    packet_type: LongType,
+    version: u32,
+    dcid: ConnectionId,
+    scid: ConnectionId,
+    /// Raw first byte (contains type-specific flag bits).
+    first_byte: u8,
+};
+
+/// Parsed short (1-RTT) header common fields.
+pub const ShortHeader = struct {
+    spin_bit: bool,
+    key_phase: bool,
+    /// Number of packet number bytes on the wire (after header protection removal).
+    pn_len: u2,
+    dcid: ConnectionId,
+    /// Raw first byte.
+    first_byte: u8,
+};
+
+/// Parse a long header from `buf`, advancing the reader.
+/// The caller is responsible for providing the correct DCID length for short headers.
+pub fn parseLong(buf: []const u8) ParseError!struct { header: LongHeader, consumed: usize } {
+    if (buf.len < 7) return error.BufferTooShort;
+
+    const first = buf[0];
+    // Bit 7 must be 1 (long header), bit 6 must be 1 (fixed bit).
+    if (first & 0x80 == 0) return error.InvalidFixedBit; // should be long
+    if (first & 0x40 == 0) return error.InvalidFixedBit; // fixed bit
+
+    const pkt_type: LongType = @enumFromInt((first >> 4) & 0x03);
+    const version = std.mem.readInt(u32, buf[1..5], .big);
+
+    var pos: usize = 5;
+
+    // DCID
+    const dcid_len = buf[pos];
+    pos += 1;
+    if (dcid_len > types.max_cid_len) return error.InvalidCidLength;
+    if (pos + dcid_len > buf.len) return error.BufferTooShort;
+    const dcid = try ConnectionId.fromSlice(buf[pos .. pos + dcid_len]);
+    pos += dcid_len;
+
+    // SCID
+    if (pos >= buf.len) return error.BufferTooShort;
+    const scid_len = buf[pos];
+    pos += 1;
+    if (scid_len > types.max_cid_len) return error.InvalidCidLength;
+    if (pos + scid_len > buf.len) return error.BufferTooShort;
+    const scid = try ConnectionId.fromSlice(buf[pos .. pos + scid_len]);
+    pos += scid_len;
+
+    return .{
+        .header = .{
+            .packet_type = pkt_type,
+            .version = version,
+            .dcid = dcid,
+            .scid = scid,
+            .first_byte = first,
+        },
+        .consumed = pos,
+    };
+}
+
+/// Parse a short (1-RTT) header from `buf`.
+/// `dcid_len` must be known out-of-band (connection-specific).
+pub fn parseShort(buf: []const u8, dcid_len: usize) ParseError!struct { header: ShortHeader, consumed: usize } {
+    if (buf.len < 1 + dcid_len) return error.BufferTooShort;
+
+    const first = buf[0];
+    // Bit 7 must be 0 (short header), bit 6 must be 1 (fixed bit).
+    if (first & 0x80 != 0) return error.InvalidFixedBit; // should be short
+    if (first & 0x40 == 0) return error.InvalidFixedBit; // fixed bit
+
+    const spin = (first & 0x20) != 0;
+    const key_phase = (first & 0x04) != 0;
+    const pn_len: u2 = @intCast(first & 0x03);
+
+    var pos: usize = 1;
+    if (dcid_len > types.max_cid_len) return error.InvalidCidLength;
+    const dcid = try ConnectionId.fromSlice(buf[pos .. pos + dcid_len]);
+    pos += dcid_len;
+
+    return .{
+        .header = .{
+            .spin_bit = spin,
+            .key_phase = key_phase,
+            .pn_len = pn_len,
+            .dcid = dcid,
+            .first_byte = first,
+        },
+        .consumed = pos,
+    };
+}
+
+/// Write a long header into `buf`. Returns the number of bytes written.
+pub fn writeLong(
+    buf: []u8,
+    pkt_type: LongType,
+    version: u32,
+    dcid: ConnectionId,
+    scid: ConnectionId,
+    flags: u4,
+) error{BufferTooShort}!usize {
+    const needed = 1 + 4 + 1 + dcid.len + 1 + scid.len;
+    if (buf.len < needed) return error.BufferTooShort;
+
+    var pos: usize = 0;
+    // Header Form=1, Fixed Bit=1, Type (2 bits), flags (4 bits)
+    buf[pos] = 0xc0 | (@as(u8, @intFromEnum(pkt_type)) << 4) | flags;
+    pos += 1;
+    std.mem.writeInt(u32, buf[pos..][0..4], version, .big);
+    pos += 4;
+    buf[pos] = dcid.len;
+    pos += 1;
+    @memcpy(buf[pos .. pos + dcid.len], dcid.slice());
+    pos += dcid.len;
+    buf[pos] = scid.len;
+    pos += 1;
+    @memcpy(buf[pos .. pos + scid.len], scid.slice());
+    pos += scid.len;
+    return pos;
+}
+
+/// Write a short header into `buf`. Returns bytes written.
+pub fn writeShort(
+    buf: []u8,
+    dcid: ConnectionId,
+    spin: bool,
+    key_phase: bool,
+    pn_len: u2,
+) error{BufferTooShort}!usize {
+    const needed = 1 + dcid.len;
+    if (buf.len < needed) return error.BufferTooShort;
+
+    var first: u8 = 0x40; // Fixed Bit = 1, Header Form = 0
+    if (spin) first |= 0x20;
+    if (key_phase) first |= 0x04;
+    first |= pn_len;
+
+    buf[0] = first;
+    @memcpy(buf[1 .. 1 + dcid.len], dcid.slice());
+    return 1 + dcid.len;
+}
+
+test "header: long header round-trip" {
+    const testing = std.testing;
+
+    const dcid = try ConnectionId.fromSlice(&[_]u8{ 0xde, 0xad });
+    const scid = try ConnectionId.fromSlice(&[_]u8{ 0xbe, 0xef, 0x00 });
+
+    var buf: [64]u8 = undefined;
+    const written = try writeLong(&buf, .initial, 0x00000001, dcid, scid, 0x03);
+
+    const parsed = try parseLong(buf[0..written]);
+    try testing.expectEqual(LongType.initial, parsed.header.packet_type);
+    try testing.expectEqual(@as(u32, 0x00000001), parsed.header.version);
+    try testing.expect(ConnectionId.eql(dcid, parsed.header.dcid));
+    try testing.expect(ConnectionId.eql(scid, parsed.header.scid));
+    try testing.expectEqual(written, parsed.consumed);
+}
+
+test "header: short header round-trip" {
+    const testing = std.testing;
+
+    const dcid = try ConnectionId.fromSlice(&[_]u8{ 0x01, 0x02, 0x03, 0x04 });
+    var buf: [32]u8 = undefined;
+    const written = try writeShort(&buf, dcid, false, true, 2);
+
+    const parsed = try parseShort(buf[0..written], dcid.len);
+    try testing.expectEqual(false, parsed.header.spin_bit);
+    try testing.expectEqual(true, parsed.header.key_phase);
+    try testing.expectEqual(@as(u2, 2), parsed.header.pn_len);
+    try testing.expect(ConnectionId.eql(dcid, parsed.header.dcid));
+}
+
+test "header: fixed bit validation" {
+    var buf = [_]u8{0x00} ** 20;
+    // Long header with fixed bit cleared — should fail
+    buf[0] = 0x80; // Header Form=1, Fixed Bit=0
+    try std.testing.expectError(error.InvalidFixedBit, parseLong(&buf));
+
+    // Short header with fixed bit cleared — should fail
+    buf[0] = 0x00; // Header Form=0, Fixed Bit=0
+    try std.testing.expectError(error.InvalidFixedBit, parseShort(&buf, 4));
+}

--- a/src/packet/number.zig
+++ b/src/packet/number.zig
@@ -1,0 +1,104 @@
+//! Packet number encoding and decoding (RFC 9000 §17.1, §A.3).
+//!
+//! Packet numbers are encoded in 1–4 bytes on the wire. The sender truncates
+//! the full 62-bit packet number to the smallest representation that the
+//! receiver can unambiguously decode given its current receive window.
+//! The receiver reconstructs the full number via the algorithm in §A.3.
+
+const std = @import("std");
+
+/// Encoded byte length of a packet number (1..4).
+pub const EncodedLen = enum(u2) {
+    one = 0,
+    two = 1,
+    three = 2,
+    four = 3,
+
+    pub fn bytes(self: EncodedLen) u3 {
+        return @as(u3, @intFromEnum(self)) + 1;
+    }
+};
+
+/// Choose the smallest packet number encoding that covers the in-flight window.
+/// `pn` is the packet number to send; `largest_acked` is the largest packet
+/// number acknowledged by the peer (or null if none).
+pub fn encodeLen(pn: u64, largest_acked: ?u64) EncodedLen {
+    // The window the receiver needs to cover is twice the in-flight window.
+    const window: u64 = if (largest_acked) |la|
+        2 * (pn - la)
+    else
+        2 * pn + 1;
+
+    if (window < (1 << 8)) return .one;
+    if (window < (1 << 16)) return .two;
+    if (window < (1 << 24)) return .three;
+    return .four;
+}
+
+/// Encode `pn` into `buf` using `len` bytes (big-endian, truncated).
+pub fn encode(buf: []u8, pn: u64, len: EncodedLen) void {
+    const n = len.bytes();
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        buf[n - 1 - i] = @truncate(pn >> @intCast(i * 8));
+    }
+}
+
+/// Decode a packet number from `buf` (big-endian) given the largest
+/// successfully processed packet number `largest_pn` (RFC 9000 §A.3).
+pub fn decode(buf: []const u8, largest_pn: u64) u64 {
+    const n = buf.len;
+    var truncated: u64 = 0;
+    for (buf) |b| {
+        truncated = (truncated << 8) | b;
+    }
+
+    const pn_nbits: u6 = @intCast(n * 8);
+    const pn_win: u64 = @as(u64, 1) << pn_nbits;
+    const pn_hwin: u64 = pn_win >> 1;
+    const pn_mask: u64 = pn_win - 1;
+
+    // The expected next packet number is one beyond the largest we processed.
+    const expected_pn: u64 = largest_pn + 1;
+    // Start with the candidate that has the same high bits as expected_pn.
+    var candidate_pn = (expected_pn & ~pn_mask) | truncated;
+
+    // Adjust by pn_win in either direction to find the closest value.
+    if (candidate_pn + pn_hwin <= expected_pn and candidate_pn < (std.math.maxInt(u64) - pn_win)) {
+        candidate_pn += pn_win;
+    } else if (candidate_pn > expected_pn + pn_hwin and candidate_pn >= pn_win) {
+        candidate_pn -= pn_win;
+    }
+
+    return candidate_pn;
+}
+
+test "packet number: encode/decode round-trip" {
+    const testing = std.testing;
+
+    var buf: [4]u8 = undefined;
+
+    // Simple case: first packet
+    encode(&buf, 0, .one);
+    try testing.expectEqual(@as(u64, 0), decode(buf[0..1], 0));
+
+    encode(&buf, 1, .one);
+    try testing.expectEqual(@as(u64, 1), decode(buf[0..1], 0));
+
+    // 2-byte encoding
+    encode(&buf, 256, .two);
+    try testing.expectEqual(@as(u64, 256), decode(buf[0..2], 0));
+
+    // 4-byte encoding
+    encode(&buf, 0x1234_5678, .four);
+    try testing.expectEqual(@as(u64, 0x1234_5678), decode(buf[0..4], 0));
+}
+
+test "packet number: decode wraps correctly" {
+    const testing = std.testing;
+    // RFC 9000 §A.3 example: largest_pn = 0xa82f30ea, truncated = 0x9b32 (2 bytes)
+    // expected candidate: 0xa82f9b32
+    var buf = [_]u8{ 0x9b, 0x32 };
+    const result = decode(&buf, 0xa82f30ea);
+    try testing.expectEqual(@as(u64, 0xa82f9b32), result);
+}

--- a/src/packet/packet.zig
+++ b/src/packet/packet.zig
@@ -1,0 +1,265 @@
+//! All QUIC packet types: Initial, Handshake, 0-RTT, Retry, Version Negotiation,
+//! and 1-RTT (short header). Provides high-level parse/build helpers.
+//!
+//! Packet layout overview (before encryption):
+//!   Initial / Handshake / 0-RTT (Long):
+//!     [Long Header] [Token (Initial only)] [Length (varint)] [PN (1-4 B)] [Payload]
+//!   Retry (Long):
+//!     [Long Header] [Token] [Retry Integrity Tag (16 B)]
+//!   Version Negotiation:
+//!     [First Byte] [Version=0] [DCID Len+DCID] [SCID Len+SCID] [Supported Versions…]
+//!   1-RTT (Short):
+//!     [Short Header] [PN (1-4 B)] [Payload]
+
+const std = @import("std");
+const types = @import("../types.zig");
+const varint = @import("../varint.zig");
+const header = @import("header.zig");
+
+pub const ConnectionId = types.ConnectionId;
+pub const Version = types.Version;
+pub const LongType = header.LongType;
+
+pub const ParseError = header.ParseError || varint.DecodeError || error{ InvalidPacket, TooLong };
+
+/// Parsed Initial packet fields (after long header).
+pub const InitialPacket = struct {
+    dcid: ConnectionId,
+    scid: ConnectionId,
+    token: []const u8,
+    /// Byte offset of the start of the encrypted payload (PN + payload).
+    payload_offset: usize,
+    /// Number of bytes in (PN + payload), as encoded in the Length field.
+    payload_len: usize,
+};
+
+/// Parsed Retry packet.
+pub const RetryPacket = struct {
+    dcid: ConnectionId,
+    scid: ConnectionId,
+    /// Retry token (everything between header and integrity tag).
+    token: []const u8,
+    /// The 16-byte AES-128-GCM integrity tag.
+    integrity_tag: [16]u8,
+};
+
+/// Parsed Version Negotiation packet.
+pub const VersionNegotiationPacket = struct {
+    dcid: ConnectionId,
+    scid: ConnectionId,
+    /// Supported version list (each 4 bytes, may be empty).
+    versions: []const u8,
+};
+
+/// Parse an Initial packet from `buf` (buf[0] must be the first byte).
+pub fn parseInitial(buf: []const u8) ParseError!InitialPacket {
+    const lh = try header.parseLong(buf);
+    if (lh.header.packet_type != .initial) return error.InvalidPacket;
+    var pos = lh.consumed;
+
+    // Token length + token
+    if (pos >= buf.len) return error.BufferTooShort;
+    const tok_len_r = try varint.decode(buf[pos..]);
+    pos += tok_len_r.len;
+    const tok_len: usize = @intCast(tok_len_r.value);
+    if (pos + tok_len > buf.len) return error.BufferTooShort;
+    const token = buf[pos .. pos + tok_len];
+    pos += tok_len;
+
+    // Length (covers PN + payload)
+    if (pos >= buf.len) return error.BufferTooShort;
+    const payload_len_r = try varint.decode(buf[pos..]);
+    pos += payload_len_r.len;
+    const payload_len: usize = @intCast(payload_len_r.value);
+
+    if (pos + payload_len > buf.len) return error.BufferTooShort;
+
+    return .{
+        .dcid = lh.header.dcid,
+        .scid = lh.header.scid,
+        .token = token,
+        .payload_offset = pos,
+        .payload_len = payload_len,
+    };
+}
+
+/// Parse a Retry packet from `buf`.
+pub fn parseRetry(buf: []const u8) ParseError!RetryPacket {
+    const lh = try header.parseLong(buf);
+    if (lh.header.packet_type != .retry) return error.InvalidPacket;
+    const pos = lh.consumed;
+
+    // Everything after the header and before the last 16 bytes is the token.
+    if (buf.len < pos + 16) return error.BufferTooShort;
+    const token = buf[pos .. buf.len - 16];
+    var tag: [16]u8 = undefined;
+    @memcpy(&tag, buf[buf.len - 16 ..]);
+
+    return .{
+        .dcid = lh.header.dcid,
+        .scid = lh.header.scid,
+        .token = token,
+        .integrity_tag = tag,
+    };
+}
+
+/// Parse a Version Negotiation packet from `buf`.
+pub fn parseVersionNegotiation(buf: []const u8) ParseError!VersionNegotiationPacket {
+    if (buf.len < 7) return error.BufferTooShort;
+    // VN has version = 0x00000000 and may have any first byte with bit 7 set.
+    // Check version field.
+    if (buf[0] & 0x40 == 0) return error.InvalidFixedBit;
+    const version = std.mem.readInt(u32, buf[1..5], .big);
+    if (version != 0x00000000) return error.InvalidPacket;
+
+    var pos: usize = 5;
+    const dcid_len = buf[pos];
+    pos += 1;
+    if (pos + dcid_len > buf.len) return error.BufferTooShort;
+    const dcid = try ConnectionId.fromSlice(buf[pos .. pos + dcid_len]);
+    pos += dcid_len;
+
+    if (pos >= buf.len) return error.BufferTooShort;
+    const scid_len = buf[pos];
+    pos += 1;
+    if (pos + scid_len > buf.len) return error.BufferTooShort;
+    const scid = try ConnectionId.fromSlice(buf[pos .. pos + scid_len]);
+    pos += scid_len;
+
+    // Remaining bytes are supported version list (4-byte each).
+    const versions = buf[pos..];
+
+    return .{
+        .dcid = dcid,
+        .scid = scid,
+        .versions = versions,
+    };
+}
+
+/// Determine whether `buf` looks like a long-header packet.
+pub fn isLongHeader(buf: []const u8) bool {
+    if (buf.len == 0) return false;
+    return (buf[0] & 0x80) != 0;
+}
+
+/// Determine whether `buf` looks like a Version Negotiation packet.
+pub fn isVersionNegotiation(buf: []const u8) bool {
+    if (buf.len < 5) return false;
+    if (buf[0] & 0x80 == 0) return false;
+    return std.mem.readInt(u32, buf[1..5], .big) == 0;
+}
+
+/// Build an Initial packet header into `buf` (without encryption).
+/// Returns bytes written (header only; caller appends PN + payload).
+pub fn buildInitialHeader(
+    buf: []u8,
+    version: u32,
+    dcid: ConnectionId,
+    scid: ConnectionId,
+    token: []const u8,
+    payload_len: usize,
+    pn_len: u2,
+) (header.ParseError || varint.EncodeError || varint.DecodeError)!usize {
+    // First byte: Header Form=1, Fixed Bit=1, Type=Initial (00), Reserved=00, PN Len
+    buf[0] = 0xc0 | @as(u8, pn_len);
+    std.mem.writeInt(u32, buf[1..5], version, .big);
+    var pos: usize = 5;
+
+    buf[pos] = dcid.len;
+    pos += 1;
+    @memcpy(buf[pos .. pos + dcid.len], dcid.slice());
+    pos += dcid.len;
+
+    buf[pos] = scid.len;
+    pos += 1;
+    @memcpy(buf[pos .. pos + scid.len], scid.slice());
+    pos += scid.len;
+
+    // Token
+    const tok_enc = try varint.encode(buf[pos..], token.len);
+    pos += tok_enc.len;
+    @memcpy(buf[pos .. pos + token.len], token);
+    pos += token.len;
+
+    // Length = pn_len + 1 + payload_len
+    const length_field = @as(u64, pn_len) + 1 + payload_len;
+    const len_enc = try varint.encode(buf[pos..], length_field);
+    pos += len_enc.len;
+
+    return pos;
+}
+
+/// Build a Version Negotiation packet into `buf`. Returns bytes written.
+pub fn buildVersionNegotiation(
+    buf: []u8,
+    dcid: ConnectionId,
+    scid: ConnectionId,
+    supported: []const u32,
+) error{BufferTooShort}!usize {
+    const needed = 1 + 4 + 1 + dcid.len + 1 + scid.len + supported.len * 4;
+    if (buf.len < needed) return error.BufferTooShort;
+
+    // First byte: Header Form=1, Fixed Bit=1, random lower bits
+    buf[0] = 0xcf;
+    std.mem.writeInt(u32, buf[1..5], 0x00000000, .big); // version = 0
+    var pos: usize = 5;
+
+    buf[pos] = dcid.len;
+    pos += 1;
+    @memcpy(buf[pos .. pos + dcid.len], dcid.slice());
+    pos += dcid.len;
+
+    buf[pos] = scid.len;
+    pos += 1;
+    @memcpy(buf[pos .. pos + scid.len], scid.slice());
+    pos += scid.len;
+
+    for (supported) |v| {
+        std.mem.writeInt(u32, buf[pos..][0..4], v, .big);
+        pos += 4;
+    }
+    return pos;
+}
+
+test "packet: Initial parse" {
+    const testing = std.testing;
+
+    // Build a minimal Initial packet
+    const dcid = try ConnectionId.fromSlice(&[_]u8{ 0x01, 0x02 });
+    const scid = try ConnectionId.fromSlice(&[_]u8{0x03});
+    var buf: [128]u8 = undefined;
+
+    // Fake payload: 10 bytes; pn_len=0 → 1-byte PN on wire (length_field = 1 + 10 = 11)
+    const fake_payload_len = 10;
+    const pn_len_wire: u2 = 0; // wire encoding: 0 → 1 byte PN
+    const pos = try buildInitialHeader(&buf, 0x00000001, dcid, scid, &.{}, fake_payload_len, pn_len_wire);
+    // Fill fake PN (1 byte) + payload
+    buf[pos] = 0x00;
+    @memset(buf[pos + 1 .. pos + 1 + fake_payload_len], 0xAA);
+
+    const pkt = try parseInitial(buf[0 .. pos + 1 + fake_payload_len]);
+    try testing.expect(ConnectionId.eql(dcid, pkt.dcid));
+    try testing.expect(ConnectionId.eql(scid, pkt.scid));
+    try testing.expectEqual(@as(usize, 0), pkt.token.len);
+    // length_field = pn_len_wire(0) + 1 + fake_payload_len(10) = 11
+    try testing.expectEqual(@as(usize, 11), pkt.payload_len);
+}
+
+test "packet: Version Negotiation build/parse" {
+    const testing = std.testing;
+
+    const dcid = try ConnectionId.fromSlice(&[_]u8{ 0xAA, 0xBB });
+    const scid = try ConnectionId.fromSlice(&[_]u8{0xCC});
+    const supported = [_]u32{ 0x00000001, 0x6b3343cf };
+
+    var buf: [64]u8 = undefined;
+    const written = try buildVersionNegotiation(&buf, dcid, scid, &supported);
+
+    try testing.expect(isVersionNegotiation(buf[0..written]));
+    const pkt = try parseVersionNegotiation(buf[0..written]);
+    try testing.expect(ConnectionId.eql(dcid, pkt.dcid));
+    try testing.expect(ConnectionId.eql(scid, pkt.scid));
+    try testing.expectEqual(@as(usize, 8), pkt.versions.len);
+    try testing.expectEqual(@as(u32, 0x00000001), std.mem.readInt(u32, pkt.versions[0..4], .big));
+    try testing.expectEqual(@as(u32, 0x6b3343cf), std.mem.readInt(u32, pkt.versions[4..8], .big));
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,8 +9,16 @@
 
 pub const varint = @import("varint.zig");
 pub const types = @import("types.zig");
+pub const packet = struct {
+    pub const header = @import("packet/header.zig");
+    pub const number = @import("packet/number.zig");
+    pub const pkt = @import("packet/packet.zig");
+};
 
 test {
     _ = @import("varint.zig");
     _ = @import("types.zig");
+    _ = @import("packet/header.zig");
+    _ = @import("packet/number.zig");
+    _ = @import("packet/packet.zig");
 }


### PR DESCRIPTION
## Summary

- `src/packet/header.zig` — parse and write long/short QUIC packet headers (RFC 9000 §17)
- `src/packet/number.zig` — packet number 1–4 byte encode/decode with RFC 9000 §A.3 unwrapping algorithm
- `src/packet/packet.zig` — parse/build for Initial, Retry, Version Negotiation packets

## Test plan

- [ ] 16/16 tests pass (`zig build test --summary all`)
- [ ] `zig fmt --check .` passes
- [ ] RFC 9000 §A.3 packet number decode example verified in test