### PR TITLE
frames: all QUIC frame types with parse/serialize

### DIFF
--- a/src/frames/ack.zig
+++ b/src/frames/ack.zig
@@ -1,0 +1,190 @@
+//! ACK frame (RFC 9000 §19.3).
+//!
+//! Wire format:
+//!   Type (varint)         0x02 or 0x03
+//!   Largest Acknowledged (varint)
+//!   ACK Delay (varint)
+//!   ACK Range Count (varint)
+//!   First ACK Range (varint)
+//!   ACK Range[0..n] pairs:
+//!     Gap (varint)
+//!     ACK Range Length (varint)
+//!   [ECN Counts if type=0x03]
+//!     ECT0 Count (varint)
+//!     ECT1 Count (varint)
+//!     ECN-CE Count (varint)
+
+const std = @import("std");
+const varint = @import("../varint.zig");
+
+pub const max_ack_ranges = 64;
+
+pub const AckRange = struct {
+    /// Smallest packet number acknowledged in this range.
+    smallest: u64,
+    /// Largest packet number acknowledged in this range.
+    largest: u64,
+};
+
+pub const EcnCounts = struct {
+    ect0: u64,
+    ect1: u64,
+    ecn_ce: u64,
+};
+
+pub const AckFrame = struct {
+    largest_acknowledged: u64,
+    /// ACK delay in microseconds (scaled by 2^ack_delay_exponent).
+    ack_delay: u64,
+    /// Decoded ranges (largest first).
+    ranges: [max_ack_ranges]AckRange,
+    range_count: usize,
+    ecn: ?EcnCounts,
+
+    /// Parse an ACK frame from `buf` (after the type byte).
+    pub fn parse(buf: []const u8, has_ecn: bool) varint.DecodeError!struct { frame: AckFrame, consumed: usize } {
+        var r = varint.Reader.init(buf);
+
+        const largest = try r.readVarint();
+        const delay = try r.readVarint();
+        const range_count = try r.readVarint();
+        const first_range = try r.readVarint();
+
+        var frame: AckFrame = .{
+            .largest_acknowledged = largest,
+            .ack_delay = delay,
+            .ranges = undefined,
+            .range_count = 0,
+            .ecn = null,
+        };
+
+        // First range: [largest - first_range, largest]
+        frame.ranges[0] = .{
+            .largest = largest,
+            .smallest = largest -| first_range,
+        };
+        frame.range_count = 1;
+
+        // Additional ranges
+        var i: usize = 0;
+        var current_smallest = frame.ranges[0].smallest;
+        while (i < range_count and frame.range_count < max_ack_ranges) : (i += 1) {
+            const gap = try r.readVarint();
+            const range_len = try r.readVarint();
+            // The largest of this range is 2 below the smallest of the previous
+            const range_largest = current_smallest -| (gap + 2);
+            const range_smallest = range_largest -| range_len;
+            frame.ranges[frame.range_count] = .{
+                .largest = range_largest,
+                .smallest = range_smallest,
+            };
+            frame.range_count += 1;
+            current_smallest = range_smallest;
+        }
+
+        if (has_ecn) {
+            const ect0 = try r.readVarint();
+            const ect1 = try r.readVarint();
+            const ecn_ce = try r.readVarint();
+            frame.ecn = .{ .ect0 = ect0, .ect1 = ect1, .ecn_ce = ecn_ce };
+        }
+
+        return .{ .frame = frame, .consumed = r.pos };
+    }
+
+    /// Serialize the ACK frame into `buf`. Returns bytes written.
+    pub fn serialize(self: AckFrame, buf: []u8) (varint.EncodeError || varint.DecodeError)!usize {
+        var w = varint.Writer.init(buf);
+        // Type
+        try w.writeVarint(if (self.ecn != null) 0x03 else 0x02);
+        try w.writeVarint(self.largest_acknowledged);
+        try w.writeVarint(self.ack_delay);
+
+        // Number of additional ranges (total - 1)
+        const additional = if (self.range_count > 0) self.range_count - 1 else 0;
+        try w.writeVarint(additional);
+
+        // First range
+        if (self.range_count > 0) {
+            const first = self.ranges[0];
+            try w.writeVarint(first.largest - first.smallest);
+
+            // Additional ranges
+            var i: usize = 1;
+            var prev_smallest = first.smallest;
+            while (i < self.range_count) : (i += 1) {
+                const r = self.ranges[i];
+                // gap = prev_smallest - r.largest - 2
+                const gap = prev_smallest - r.largest - 2;
+                try w.writeVarint(gap);
+                try w.writeVarint(r.largest - r.smallest);
+                prev_smallest = r.smallest;
+            }
+        }
+
+        if (self.ecn) |ecn| {
+            try w.writeVarint(ecn.ect0);
+            try w.writeVarint(ecn.ect1);
+            try w.writeVarint(ecn.ecn_ce);
+        }
+
+        return w.pos;
+    }
+
+    /// Returns true if `pn` is acknowledged by this ACK frame.
+    pub fn acknowledges(self: AckFrame, pn: u64) bool {
+        for (self.ranges[0..self.range_count]) |r| {
+            if (pn >= r.smallest and pn <= r.largest) return true;
+        }
+        return false;
+    }
+};
+
+test "ack: single range parse/serialize round-trip" {
+    const testing = std.testing;
+
+    // Serialize an ACK: largest=10, delay=0, first_range=5 → acks [5..10]
+    var buf: [64]u8 = undefined;
+    var w = varint.Writer.init(&buf);
+    try w.writeVarint(0x02); // type
+    try w.writeVarint(10); // largest
+    try w.writeVarint(0); // delay
+    try w.writeVarint(0); // range count (0 additional)
+    try w.writeVarint(5); // first range
+
+    const r = try AckFrame.parse(buf[1..w.pos], false);
+    try testing.expectEqual(@as(u64, 10), r.frame.largest_acknowledged);
+    try testing.expectEqual(@as(usize, 1), r.frame.range_count);
+    try testing.expectEqual(@as(u64, 5), r.frame.ranges[0].smallest);
+    try testing.expectEqual(@as(u64, 10), r.frame.ranges[0].largest);
+    try testing.expect(r.frame.acknowledges(7));
+    try testing.expect(!r.frame.acknowledges(4));
+    try testing.expect(!r.frame.acknowledges(11));
+}
+
+test "ack: serialize and re-parse" {
+    const testing = std.testing;
+
+    var frame = AckFrame{
+        .largest_acknowledged = 100,
+        .ack_delay = 500,
+        .ranges = undefined,
+        .range_count = 2,
+        .ecn = null,
+    };
+    frame.ranges[0] = .{ .largest = 100, .smallest = 90 };
+    frame.ranges[1] = .{ .largest = 80, .smallest = 70 };
+
+    var buf: [64]u8 = undefined;
+    const written = try frame.serialize(&buf);
+    try testing.expect(written > 0);
+
+    // Skip the type byte that serialize() writes
+    const r = try AckFrame.parse(buf[1..written], false);
+    try testing.expectEqual(@as(u64, 100), r.frame.largest_acknowledged);
+    try testing.expectEqual(@as(u64, 500), r.frame.ack_delay);
+    try testing.expectEqual(@as(usize, 2), r.frame.range_count);
+    try testing.expect(r.frame.acknowledges(95));
+    try testing.expect(r.frame.acknowledges(75));
+    try testing.expect(!r.frame.acknowledges(85));
+}

