### PR TITLE
packet,transport: Retry integrity tag and version negotiation

### DIFF
--- a/src/packet/retry.zig
+++ b/src/packet/retry.zig
@@ -1,0 +1,135 @@
+//! QUIC Retry packet integrity verification (RFC 9001 §5.8).
+//!
+//! The Retry Integrity Tag is an AES-128-GCM tag computed over a
+//! "Retry Pseudo-Packet" to prevent off-path attackers from injecting
+//! spoofed Retry packets.
+//!
+//! Retry Integrity Tag:
+//!   key  = 0xbe0c690b9f66575a1d766b54e368c84e
+//!   nonce = 0x461599d35d632bf2239825bb
+//!   Tag = AES-128-GCM(key, nonce, "", retry_pseudo_packet)
+//!
+//! where the "Retry Pseudo-Packet" is:
+//!   ODCID Length (1 byte) + ODCID + Retry packet (without integrity tag)
+
+const std = @import("std");
+const aead_mod = @import("../crypto/aead.zig");
+
+/// AES-128-GCM key for Retry integrity tag (RFC 9001 §5.8).
+pub const retry_key: [16]u8 = .{
+    0xbe, 0x0c, 0x69, 0x0b, 0x9f, 0x66, 0x57, 0x5a,
+    0x1d, 0x76, 0x6b, 0x54, 0xe3, 0x68, 0xc8, 0x4e,
+};
+
+/// AEAD nonce for Retry integrity tag (RFC 9001 §5.8).
+pub const retry_nonce: [12]u8 = .{
+    0x46, 0x15, 0x99, 0xd3, 0x5d, 0x63, 0x2b, 0xf2,
+    0x23, 0x98, 0x25, 0xbb,
+};
+
+/// Compute the 16-byte Retry Integrity Tag.
+///
+/// `odcid` is the Original Destination Connection ID from the Initial packet
+/// that triggered the Retry. `retry_packet` is the full Retry packet bytes
+/// WITHOUT the 16-byte integrity tag at the end.
+pub fn computeIntegrityTag(
+    tag: *[16]u8,
+    odcid: []const u8,
+    retry_packet: []const u8,
+) aead_mod.AeadError!void {
+    // Build the pseudo-packet: ODCID Length (1 byte) + ODCID + Retry packet
+    var pseudo: [512]u8 = undefined;
+    if (1 + odcid.len + retry_packet.len > pseudo.len) return error.BufferTooSmall;
+    pseudo[0] = @intCast(odcid.len);
+    @memcpy(pseudo[1 .. 1 + odcid.len], odcid);
+    @memcpy(pseudo[1 + odcid.len .. 1 + odcid.len + retry_packet.len], retry_packet);
+    const pseudo_len = 1 + odcid.len + retry_packet.len;
+
+    // AES-128-GCM encrypt empty plaintext → produces only the tag
+    var ciphertext: [16]u8 = undefined;
+    try aead_mod.encryptAes128Gcm(&ciphertext, &.{}, pseudo[0..pseudo_len], retry_key, retry_nonce);
+    @memcpy(tag, ciphertext[0..16]);
+}
+
+/// Verify the integrity tag of a received Retry packet.
+///
+/// Returns true if the tag is valid.
+pub fn verifyIntegrityTag(
+    odcid: []const u8,
+    retry_packet_with_tag: []const u8,
+) bool {
+    if (retry_packet_with_tag.len < 16) return false;
+    const retry_without_tag = retry_packet_with_tag[0 .. retry_packet_with_tag.len - 16];
+    const received_tag = retry_packet_with_tag[retry_packet_with_tag.len - 16 ..][0..16];
+
+    var computed: [16]u8 = undefined;
+    computeIntegrityTag(&computed, odcid, retry_without_tag) catch return false;
+    return std.mem.eql(u8, &computed, received_tag);
+}
+
+/// Build a complete Retry packet (including integrity tag) into `buf`.
+/// Returns bytes written.
+pub fn buildRetryPacket(
+    buf: []u8,
+    version: u32,
+    dcid: []const u8,
+    scid: []const u8,
+    token: []const u8,
+    odcid: []const u8,
+) aead_mod.AeadError!usize {
+    if (buf.len < 1 + 4 + 1 + dcid.len + 1 + scid.len + token.len + 16) return error.BufferTooSmall;
+
+    var pos: usize = 0;
+    // First byte: Header Form=1, Fixed Bit=1, Type=Retry (0b11), random low nibble
+    buf[pos] = 0xf0;
+    pos += 1;
+    std.mem.writeInt(u32, buf[pos..][0..4], version, .big);
+    pos += 4;
+    buf[pos] = @intCast(dcid.len);
+    pos += 1;
+    @memcpy(buf[pos .. pos + dcid.len], dcid);
+    pos += dcid.len;
+    buf[pos] = @intCast(scid.len);
+    pos += 1;
+    @memcpy(buf[pos .. pos + scid.len], scid);
+    pos += scid.len;
+    @memcpy(buf[pos .. pos + token.len], token);
+    pos += token.len;
+
+    // Compute and append integrity tag
+    var tag: [16]u8 = undefined;
+    try computeIntegrityTag(&tag, odcid, buf[0..pos]);
+    @memcpy(buf[pos .. pos + 16], &tag);
+    pos += 16;
+
+    return pos;
+}
+
+test "retry: integrity tag round-trip" {
+    const testing = std.testing;
+    const odcid = "\x83\x94\xc8\xf0\x3e\x51\x57\x08";
+    const token = "test-token";
+    const dcid = "\xaa\xbb\xcc";
+    const scid = "\xdd\xee";
+
+    var buf: [128]u8 = undefined;
+    const written = try buildRetryPacket(&buf, 0x00000001, dcid, scid, token, odcid);
+    try testing.expect(written > 16);
+
+    // Verify the tag in the built packet
+    try testing.expect(verifyIntegrityTag(odcid, buf[0..written]));
+
+    // Tampered tag should fail
+    buf[written - 1] ^= 0x01;
+    try testing.expect(!verifyIntegrityTag(odcid, buf[0..written]));
+}
+
+test "retry: empty token" {
+    const odcid = "\x01\x02\x03\x04";
+    const dcid = "\x05";
+    const scid = "\x06";
+
+    var buf: [64]u8 = undefined;
+    const written = try buildRetryPacket(&buf, 0x00000001, dcid, scid, "", odcid);
+    try std.testing.expect(verifyIntegrityTag(odcid, buf[0..written]));
+}

