### PR TITLE
http09: HTTP/0.9 server and client helpers for interop runner

### DIFF
--- a/src/http09/client.zig
+++ b/src/http09/client.zig
@@ -1,0 +1,69 @@
+//! Minimal HTTP/0.9 client for quic-interop-runner compatibility.
+//!
+//! The QUIC interop runner's `transfer` test case expects the client to:
+//! 1. Open a new QUIC stream for each requested URL.
+//! 2. Send "GET <path>\r\n" on the stream.
+//! 3. Receive the raw file bytes until the server closes the stream.
+//! 4. Write the received bytes to `/downloads/<filename>`.
+//!
+//! This module provides request building and response writing helpers.
+
+const std = @import("std");
+
+pub const downloads_root: []const u8 = "/downloads";
+
+/// Maximum URL length accepted by buildRequest.
+pub const max_url_len: usize = 2048;
+
+/// Build an HTTP/0.9 GET request line for `path` into `buf`.
+///
+/// Returns the slice of `buf` that was written.
+pub fn buildRequest(path: []const u8, buf: []u8) error{BufferTooSmall}![]u8 {
+    const line = std.fmt.bufPrint(buf, "GET {s}\r\n", .{path}) catch return error.BufferTooSmall;
+    return line;
+}
+
+/// Extract the filename component from a URL path.
+///
+/// "/foo/bar/baz.txt" → "baz.txt"
+/// "/index.html"      → "index.html"
+/// "/"               → "index.html" (fallback)
+pub fn filenameFromPath(path: []const u8) []const u8 {
+    if (std.mem.lastIndexOfScalar(u8, path, '/')) |slash| {
+        const after = path[slash + 1 ..];
+        if (after.len > 0) return after;
+    }
+    return "index.html";
+}
+
+/// Build the local download destination path for a given URL path.
+///
+/// "/foo/bar.txt" → "/downloads/bar.txt"
+pub fn downloadPath(path: []const u8, buf: []u8) error{BufferTooSmall}![]u8 {
+    const name = filenameFromPath(path);
+    return std.fmt.bufPrint(buf, "{s}/{s}", .{ downloads_root, name }) catch error.BufferTooSmall;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "http09 client: buildRequest" {
+    var buf: [64]u8 = undefined;
+    const req = try buildRequest("/hello.txt", &buf);
+    try std.testing.expectEqualSlices(u8, "GET /hello.txt\r\n", req);
+}
+
+test "http09 client: filenameFromPath" {
+    const testing = std.testing;
+    try testing.expectEqualSlices(u8, "bar.txt", filenameFromPath("/foo/bar.txt"));
+    try testing.expectEqualSlices(u8, "index.html", filenameFromPath("/index.html"));
+    try testing.expectEqualSlices(u8, "index.html", filenameFromPath("/"));
+    try testing.expectEqualSlices(u8, "file", filenameFromPath("/a/b/file"));
+}
+
+test "http09 client: downloadPath" {
+    var buf: [64]u8 = undefined;
+    const p = try downloadPath("/data/result.bin", &buf);
+    try std.testing.expectEqualSlices(u8, "/downloads/result.bin", p);
+}

--- a/src/http09/server.zig
+++ b/src/http09/server.zig
@@ -1,0 +1,96 @@
+//! Minimal HTTP/0.9 server for quic-interop-runner compatibility.
+//!
+//! The QUIC interop runner's `transfer` test case uses HTTP/0.9: the client
+//! sends a simple request "GET /path\r\n" on a QUIC stream, and the server
+//! responds with the raw file contents followed by stream FIN.
+//!
+//! This module provides request parsing and response building for that
+//! protocol, independent of the QUIC transport layer.
+//!
+//! File root: requests are served from the `/www` directory (interop
+//! convention).
+
+const std = @import("std");
+
+pub const www_root: []const u8 = "/www";
+
+/// Maximum request line length (e.g. "GET /index.html\r\n").
+pub const max_request_len: usize = 4096;
+
+/// Parsed HTTP/0.9 GET request.
+pub const Request = struct {
+    path: []const u8,
+};
+
+pub const ParseError = error{
+    NotAGetRequest,
+    MissingPath,
+    PathTooLong,
+    Incomplete,
+};
+
+/// Parse an HTTP/0.9 request from `data`.
+///
+/// Expects: "GET <path>\r\n" or "GET <path>\n"
+/// Returns `error.Incomplete` if the line terminator has not arrived yet.
+pub fn parseRequest(data: []const u8) ParseError!Request {
+    if (data.len < 5) return error.Incomplete;
+    if (!std.mem.startsWith(u8, data, "GET ")) return error.NotAGetRequest;
+
+    const after_get = data[4..];
+    // Find line terminator
+    const nl = std.mem.indexOfScalar(u8, after_get, '\n') orelse return error.Incomplete;
+    var path_end = nl;
+    if (path_end > 0 and after_get[path_end - 1] == '\r') path_end -= 1;
+    if (path_end == 0) return error.MissingPath;
+    const path = after_get[0..path_end];
+    if (path.len > 1024) return error.PathTooLong;
+    return Request{ .path = path };
+}
+
+/// Resolve a request path to a filesystem path under `www_root`.
+///
+/// Security: Rejects paths containing `..` or `//` to prevent directory
+/// traversal.
+pub fn resolvePath(path: []const u8, buf: []u8) error{ PathTooLong, Unsafe }![]u8 {
+    if (std.mem.indexOf(u8, path, "..") != null) return error.Unsafe;
+    if (std.mem.indexOf(u8, path, "//") != null) return error.Unsafe;
+    const resolved = std.fmt.bufPrint(buf, "{s}{s}", .{ www_root, path }) catch return error.PathTooLong;
+    return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "http09 server: parse GET request" {
+    const testing = std.testing;
+    const req = try parseRequest("GET /index.html\r\n");
+    try testing.expectEqualSlices(u8, "/index.html", req.path);
+}
+
+test "http09 server: parse GET request unix line ending" {
+    const req = try parseRequest("GET /foo\n");
+    try std.testing.expectEqualSlices(u8, "/foo", req.path);
+}
+
+test "http09 server: incomplete request" {
+    const result = parseRequest("GET /foo");
+    try std.testing.expectError(error.Incomplete, result);
+}
+
+test "http09 server: not a GET" {
+    const result = parseRequest("POST /foo\r\n");
+    try std.testing.expectError(error.NotAGetRequest, result);
+}
+
+test "http09 server: resolve path" {
+    var buf: [256]u8 = undefined;
+    const resolved = try resolvePath("/hello.txt", &buf);
+    try std.testing.expectEqualSlices(u8, "/www/hello.txt", resolved);
+}
+
+test "http09 server: reject path traversal" {
+    var buf: [256]u8 = undefined;
+    try std.testing.expectError(error.Unsafe, resolvePath("/../etc/passwd", &buf));
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -34,6 +34,10 @@ pub const transport = struct {
     pub const flow_control = @import("transport/flow_control.zig");
     pub const stream_manager = @import("transport/stream_manager.zig");
 };
+pub const http09 = struct {
+    pub const server = @import("http09/server.zig");
+    pub const client = @import("http09/client.zig");
+};
 pub const frames = struct {
     pub const frame = @import("frames/frame.zig");
     pub const ack = @import("frames/ack.zig");
@@ -62,6 +66,8 @@ test {
     _ = @import("transport/endpoint.zig");
     _ = @import("transport/flow_control.zig");
     _ = @import("transport/stream_manager.zig");
+    _ = @import("http09/server.zig");
+    _ = @import("http09/client.zig");
     _ = @import("frames/frame.zig");
     _ = @import("frames/ack.zig");
     _ = @import("frames/crypto_frame.zig");


### PR DESCRIPTION
## Summary

- `src/http09/server.zig`: request parsing (`GET <path>\r\n`), path resolution with `/www` root, directory-traversal rejection
- `src/http09/client.zig`: request building, filename extraction from URL path, download path mapping to `/downloads/<file>`

These helpers implement the HTTP/0.9 protocol expected by the `quic-interop-runner` `transfer` test case.

## Test plan

- [x] Parse `GET /index.html\r\n` → correct path
- [x] Unix line ending (`\n` only)
- [x] Incomplete request → `error.Incomplete`
- [x] Non-GET method → `error.NotAGetRequest`
- [x] `resolvePath` → `/www/hello.txt`
- [x] Path traversal `/../etc/passwd` → `error.Unsafe`
- [x] `buildRequest` → `"GET /hello.txt\r\n"`
- [x] `filenameFromPath` edge cases (root `/`, nested `/a/b/file`)
- [x] `downloadPath` → `/downloads/result.bin`
- [x] All 85 tests pass