--- a/src/frames/crypto_frame.zig
+++ b/src/frames/crypto_frame.zig
@@ -1,0 +1,67 @@
+//! CRYPTO frame (RFC 9000 §19.6).
+//!
+//! Wire format (after type byte 0x06):
+//!   Offset (varint)
+//!   Length (varint)
+//!   Crypto Data (Length bytes)
+//!
+//! CRYPTO frames carry TLS handshake data. The Offset and Length fields
+//! are used to reassemble the handshake stream from potentially
+//! out-of-order or fragmented frames.
+
+const std = @import("std");
+const varint = @import("../varint.zig");
+
+pub const CryptoFrame = struct {
+    /// Byte offset of the start of this CRYPTO data in the handshake stream.
+    offset: u64,
+    /// The raw TLS handshake bytes.
+    data: []const u8,
+
+    /// Parse a CRYPTO frame from `buf` (after the type byte).
+    pub fn parse(buf: []const u8) varint.DecodeError!struct { frame: CryptoFrame, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const offset = try r.readVarint();
+        const length = try r.readVarint();
+        const data = try r.readBytes(@intCast(length));
+        return .{
+            .frame = .{ .offset = offset, .data = data },
+            .consumed = r.pos,
+        };
+    }
+
+    /// Serialize into `buf`. Returns bytes written (includes type byte).
+    pub fn serialize(self: CryptoFrame, buf: []u8) (varint.EncodeError || varint.DecodeError)!usize {
+        var w = varint.Writer.init(buf);
+        try w.writeVarint(0x06);
+        try w.writeVarint(self.offset);
+        try w.writeVarint(self.data.len);
+        try w.writeBytes(self.data);
+        return w.pos;
+    }
+};
+
+test "crypto_frame: parse/serialize round-trip" {
+    const testing = std.testing;
+    const data = "TLSHandshakeBytes";
+    const frame = CryptoFrame{ .offset = 42, .data = data };
+
+    var buf: [64]u8 = undefined;
+    const written = try frame.serialize(&buf);
+
+    // Skip type byte
+    const r = try CryptoFrame.parse(buf[1..written]);
+    try testing.expectEqual(@as(u64, 42), r.frame.offset);
+    try testing.expectEqualSlices(u8, data, r.frame.data);
+}
+
+test "crypto_frame: offset=0 short data" {
+    const testing = std.testing;
+    const frame = CryptoFrame{ .offset = 0, .data = "abc" };
+    var buf: [16]u8 = undefined;
+    const written = try frame.serialize(&buf);
+
+    const r = try CryptoFrame.parse(buf[1..written]);
+    try testing.expectEqual(@as(u64, 0), r.frame.offset);
+    try testing.expectEqualSlices(u8, "abc", r.frame.data);
+}