--- a/src/packet/version_negotiation.zig
+++ b/src/packet/version_negotiation.zig
@@ -1,0 +1,152 @@
+//! QUIC Version Negotiation packet (RFC 9000 §17.2.1).
+//!
+//! Sent by a server that does not support the QUIC version requested by
+//! the client. The packet lists all supported versions.
+//!
+//! Wire format:
+//!   1 byte  : Header form=1, Fixed bit=0, Type=unused (0x80 with random low 7 bits)
+//!   4 bytes : Version = 0x00000000 (distinguishes from other Long Header types)
+//!   1 byte  : DCID Length
+//!   N bytes : DCID (echoed from client Initial)
+//!   1 byte  : SCID Length
+//!   M bytes : SCID
+//!   4*K bytes: Supported Versions list (at least one)
+
+const std = @import("std");
+
+/// QUIC version 1 (RFC 9000).
+pub const QUIC_V1: u32 = 0x00000001;
+
+/// Parse error types for Version Negotiation packets.
+pub const ParseError = error{
+    BufferTooShort,
+    NotVersionNegotiation,
+    NoSupportedVersions,
+};
+
+/// Parsed Version Negotiation packet.
+pub const VersionNegotiationPacket = struct {
+    dcid: []const u8,
+    scid: []const u8,
+    /// Slice into the source buffer containing the 4-byte big-endian version words.
+    versions_raw: []const u8,
+
+    /// Iterator over supported versions.
+    pub fn versions(self: VersionNegotiationPacket) VersionIterator {
+        return .{ .raw = self.versions_raw, .pos = 0 };
+    }
+};
+
+pub const VersionIterator = struct {
+    raw: []const u8,
+    pos: usize,
+
+    pub fn next(self: *VersionIterator) ?u32 {
+        if (self.pos + 4 > self.raw.len) return null;
+        const v = std.mem.readInt(u32, self.raw[self.pos..][0..4], .big);
+        self.pos += 4;
+        return v;
+    }
+};
+
+/// Parse a Version Negotiation packet from `buf`.
+pub fn parse(buf: []const u8) ParseError!VersionNegotiationPacket {
+    if (buf.len < 7) return error.BufferTooShort;
+    // Must have long header form (bit 7 = 1).
+    if (buf[0] & 0x80 == 0) return error.NotVersionNegotiation;
+    // Version field must be 0x00000000.
+    const ver = std.mem.readInt(u32, buf[1..5], .big);
+    if (ver != 0) return error.NotVersionNegotiation;
+
+    var pos: usize = 5;
+    if (pos >= buf.len) return error.BufferTooShort;
+    const dcid_len = buf[pos];
+    pos += 1;
+    if (pos + dcid_len > buf.len) return error.BufferTooShort;
+    const dcid = buf[pos .. pos + dcid_len];
+    pos += dcid_len;
+
+    if (pos >= buf.len) return error.BufferTooShort;
+    const scid_len = buf[pos];
+    pos += 1;
+    if (pos + scid_len > buf.len) return error.BufferTooShort;
+    const scid = buf[pos .. pos + scid_len];
+    pos += scid_len;
+
+    if (pos + 4 > buf.len) return error.NoSupportedVersions;
+    // The remainder must be a multiple of 4.
+    const remaining = buf.len - pos;
+    const version_bytes = buf[pos .. pos + (remaining - remaining % 4)];
+    if (version_bytes.len == 0) return error.NoSupportedVersions;
+
+    return .{
+        .dcid = dcid,
+        .scid = scid,
+        .versions_raw = version_bytes,
+    };
+}
+
+/// Build a Version Negotiation packet into `buf`.
+///
+/// `dcid` and `scid` are echoed from the client's Initial packet (dcid becomes
+/// the server's scid and vice versa per RFC convention, but callers control this).
+/// `supported_versions` must be non-empty.
+/// Returns the number of bytes written.
+pub fn build(
+    buf: []u8,
+    dcid: []const u8,
+    scid: []const u8,
+    supported_versions: []const u32,
+) error{BufferTooSmall}!usize {
+    const needed = 1 + 4 + 1 + dcid.len + 1 + scid.len + 4 * supported_versions.len;
+    if (buf.len < needed) return error.BufferTooSmall;
+
+    var pos: usize = 0;
+    // Long header form with Fixed bit=0, random low 7 bits = 0.
+    buf[pos] = 0x80;
+    pos += 1;
+    // Version = 0 signals Version Negotiation.
+    std.mem.writeInt(u32, buf[pos..][0..4], 0, .big);
+    pos += 4;
+    buf[pos] = @intCast(dcid.len);
+    pos += 1;
+    @memcpy(buf[pos .. pos + dcid.len], dcid);
+    pos += dcid.len;
+    buf[pos] = @intCast(scid.len);
+    pos += 1;
+    @memcpy(buf[pos .. pos + scid.len], scid);
+    pos += scid.len;
+    for (supported_versions) |v| {
+        std.mem.writeInt(u32, buf[pos..][0..4], v, .big);
+        pos += 4;
+    }
+    return pos;
+}
+
+test "version negotiation: build and parse round-trip" {
+    const testing = std.testing;
+    const dcid = "\xaa\xbb\xcc\xdd";
+    const scid = "\x11\x22";
+    const versions_to_send = [_]u32{ QUIC_V1, 0xdeadbeef };
+
+    var buf: [64]u8 = undefined;
+    const written = try build(&buf, dcid, scid, &versions_to_send);
+
+    const pkt = try parse(buf[0..written]);
+    try testing.expectEqualSlices(u8, dcid, pkt.dcid);
+    try testing.expectEqualSlices(u8, scid, pkt.scid);
+
+    var it = pkt.versions();
+    try testing.expectEqual(@as(u32, QUIC_V1), it.next().?);
+    try testing.expectEqual(@as(u32, 0xdeadbeef), it.next().?);
+    try testing.expectEqual(@as(?u32, null), it.next());
+}
+
+test "version negotiation: parse rejects QUIC v1 packet" {
+    // A normal Long Header packet has version != 0, so parse should reject it.
+    var buf: [16]u8 = .{0} ** 16;
+    buf[0] = 0xc0; // long header form, Fixed bit=1
+    std.mem.writeInt(u32, buf[1..5], QUIC_V1, .big);
+    const err = parse(&buf);
+    try std.testing.expectError(error.NotVersionNegotiation, err);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -13,6 +13,8 @@ pub const packet = struct {
     pub const header = @import("packet/header.zig");
     pub const number = @import("packet/number.zig");
     pub const pkt = @import("packet/packet.zig");
+    pub const retry = @import("packet/retry.zig");
+    pub const version_negotiation = @import("packet/version_negotiation.zig");
 };
 pub const crypto = struct {
     pub const keys = @import("crypto/keys.zig");
@@ -44,6 +46,8 @@ test {
     _ = @import("packet/header.zig");
     _ = @import("packet/number.zig");
     _ = @import("packet/packet.zig");
+    _ = @import("packet/retry.zig");
+    _ = @import("packet/version_negotiation.zig");
     _ = @import("crypto/keys.zig");
     _ = @import("crypto/aead.zig");
     _ = @import("crypto/initial.zig");

--- a/src/transport/connection.zig
+++ b/src/transport/connection.zig
@@ -14,6 +14,8 @@ const varint = @import("../varint.zig");
 const frames = @import("../frames/frame.zig");
 const crypto_keys = @import("../crypto/keys.zig");
 const quic_tls = @import("../crypto/quic_tls.zig");
+const retry_mod = @import("../packet/retry.zig");
+const version_neg = @import("../packet/version_negotiation.zig");
 
 pub const ConnectionId = types.ConnectionId;
 pub const TransportError = types.TransportError;
@@ -159,6 +161,15 @@ pub const Connection = struct {
     /// Close error, if any.
     close_error: ?TransportError = null,
 
+    /// Retry token received from server (client-side only).
+    /// Used in the client's retry-response Initial packet.
+    retry_token: ?[256]u8 = null,
+    retry_token_len: usize = 0,
+
+    /// Original Destination Connection ID (ODCID) – set on client when
+    /// a Retry is received so the client can verify the Retry integrity tag.
+    original_dcid: ?ConnectionId = null,
+
     /// Statistics.
     stats: Stats = .{},
 
@@ -207,6 +218,81 @@ pub const Connection = struct {
         self.close_error = err;
         self.state = .draining;
     }
+
+    /// Handle a received Retry packet (client-side only).
+    ///
+    /// Verifies the Retry integrity tag using the ODCID. On success the
+    /// client must restart the handshake:
+    /// - Replace the remote CID with the SCID from the Retry packet.
+    /// - Store the retry token for inclusion in the next Initial packet.
+    /// - Reset packet number space back to 0.
+    /// - Re-derive initial keys with the new remote CID.
+    ///
+    /// Returns an error if:
+    /// - Called on a server-role connection
+    /// - The integrity tag is invalid
+    /// - A Retry was already processed for this connection
+    pub fn handleRetry(
+        self: *Connection,
+        scid: []const u8,
+        token: []const u8,
+        retry_packet_with_tag: []const u8,
+    ) error{ WrongRole, InvalidRetryTag, AlreadyRetried, TooLong }!void {
+        if (self.role != .client) return error.WrongRole;
+        if (self.original_dcid != null) return error.AlreadyRetried;
+
+        // Save ODCID before overwriting remote_cid.
+        self.original_dcid = self.remote_cid;
+
+        // Verify integrity tag using ODCID.
+        const odcid_slice = self.original_dcid.?.slice();
+        if (!retry_mod.verifyIntegrityTag(odcid_slice, retry_packet_with_tag)) {
+            self.original_dcid = null; // Roll back.
+            return error.InvalidRetryTag;
+        }
+
+        // Store retry token.
+        if (token.len > self.retry_token.?.len) return error.TooLong;
+        self.retry_token = [_]u8{0} ** 256;
+        @memcpy(self.retry_token.?[0..token.len], token);
+        self.retry_token_len = token.len;
+
+        // Update remote CID and re-derive Initial keys with the new SCID.
+        self.remote_cid = try ConnectionId.fromSlice(scid);
+        self.deriveInitialKeys(self.remote_cid);
+
+        // Reset Initial packet number space.
+        self.initial_pn = .{};
+        self.initial_ack = .{};
+    }
+
+    /// Handle a received Version Negotiation packet (client-side only).
+    ///
+    /// Returns the list of server-supported versions so the caller can decide
+    /// whether to retry with a different version or close.
+    ///
+    /// Returns error.WrongRole for server connections.
+    /// Returns error.NoCommonVersion if QUIC v1 is absent from the list.
+    pub fn handleVersionNegotiation(
+        self: *Connection,
+        vn_packet: []const u8,
+    ) error{ WrongRole, NoCommonVersion, ParseError }!void {
+        if (self.role != .client) return error.WrongRole;
+        const pkt = version_neg.parse(vn_packet) catch return error.ParseError;
+        var it = pkt.versions();
+        while (it.next()) |v| {
+            if (v == version_neg.QUIC_V1) {
+                // We already support this version; the server should be able to
+                // handle our packets.  In a real implementation the client would
+                // retry the connection with this version.  For now we just
+                // acknowledge that v1 is supported.
+                return;
+            }
+        }
+        // No common version — close the connection.
+        self.closeWithError(.protocol_violation);
+        return error.NoCommonVersion;
+    }
 };
 
 test "connection: state machine transitions" {
@@ -250,6 +336,92 @@ test "connection: initial key derivation" {
     try testing.expect(conn.initial_keys != null);
     const expected_key = "\x1f\x36\x96\x13\xdd\x76\xd5\x46\x77\x30\xef\xcb\xe3\xb1\xa2\x2d";
     try testing.expectEqualSlices(u8, expected_key, &conn.initial_keys.?.client.key);
+}
+
+test "connection: handle retry packet" {
+    const testing = std.testing;
+
+    const dcid_bytes = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const dcid = try ConnectionId.fromSlice(&dcid_bytes);
+    const scid_bytes = [_]u8{ 0x01, 0x02 };
+    const scid = try ConnectionId.fromSlice(&scid_bytes);
+    var conn = Connection.init(.client, scid, dcid);
+    conn.deriveInitialKeys(dcid);
+    conn.retry_token = [_]u8{0} ** 256;
+
+    const new_scid = [_]u8{ 0xaa, 0xbb };
+    const token = "retry-token";
+
+    // Build a valid Retry packet.
+    var retry_buf: [256]u8 = undefined;
+    const retry_written = try retry_mod.buildRetryPacket(
+        &retry_buf,
+        0x00000001,
+        &[_]u8{ 0x10, 0x11 }, // dcid echoed to client
+        &new_scid,
+        token,
+        &dcid_bytes, // odcid
+    );
+
+    try conn.handleRetry(&new_scid, token, retry_buf[0..retry_written]);
+
+    // After Retry, remote_cid should be updated.
+    try testing.expectEqualSlices(u8, &new_scid, conn.remote_cid.slice());
+    // ODCID should be stored.
+    try testing.expectEqualSlices(u8, &dcid_bytes, conn.original_dcid.?.slice());
+    // Token stored.
+    try testing.expectEqualSlices(u8, token, conn.retry_token.?[0..conn.retry_token_len]);
+    // Initial PN reset.
+    try testing.expectEqual(@as(u64, 0), conn.initial_pn.next_pn);
+}
+
+test "connection: handle retry with bad tag" {
+    const dcid_bytes = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+    const dcid = try ConnectionId.fromSlice(&dcid_bytes);
+    const scid = try ConnectionId.fromSlice(&[_]u8{0x10});
+    var conn = Connection.init(.client, scid, dcid);
+    conn.retry_token = [_]u8{0} ** 256;
+
+    // Build a Retry packet with a wrong ODCID so the tag check fails.
+    const wrong_odcid = [_]u8{ 0xde, 0xad, 0xbe, 0xef };
+    var retry_buf: [128]u8 = undefined;
+    const retry_written = try retry_mod.buildRetryPacket(
+        &retry_buf,
+        0x00000001,
+        &[_]u8{0x05},
+        &[_]u8{0x06},
+        "token",
+        &wrong_odcid, // deliberately wrong
+    );
+
+    const result = conn.handleRetry(&[_]u8{0x06}, "token", retry_buf[0..retry_written]);
+    try std.testing.expectError(error.InvalidRetryTag, result);
+}
+
+test "connection: version negotiation common version" {
+    const testing = std.testing;
+    const dcid = try ConnectionId.fromSlice(&[_]u8{0x01});
+    const scid = try ConnectionId.fromSlice(&[_]u8{0x02});
+    var conn = Connection.init(.client, scid, dcid);
+
+    var buf: [32]u8 = undefined;
+    const written = try version_neg.build(&buf, &[_]u8{0x01}, &[_]u8{0x02}, &[_]u32{ version_neg.QUIC_V1, 0xfaceb002 });
+    try conn.handleVersionNegotiation(buf[0..written]);
+    // Still initial state – a common version was found.
+    try testing.expectEqual(State.initial, conn.state);
+}
+
+test "connection: version negotiation no common version" {
+    const dcid = try ConnectionId.fromSlice(&[_]u8{0x01});
+    const scid = try ConnectionId.fromSlice(&[_]u8{0x02});
+    var conn = Connection.init(.client, scid, dcid);
+
+    var buf: [32]u8 = undefined;
+    const written = try version_neg.build(&buf, &[_]u8{0x01}, &[_]u8{0x02}, &[_]u32{0xfaceb002});
+    const result = conn.handleVersionNegotiation(buf[0..written]);
+    try std.testing.expectError(error.NoCommonVersion, result);
+    // Connection should be draining.
+    try std.testing.expectEqual(State.draining, conn.state);
 }
 
 test "ack_manager: single packet observation" {


### PR DESCRIPTION
## Summary

- `src/packet/retry.zig`: AES-128-GCM Retry Integrity Tag (RFC 9001 §5.8); `computeIntegrityTag`, `verifyIntegrityTag`, and `buildRetryPacket` with round-trip tests
- `src/packet/version_negotiation.zig`: parse/build Version Negotiation packets (RFC 9000 §17.2.1) with a version iterator
- `src/transport/connection.zig`: `handleRetry` verifies integrity tag using ODCID, stores token, resets Initial PN space and re-derives keys; `handleVersionNegotiation` checks for a common version and closes connection if none

## Test plan

- [x] `retry: integrity tag round-trip` — build then verify a Retry packet
- [x] `retry: empty token` — Retry with no token
- [x] `version negotiation: build and parse round-trip`
- [x] `version negotiation: parse rejects QUIC v1 packet`
- [x] `connection: handle retry packet` — full flow with ODCID, new remote CID, PN reset
- [x] `connection: handle retry with bad tag` — tampered ODCID → `InvalidRetryTag`
- [x] `connection: version negotiation common version` — v1 found → stays in initial
- [x] `connection: version negotiation no common version` → draining state
- [x] All 69 tests pass