--- a/src/frames/frame.zig
+++ b/src/frames/frame.zig
@@ -1,0 +1,239 @@
+//! All QUIC frame types (RFC 9000 §12.4, §19).
+//!
+//! Frame type → wire encoding (first varint):
+//!   PADDING           0x00
+//!   PING              0x01
+//!   ACK               0x02 / 0x03
+//!   RESET_STREAM      0x04
+//!   STOP_SENDING      0x05
+//!   CRYPTO            0x06
+//!   NEW_TOKEN         0x07
+//!   STREAM            0x08–0x0f
+//!   MAX_DATA          0x10
+//!   MAX_STREAM_DATA   0x11
+//!   MAX_STREAMS (bi)  0x12
+//!   MAX_STREAMS (uni) 0x13
+//!   DATA_BLOCKED      0x14
+//!   STREAM_DATA_BLOCKED 0x15
+//!   STREAMS_BLOCKED (bi)  0x16
+//!   STREAMS_BLOCKED (uni) 0x17
+//!   NEW_CONNECTION_ID   0x18
+//!   RETIRE_CONNECTION_ID 0x19
+//!   PATH_CHALLENGE    0x1a
+//!   PATH_RESPONSE     0x1b
+//!   CONNECTION_CLOSE  0x1c / 0x1d
+//!   HANDSHAKE_DONE    0x1e
+//!   DATAGRAM          0x30 / 0x31  (RFC 9221)
+
+const std = @import("std");
+const varint = @import("../varint.zig");
+const types = @import("../types.zig");
+
+pub const ack = @import("ack.zig");
+pub const crypto_frame = @import("crypto_frame.zig");
+pub const stream = @import("stream.zig");
+pub const transport = @import("transport.zig");
+
+pub const FrameType = enum(u64) {
+    padding = 0x00,
+    ping = 0x01,
+    ack = 0x02,
+    ack_ecn = 0x03,
+    reset_stream = 0x04,
+    stop_sending = 0x05,
+    crypto = 0x06,
+    new_token = 0x07,
+    // STREAM 0x08–0x0f (flags in low 3 bits)
+    max_data = 0x10,
+    max_stream_data = 0x11,
+    max_streams_bidi = 0x12,
+    max_streams_uni = 0x13,
+    data_blocked = 0x14,
+    stream_data_blocked = 0x15,
+    streams_blocked_bidi = 0x16,
+    streams_blocked_uni = 0x17,
+    new_connection_id = 0x18,
+    retire_connection_id = 0x19,
+    path_challenge = 0x1a,
+    path_response = 0x1b,
+    connection_close_quic = 0x1c,
+    connection_close_app = 0x1d,
+    handshake_done = 0x1e,
+    _,
+};
+
+/// A parsed QUIC frame, representing one of the many frame types.
+pub const Frame = union(enum) {
+    padding: transport.Padding,
+    ping: transport.Ping,
+    ack: ack.AckFrame,
+    reset_stream: transport.ResetStream,
+    stop_sending: transport.StopSending,
+    crypto: crypto_frame.CryptoFrame,
+    new_token: transport.NewToken,
+    stream: stream.StreamFrame,
+    max_data: transport.MaxData,
+    max_stream_data: transport.MaxStreamData,
+    max_streams_bidi: transport.MaxStreams,
+    max_streams_uni: transport.MaxStreams,
+    data_blocked: transport.DataBlocked,
+    stream_data_blocked: transport.StreamDataBlocked,
+    streams_blocked_bidi: transport.StreamsBlocked,
+    streams_blocked_uni: transport.StreamsBlocked,
+    new_connection_id: transport.NewConnectionId,
+    retire_connection_id: transport.RetireConnectionId,
+    path_challenge: transport.PathChallenge,
+    path_response: transport.PathResponse,
+    connection_close: transport.ConnectionClose,
+    handshake_done: transport.HandshakeDone,
+
+    /// Returns true if this frame type is allowed in Initial packets.
+    pub fn allowedInInitial(self: Frame) bool {
+        return switch (self) {
+            .padding, .ping, .crypto, .connection_close, .ack => true,
+            else => false,
+        };
+    }
+
+    /// Returns true if this frame type is allowed in Handshake packets.
+    pub fn allowedInHandshake(self: Frame) bool {
+        return switch (self) {
+            .padding, .ping, .crypto, .connection_close, .ack => true,
+            else => false,
+        };
+    }
+};
+
+pub const ParseError = varint.DecodeError || error{
+    UnknownFrameType,
+    InvalidFrame,
+    BufferTooShort,
+    TooLong,
+};
+
+/// Parse one frame from `buf`. Returns the frame and bytes consumed.
+pub fn parseOne(buf: []const u8) ParseError!struct { frame: Frame, consumed: usize } {
+    if (buf.len == 0) return error.BufferTooShort;
+
+    const type_r = try varint.decode(buf);
+    const pos: usize = type_r.len;
+    const ft = type_r.value;
+
+    // STREAM frames: type 0x08..0x0f
+    if (ft >= 0x08 and ft <= 0x0f) {
+        const r = try stream.StreamFrame.parse(buf[pos..], ft);
+        return .{ .frame = .{ .stream = r.frame }, .consumed = pos + r.consumed };
+    }
+
+    switch (ft) {
+        0x00 => {
+            // PADDING: one or more 0x00 bytes; consume all consecutive zeros
+            var count: usize = 0;
+            while (pos + count < buf.len and buf[pos + count] == 0x00) : (count += 1) {}
+            return .{ .frame = .{ .padding = .{ .length = count + 1 } }, .consumed = pos + count };
+        },
+        0x01 => return .{ .frame = .{ .ping = .{} }, .consumed = pos },
+        0x02, 0x03 => {
+            const r = try ack.AckFrame.parse(buf[pos..], ft == 0x03);
+            return .{ .frame = .{ .ack = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x04 => {
+            const r = try transport.ResetStream.parse(buf[pos..]);
+            return .{ .frame = .{ .reset_stream = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x05 => {
+            const r = try transport.StopSending.parse(buf[pos..]);
+            return .{ .frame = .{ .stop_sending = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x06 => {
+            const r = try crypto_frame.CryptoFrame.parse(buf[pos..]);
+            return .{ .frame = .{ .crypto = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x07 => {
+            const r = try transport.NewToken.parse(buf[pos..]);
+            return .{ .frame = .{ .new_token = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x10 => {
+            const r = try varint.decode(buf[pos..]);
+            return .{ .frame = .{ .max_data = .{ .maximum_data = r.value } }, .consumed = pos + r.len };
+        },
+        0x11 => {
+            const r = try transport.MaxStreamData.parse(buf[pos..]);
+            return .{ .frame = .{ .max_stream_data = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x12 => {
+            const r = try varint.decode(buf[pos..]);
+            return .{ .frame = .{ .max_streams_bidi = .{ .maximum_streams = r.value } }, .consumed = pos + r.len };
+        },
+        0x13 => {
+            const r = try varint.decode(buf[pos..]);
+            return .{ .frame = .{ .max_streams_uni = .{ .maximum_streams = r.value } }, .consumed = pos + r.len };
+        },
+        0x14 => {
+            const r = try varint.decode(buf[pos..]);
+            return .{ .frame = .{ .data_blocked = .{ .maximum_data = r.value } }, .consumed = pos + r.len };
+        },
+        0x15 => {
+            const r = try transport.StreamDataBlocked.parse(buf[pos..]);
+            return .{ .frame = .{ .stream_data_blocked = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x16 => {
+            const r = try varint.decode(buf[pos..]);
+            return .{ .frame = .{ .streams_blocked_bidi = .{ .maximum_streams = r.value } }, .consumed = pos + r.len };
+        },
+        0x17 => {
+            const r = try varint.decode(buf[pos..]);
+            return .{ .frame = .{ .streams_blocked_uni = .{ .maximum_streams = r.value } }, .consumed = pos + r.len };
+        },
+        0x18 => {
+            const r = try transport.NewConnectionId.parse(buf[pos..]);
+            return .{ .frame = .{ .new_connection_id = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x19 => {
+            const r = try varint.decode(buf[pos..]);
+            return .{ .frame = .{ .retire_connection_id = .{ .sequence_number = r.value } }, .consumed = pos + r.len };
+        },
+        0x1a => {
+            if (buf.len < pos + 8) return error.BufferTooShort;
+            var data: [8]u8 = undefined;
+            @memcpy(&data, buf[pos .. pos + 8]);
+            return .{ .frame = .{ .path_challenge = .{ .data = data } }, .consumed = pos + 8 };
+        },
+        0x1b => {
+            if (buf.len < pos + 8) return error.BufferTooShort;
+            var data: [8]u8 = undefined;
+            @memcpy(&data, buf[pos .. pos + 8]);
+            return .{ .frame = .{ .path_response = .{ .data = data } }, .consumed = pos + 8 };
+        },
+        0x1c, 0x1d => {
+            const r = try transport.ConnectionClose.parse(buf[pos..], ft == 0x1d);
+            return .{ .frame = .{ .connection_close = r.frame }, .consumed = pos + r.consumed };
+        },
+        0x1e => return .{ .frame = .{ .handshake_done = .{} }, .consumed = pos },
+        else => return error.UnknownFrameType,
+    }
+}
+
+test "frame: parse PING" {
+    const testing = std.testing;
+    var buf = [_]u8{0x01};
+    const r = try parseOne(&buf);
+    try testing.expect(r.frame == .ping);
+    try testing.expectEqual(@as(usize, 1), r.consumed);
+}
+
+test "frame: parse PADDING" {
+    const testing = std.testing;
+    var buf = [_]u8{ 0x00, 0x00, 0x00 };
+    const r = try parseOne(&buf);
+    try testing.expect(r.frame == .padding);
+    try testing.expectEqual(@as(usize, 3), r.consumed);
+}
+
+test "frame: parse PATH_CHALLENGE" {
+    const testing = std.testing;
+    var buf = [_]u8{ 0x1a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    const r = try parseOne(&buf);
+    try testing.expect(r.frame == .path_challenge);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }, &r.frame.path_challenge.data);
+}

--- a/src/frames/stream.zig
+++ b/src/frames/stream.zig
@@ -1,0 +1,115 @@
+//! STREAM frame (RFC 9000 §19.8).
+//!
+//! Wire format (type 0x08..0x0f):
+//!   Type bits: 0x08 | OFF_bit | LEN_bit | FIN_bit
+//!   Stream ID (varint)
+//!   [Offset (varint) if OFF_bit=1]
+//!   [Length (varint) if LEN_bit=1]
+//!   Stream Data (Length bytes, or to end of packet if LEN_bit=0)
+//!
+//! FIN_bit = 1: this frame carries the final byte of the stream.
+
+const std = @import("std");
+const varint = @import("../varint.zig");
+
+pub const StreamFrame = struct {
+    stream_id: u64,
+    offset: u64,
+    /// Raw application data.
+    data: []const u8,
+    /// True if this is the final segment of the stream.
+    fin: bool,
+    /// True if the Length field is present.
+    has_length: bool,
+
+    const OFF_BIT: u64 = 0x04;
+    const LEN_BIT: u64 = 0x02;
+    const FIN_BIT: u64 = 0x01;
+
+    /// Parse a STREAM frame from `buf` (after the type byte).
+    /// `ft` is the full frame type byte value (0x08..0x0f).
+    pub fn parse(buf: []const u8, ft: u64) varint.DecodeError!struct { frame: StreamFrame, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const sid = try r.readVarint();
+        const offset: u64 = if (ft & OFF_BIT != 0) try r.readVarint() else 0;
+        const fin = (ft & FIN_BIT) != 0;
+        const has_length = (ft & LEN_BIT) != 0;
+
+        const data: []const u8 = if (has_length) blk: {
+            const length = try r.readVarint();
+            break :blk try r.readBytes(@intCast(length));
+        } else blk: {
+            // Data extends to the end of the packet payload.
+            break :blk r.buf[r.pos..];
+        };
+
+        const consumed = if (has_length) r.pos else r.pos + r.remaining();
+
+        return .{
+            .frame = .{
+                .stream_id = sid,
+                .offset = offset,
+                .data = data,
+                .fin = fin,
+                .has_length = has_length,
+            },
+            .consumed = consumed,
+        };
+    }
+
+    /// Serialize the STREAM frame into `buf`. Returns bytes written.
+    /// Always writes the Length field (LEN_BIT=1).
+    pub fn serialize(self: StreamFrame, buf: []u8) (varint.EncodeError || varint.DecodeError)!usize {
+        var ft: u64 = 0x08 | LEN_BIT;
+        if (self.offset != 0) ft |= OFF_BIT;
+        if (self.fin) ft |= FIN_BIT;
+
+        var w = varint.Writer.init(buf);
+        try w.writeVarint(ft);
+        try w.writeVarint(self.stream_id);
+        if (self.offset != 0) try w.writeVarint(self.offset);
+        try w.writeVarint(self.data.len);
+        try w.writeBytes(self.data);
+        return w.pos;
+    }
+};
+
+test "stream: parse/serialize with offset and fin" {
+    const testing = std.testing;
+    const frame = StreamFrame{
+        .stream_id = 4,
+        .offset = 1024,
+        .data = "hello world",
+        .fin = true,
+        .has_length = true,
+    };
+    var buf: [64]u8 = undefined;
+    const written = try frame.serialize(&buf);
+
+    // Determine frame type from first byte
+    const r_type = try varint.decode(buf[0..written]);
+    const r = try StreamFrame.parse(buf[r_type.len..written], r_type.value);
+    try testing.expectEqual(@as(u64, 4), r.frame.stream_id);
+    try testing.expectEqual(@as(u64, 1024), r.frame.offset);
+    try testing.expectEqualSlices(u8, "hello world", r.frame.data);
+    try testing.expect(r.frame.fin);
+}
+
+test "stream: offset=0 no fin" {
+    const testing = std.testing;
+    const frame = StreamFrame{
+        .stream_id = 0,
+        .offset = 0,
+        .data = "data",
+        .fin = false,
+        .has_length = true,
+    };
+    var buf: [32]u8 = undefined;
+    const written = try frame.serialize(&buf);
+
+    const r_type = try varint.decode(buf[0..written]);
+    const r = try StreamFrame.parse(buf[r_type.len..written], r_type.value);
+    try testing.expectEqual(@as(u64, 0), r.frame.offset);
+    try testing.expect(!r.frame.fin);
+    try testing.expectEqualSlices(u8, "data", r.frame.data);
+}

--- a/src/frames/transport.zig
+++ b/src/frames/transport.zig
@@ -1,0 +1,209 @@
+//! Miscellaneous QUIC transport frames (RFC 9000 §19).
+
+const std = @import("std");
+const varint = @import("../varint.zig");
+const types = @import("../types.zig");
+
+pub const Padding = struct {
+    length: usize,
+};
+
+pub const Ping = struct {};
+pub const HandshakeDone = struct {};
+
+pub const ResetStream = struct {
+    stream_id: u64,
+    application_protocol_error_code: u64,
+    final_size: u64,
+
+    pub fn parse(buf: []const u8) varint.DecodeError!struct { frame: ResetStream, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const sid = try r.readVarint();
+        const code = try r.readVarint();
+        const size = try r.readVarint();
+        return .{ .frame = .{ .stream_id = sid, .application_protocol_error_code = code, .final_size = size }, .consumed = r.pos };
+    }
+
+    pub fn serialize(self: ResetStream, buf: []u8) (varint.EncodeError || varint.DecodeError)!usize {
+        var w = varint.Writer.init(buf);
+        try w.writeVarint(0x04);
+        try w.writeVarint(self.stream_id);
+        try w.writeVarint(self.application_protocol_error_code);
+        try w.writeVarint(self.final_size);
+        return w.pos;
+    }
+};
+
+pub const StopSending = struct {
+    stream_id: u64,
+    application_protocol_error_code: u64,
+
+    pub fn parse(buf: []const u8) varint.DecodeError!struct { frame: StopSending, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const sid = try r.readVarint();
+        const code = try r.readVarint();
+        return .{ .frame = .{ .stream_id = sid, .application_protocol_error_code = code }, .consumed = r.pos };
+    }
+};
+
+pub const NewToken = struct {
+    token: []const u8,
+
+    pub fn parse(buf: []const u8) varint.DecodeError!struct { frame: NewToken, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const len = try r.readVarint();
+        const token = try r.readBytes(@intCast(len));
+        return .{ .frame = .{ .token = token }, .consumed = r.pos };
+    }
+};
+
+pub const MaxData = struct {
+    maximum_data: u64,
+};
+
+pub const MaxStreamData = struct {
+    stream_id: u64,
+    maximum_stream_data: u64,
+
+    pub fn parse(buf: []const u8) varint.DecodeError!struct { frame: MaxStreamData, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const sid = try r.readVarint();
+        const max = try r.readVarint();
+        return .{ .frame = .{ .stream_id = sid, .maximum_stream_data = max }, .consumed = r.pos };
+    }
+};
+
+pub const MaxStreams = struct {
+    maximum_streams: u64,
+};
+
+pub const DataBlocked = struct {
+    maximum_data: u64,
+};
+
+pub const StreamDataBlocked = struct {
+    stream_id: u64,
+    maximum_stream_data: u64,
+
+    pub fn parse(buf: []const u8) varint.DecodeError!struct { frame: StreamDataBlocked, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const sid = try r.readVarint();
+        const max = try r.readVarint();
+        return .{ .frame = .{ .stream_id = sid, .maximum_stream_data = max }, .consumed = r.pos };
+    }
+};
+
+pub const StreamsBlocked = struct {
+    maximum_streams: u64,
+};
+
+pub const NewConnectionId = struct {
+    sequence_number: u64,
+    retire_prior_to: u64,
+    connection_id: types.ConnectionId,
+    stateless_reset_token: [16]u8,
+
+    pub fn parse(buf: []const u8) (varint.DecodeError || error{TooLong})!struct { frame: NewConnectionId, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const seq = try r.readVarint();
+        const retire = try r.readVarint();
+        if (r.remaining() < 1) return error.BufferTooShort;
+        const cid_len = r.buf[r.pos];
+        r.pos += 1;
+        if (cid_len > types.max_cid_len) return error.TooLong;
+        const cid_bytes = try r.readBytes(cid_len);
+        const cid = try types.ConnectionId.fromSlice(cid_bytes);
+        if (r.remaining() < 16) return error.BufferTooShort;
+        const token_bytes = try r.readBytes(16);
+        var token: [16]u8 = undefined;
+        @memcpy(&token, token_bytes);
+        return .{
+            .frame = .{
+                .sequence_number = seq,
+                .retire_prior_to = retire,
+                .connection_id = cid,
+                .stateless_reset_token = token,
+            },
+            .consumed = r.pos,
+        };
+    }
+};
+
+pub const RetireConnectionId = struct {
+    sequence_number: u64,
+};
+
+pub const PathChallenge = struct {
+    data: [8]u8,
+};
+
+pub const PathResponse = struct {
+    data: [8]u8,
+};
+
+pub const ConnectionClose = struct {
+    is_application: bool,
+    error_code: u64,
+    frame_type: u64,
+    reason_phrase: []const u8,
+
+    pub fn parse(buf: []const u8, is_app: bool) varint.DecodeError!struct { frame: ConnectionClose, consumed: usize } {
+        var r = varint.Reader.init(buf);
+        const code = try r.readVarint();
+        const ft: u64 = if (!is_app) try r.readVarint() else 0;
+        const reason_len = try r.readVarint();
+        const reason = try r.readBytes(@intCast(reason_len));
+        return .{
+            .frame = .{
+                .is_application = is_app,
+                .error_code = code,
+                .frame_type = ft,
+                .reason_phrase = reason,
+            },
+            .consumed = r.pos,
+        };
+    }
+
+    pub fn serialize(self: ConnectionClose, buf: []u8) (varint.EncodeError || varint.DecodeError)!usize {
+        var w = varint.Writer.init(buf);
+        try w.writeVarint(if (self.is_application) 0x1d else 0x1c);
+        try w.writeVarint(self.error_code);
+        if (!self.is_application) try w.writeVarint(self.frame_type);
+        try w.writeVarint(self.reason_phrase.len);
+        try w.writeBytes(self.reason_phrase);
+        return w.pos;
+    }
+};
+
+test "transport: RESET_STREAM round-trip" {
+    const testing = std.testing;
+    const frame = ResetStream{ .stream_id = 5, .application_protocol_error_code = 0, .final_size = 1000 };
+    var buf: [32]u8 = undefined;
+    const written = try frame.serialize(&buf);
+    const r = try ResetStream.parse(buf[1..written]);
+    try testing.expectEqual(@as(u64, 5), r.frame.stream_id);
+    try testing.expectEqual(@as(u64, 1000), r.frame.final_size);
+}
+
+test "transport: CONNECTION_CLOSE round-trip" {
+    const testing = std.testing;
+    const frame = ConnectionClose{
+        .is_application = false,
+        .error_code = 0x0a, // PROTOCOL_VIOLATION
+        .frame_type = 0x06,
+        .reason_phrase = "bad frame",
+    };
+    var buf: [64]u8 = undefined;
+    const written = try frame.serialize(&buf);
+    const r = try ConnectionClose.parse(buf[1..written], false);
+    try testing.expectEqual(@as(u64, 0x0a), r.frame.error_code);
+    try testing.expectEqualSlices(u8, "bad frame", r.frame.reason_phrase);
+}
+
+test "transport: MAX_DATA parse" {
+    const testing = std.testing;
+    const frame = @import("frame.zig");
+    var buf = [_]u8{ 0x10, 0x52, 0x34 }; // type=0x10, value=0x1234
+    const r = try frame.parseOne(&buf);
+    try testing.expectEqual(@as(u64, 0x1234), r.frame.max_data.maximum_data);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -19,6 +19,13 @@ pub const crypto = struct {
     pub const aead = @import("crypto/aead.zig");
     pub const initial = @import("crypto/initial.zig");
 };
+pub const frames = struct {
+    pub const frame = @import("frames/frame.zig");
+    pub const ack = @import("frames/ack.zig");
+    pub const crypto_frame = @import("frames/crypto_frame.zig");
+    pub const stream = @import("frames/stream.zig");
+    pub const transport = @import("frames/transport.zig");
+};
 
 test {
     _ = @import("varint.zig");
@@ -29,4 +36,9 @@ test {
     _ = @import("crypto/keys.zig");
     _ = @import("crypto/aead.zig");
     _ = @import("crypto/initial.zig");
+    _ = @import("frames/frame.zig");
+    _ = @import("frames/ack.zig");
+    _ = @import("frames/crypto_frame.zig");
+    _ = @import("frames/stream.zig");
+    _ = @import("frames/transport.zig");
 }


### PR DESCRIPTION
## Summary

- `src/frames/frame.zig` — `Frame` union and `parseOne()` dispatcher for all RFC 9000 frame types
- `src/frames/ack.zig` — ACK frame with multi-range support and ECN counts (RFC 9000 §19.3)
- `src/frames/crypto_frame.zig` — CRYPTO frame carrying TLS handshake data (RFC 9000 §19.6)
- `src/frames/stream.zig` — STREAM frame with offset, length, and FIN flag (RFC 9000 §19.8)
- `src/frames/transport.zig` — RESET_STREAM, STOP_SENDING, MAX_DATA, PATH_CHALLENGE/RESPONSE, CONNECTION_CLOSE, and all other transport frames

## Test plan

- [ ] 35/35 tests pass
- [ ] `zig fmt --check .` passes