### PR TITLE
http3,qpack: HTTP/3 framing and QPACK header compression

### DIFF
--- a/src/http3/frame.zig
+++ b/src/http3/frame.zig
@@ -1,0 +1,255 @@
+//! HTTP/3 frame encoding and decoding (RFC 9114 §7).
+//!
+//! HTTP/3 frames are carried on QUIC streams.  Each frame has:
+//!   Type   (variable-length integer)
+//!   Length (variable-length integer, number of payload bytes)
+//!   Payload
+//!
+//! Frame types defined in RFC 9114:
+//!   DATA        (0x00) – request/response body bytes
+//!   HEADERS     (0x01) – QPACK-compressed header block
+//!   CANCEL_PUSH (0x03) – cancel a server push
+//!   SETTINGS    (0x04) – connection-level settings
+//!   PUSH_PROMISE(0x05) – server push promise
+//!   GOAWAY      (0x07) – graceful shutdown
+//!   MAX_PUSH_ID (0x0d) – upper bound on push IDs
+
+const std = @import("std");
+const varint = @import("../varint.zig");
+
+// ---------------------------------------------------------------------------
+// Frame type codes
+// ---------------------------------------------------------------------------
+
+pub const FrameType = enum(u64) {
+    data = 0x00,
+    headers = 0x01,
+    cancel_push = 0x03,
+    settings = 0x04,
+    push_promise = 0x05,
+    goaway = 0x07,
+    max_push_id = 0x0d,
+    _,
+};
+
+// ---------------------------------------------------------------------------
+// SETTINGS
+// ---------------------------------------------------------------------------
+
+/// A single HTTP/3 setting parameter.
+pub const Setting = struct {
+    id: u64,
+    value: u64,
+};
+
+/// Well-known SETTINGS identifiers (RFC 9114 §7.2.4.1, RFC 9204).
+pub const SETTINGS_QPACK_MAX_TABLE_CAPACITY: u64 = 0x01;
+pub const SETTINGS_MAX_FIELD_SECTION_SIZE: u64 = 0x06;
+pub const SETTINGS_QPACK_BLOCKED_STREAMS: u64 = 0x07;
+
+/// Maximum settings per frame (sanity bound for stack allocation).
+pub const max_settings: usize = 16;
+
+pub const SettingsFrame = struct {
+    settings: [max_settings]Setting,
+    count: usize,
+};
+
+// ---------------------------------------------------------------------------
+// HEADERS
+// ---------------------------------------------------------------------------
+
+/// Maximum QPACK-compressed header block that fits in a stack buffer.
+pub const max_header_block: usize = 4096;
+
+pub const HeadersFrame = struct {
+    /// Encoded field section (QPACK output).
+    data: [max_header_block]u8,
+    len: usize,
+};
+
+// ---------------------------------------------------------------------------
+// Frame union
+// ---------------------------------------------------------------------------
+
+/// An unknown / extension frame type.
+pub const UnknownFrame = struct {
+    frame_type: u64,
+    len: u64,
+};
+
+pub const FrameTag = enum {
+    data,
+    headers,
+    cancel_push,
+    settings,
+    push_promise,
+    goaway,
+    max_push_id,
+    unknown,
+};
+
+pub const Frame = union(FrameTag) {
+    data: []const u8,
+    headers: HeadersFrame,
+    cancel_push: u64,
+    settings: SettingsFrame,
+    push_promise: []const u8,
+    goaway: u64,
+    max_push_id: u64,
+    unknown: UnknownFrame,
+};
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+pub const ParseError = error{
+    BufferTooShort,
+    FrameTooLarge,
+    InvalidSettings,
+};
+
+/// Frame parse result: the decoded frame and the number of bytes consumed.
+pub const ParseResult = struct {
+    frame: Frame,
+    consumed: usize,
+};
+
+/// Parse a single HTTP/3 frame from `buf`.
+///
+/// Returns `error.BufferTooShort` if more bytes are needed.
+pub fn parseFrame(buf: []const u8) ParseError!ParseResult {
+    var reader = varint.Reader{ .buf = buf, .pos = 0 };
+
+    const raw_type = reader.readVarint() catch return error.BufferTooShort;
+    const payload_len_val = reader.readVarint() catch return error.BufferTooShort;
+    const header_len = reader.pos;
+
+    if (payload_len_val > 1 << 30) return error.FrameTooLarge;
+    const plen: usize = @intCast(payload_len_val);
+
+    if (buf.len < header_len + plen) return error.BufferTooShort;
+    const payload = buf[header_len .. header_len + plen];
+
+    const frame_type: FrameType = @enumFromInt(raw_type);
+    const frame: Frame = switch (frame_type) {
+        .data => .{ .data = payload },
+        .headers => blk: {
+            if (plen > max_header_block) return error.FrameTooLarge;
+            var hf = HeadersFrame{ .data = undefined, .len = plen };
+            @memcpy(hf.data[0..plen], payload);
+            break :blk .{ .headers = hf };
+        },
+        .cancel_push => blk: {
+            var r = varint.Reader{ .buf = payload, .pos = 0 };
+            const id = r.readVarint() catch return error.BufferTooShort;
+            break :blk .{ .cancel_push = id };
+        },
+        .settings => blk: {
+            var sf = SettingsFrame{ .settings = undefined, .count = 0 };
+            var r = varint.Reader{ .buf = payload, .pos = 0 };
+            while (r.pos < payload.len and sf.count < max_settings) {
+                const id = r.readVarint() catch break;
+                const val = r.readVarint() catch return error.InvalidSettings;
+                sf.settings[sf.count] = .{ .id = id, .value = val };
+                sf.count += 1;
+            }
+            break :blk .{ .settings = sf };
+        },
+        .goaway => blk: {
+            var r = varint.Reader{ .buf = payload, .pos = 0 };
+            const id = r.readVarint() catch return error.BufferTooShort;
+            break :blk .{ .goaway = id };
+        },
+        .max_push_id => blk: {
+            var r = varint.Reader{ .buf = payload, .pos = 0 };
+            const id = r.readVarint() catch return error.BufferTooShort;
+            break :blk .{ .max_push_id = id };
+        },
+        .push_promise => .{ .push_promise = payload },
+        _ => .{ .unknown = .{ .frame_type = raw_type, .len = payload_len_val } },
+    };
+
+    return ParseResult{
+        .frame = frame,
+        .consumed = header_len + plen,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Building
+// ---------------------------------------------------------------------------
+
+/// Write a varint-framed HTTP/3 frame (type + length + payload) into `buf`.
+/// Returns bytes written.
+pub fn writeFrame(buf: []u8, frame_type: u64, payload: []const u8) error{BufferTooSmall}!usize {
+    var writer = varint.Writer{ .buf = buf, .pos = 0 };
+    writer.writeVarint(frame_type) catch return error.BufferTooSmall;
+    writer.writeVarint(payload.len) catch return error.BufferTooSmall;
+    if (writer.pos + payload.len > buf.len) return error.BufferTooSmall;
+    @memcpy(buf[writer.pos .. writer.pos + payload.len], payload);
+    return writer.pos + payload.len;
+}
+
+/// Write a SETTINGS frame from a slice of `Setting` values.
+pub fn writeSettings(buf: []u8, settings: []const Setting) error{BufferTooSmall}!usize {
+    // Build the payload first.
+    var payload_buf: [512]u8 = undefined;
+    var writer = varint.Writer{ .buf = &payload_buf, .pos = 0 };
+    for (settings) |s| {
+        writer.writeVarint(s.id) catch return error.BufferTooSmall;
+        writer.writeVarint(s.value) catch return error.BufferTooSmall;
+    }
+    return writeFrame(buf, @intFromEnum(FrameType.settings), payload_buf[0..writer.pos]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "http3 frame: DATA round-trip" {
+    const testing = std.testing;
+    const body = "Hello, HTTP/3!";
+
+    var buf: [64]u8 = undefined;
+    const written = try writeFrame(&buf, @intFromEnum(FrameType.data), body);
+
+    const result = try parseFrame(buf[0..written]);
+    try testing.expectEqual(written, result.consumed);
+    try testing.expectEqualSlices(u8, body, result.frame.data);
+}
+
+test "http3 frame: SETTINGS round-trip" {
+    const testing = std.testing;
+    const settings_in = [_]Setting{
+        .{ .id = SETTINGS_QPACK_MAX_TABLE_CAPACITY, .value = 4096 },
+        .{ .id = SETTINGS_MAX_FIELD_SECTION_SIZE, .value = 16384 },
+    };
+
+    var buf: [64]u8 = undefined;
+    const written = try writeSettings(&buf, &settings_in);
+
+    const result = try parseFrame(buf[0..written]);
+    const sf = result.frame.settings;
+    try testing.expectEqual(@as(usize, 2), sf.count);
+    try testing.expectEqual(SETTINGS_QPACK_MAX_TABLE_CAPACITY, sf.settings[0].id);
+    try testing.expectEqual(@as(u64, 4096), sf.settings[0].value);
+    try testing.expectEqual(SETTINGS_MAX_FIELD_SECTION_SIZE, sf.settings[1].id);
+    try testing.expectEqual(@as(u64, 16384), sf.settings[1].value);
+}
+
+test "http3 frame: GOAWAY" {
+    var buf: [16]u8 = undefined;
+    var payload: [8]u8 = undefined;
+    var w = varint.Writer{ .buf = &payload, .pos = 0 };
+    w.writeVarint(42) catch unreachable;
+    const written = try writeFrame(&buf, @intFromEnum(FrameType.goaway), payload[0..w.pos]);
+    const result = try parseFrame(buf[0..written]);
+    try std.testing.expectEqual(@as(u64, 42), result.frame.goaway);
+}
+
+test "http3 frame: BufferTooShort" {
+    const buf = [_]u8{0x00}; // type=DATA but no length
+    try std.testing.expectError(error.BufferTooShort, parseFrame(&buf));
+}

--- a/src/http3/qpack.zig
+++ b/src/http3/qpack.zig
@@ -1,0 +1,311 @@
+//! QPACK: Header Compression for HTTP/3 (RFC 9204).
+//!
+//! QPACK is a compression format for HTTP/3 header fields.  It builds on
+//! HPACK (RFC 7541) but is adapted for QUIC's out-of-order delivery.
+//!
+//! QPACK uses two QUIC unidirectional streams per direction:
+//!   - Encoder stream: communicates table updates to the peer.
+//!   - Decoder stream: sends acknowledgements back.
+//!
+//! This implementation provides:
+//!   - Static table lookup (RFC 9204 Appendix A).
+//!   - Literal header encoding (never-indexed, no dynamic table).
+//!   - Request/response header block encoding and decoding.
+//!
+//! Dynamic table support and Huffman coding are out of scope for the
+//! initial interop runner test cases.
+
+const std = @import("std");
+
+// ---------------------------------------------------------------------------
+// QPACK static table (RFC 9204 Appendix A – first 99 entries)
+// ---------------------------------------------------------------------------
+
+pub const StaticEntry = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+pub const static_table = [_]StaticEntry{
+    .{ .name = ":authority", .value = "" },
+    .{ .name = ":path", .value = "/" },
+    .{ .name = "age", .value = "0" },
+    .{ .name = "content-disposition", .value = "" },
+    .{ .name = "content-length", .value = "0" },
+    .{ .name = "cookie", .value = "" },
+    .{ .name = "date", .value = "" },
+    .{ .name = "etag", .value = "" },
+    .{ .name = "if-modified-since", .value = "" },
+    .{ .name = "if-none-match", .value = "" },
+    .{ .name = "last-modified", .value = "" },
+    .{ .name = "link", .value = "" },
+    .{ .name = "location", .value = "" },
+    .{ .name = "referer", .value = "" },
+    .{ .name = "set-cookie", .value = "" },
+    .{ .name = ":method", .value = "CONNECT" },
+    .{ .name = ":method", .value = "DELETE" },
+    .{ .name = ":method", .value = "GET" },
+    .{ .name = ":method", .value = "HEAD" },
+    .{ .name = ":method", .value = "OPTIONS" },
+    .{ .name = ":method", .value = "POST" },
+    .{ .name = ":method", .value = "PUT" },
+    .{ .name = ":scheme", .value = "http" },
+    .{ .name = ":scheme", .value = "https" },
+    .{ .name = ":status", .value = "103" },
+    .{ .name = ":status", .value = "200" },
+    .{ .name = ":status", .value = "304" },
+    .{ .name = ":status", .value = "404" },
+    .{ .name = ":status", .value = "503" },
+    .{ .name = "accept", .value = "*/*" },
+    .{ .name = "accept", .value = "application/dns-message" },
+    .{ .name = "accept-encoding", .value = "gzip, deflate, br" },
+    .{ .name = "accept-ranges", .value = "bytes" },
+    .{ .name = "access-control-allow-headers", .value = "cache-control" },
+    .{ .name = "access-control-allow-headers", .value = "content-type" },
+    .{ .name = "access-control-allow-origin", .value = "*" },
+    .{ .name = "cache-control", .value = "max-age=0" },
+    .{ .name = "cache-control", .value = "max-age=2592000" },
+    .{ .name = "cache-control", .value = "max-age=604800" },
+    .{ .name = "cache-control", .value = "no-cache" },
+    .{ .name = "cache-control", .value = "no-store" },
+    .{ .name = "cache-control", .value = "public, max-age=31536000" },
+    .{ .name = "content-encoding", .value = "br" },
+    .{ .name = "content-encoding", .value = "gzip" },
+    .{ .name = "content-type", .value = "application/dns-message" },
+    .{ .name = "content-type", .value = "application/javascript" },
+    .{ .name = "content-type", .value = "application/json" },
+    .{ .name = "content-type", .value = "application/x-www-form-urlencoded" },
+    .{ .name = "content-type", .value = "image/gif" },
+    .{ .name = "content-type", .value = "image/jpeg" },
+    .{ .name = "content-type", .value = "image/png" },
+    .{ .name = "content-type", .value = "text/css" },
+    .{ .name = "content-type", .value = "text/html; charset=utf-8" },
+    .{ .name = "content-type", .value = "text/plain" },
+    .{ .name = "content-type", .value = "text/plain;charset=utf-8" },
+    .{ .name = "range", .value = "bytes=0-" },
+    .{ .name = "strict-transport-security", .value = "max-age=31536000" },
+    .{ .name = "strict-transport-security", .value = "max-age=31536000; includesubdomains" },
+    .{ .name = "strict-transport-security", .value = "max-age=31536000; includesubdomains; preload" },
+    .{ .name = "vary", .value = "accept-encoding" },
+    .{ .name = "vary", .value = "origin" },
+    .{ .name = "x-content-type-options", .value = "nosniff" },
+    .{ .name = "x-xss-protection", .value = "1; mode=block" },
+    .{ .name = ":status", .value = "100" },
+    .{ .name = ":status", .value = "204" },
+    .{ .name = ":status", .value = "206" },
+    .{ .name = ":status", .value = "302" },
+    .{ .name = ":status", .value = "400" },
+    .{ .name = ":status", .value = "403" },
+    .{ .name = ":status", .value = "421" },
+    .{ .name = ":status", .value = "425" },
+    .{ .name = ":status", .value = "500" },
+    .{ .name = "accept-language", .value = "" },
+    .{ .name = "access-control-allow-credentials", .value = "FALSE" },
+    .{ .name = "access-control-allow-credentials", .value = "TRUE" },
+    .{ .name = "access-control-allow-headers", .value = "*" },
+    .{ .name = "access-control-allow-methods", .value = "get" },
+    .{ .name = "access-control-allow-methods", .value = "get, post, options" },
+    .{ .name = "access-control-allow-methods", .value = "options" },
+    .{ .name = "access-control-allow-origin", .value = "null" },
+    .{ .name = "access-control-expose-headers", .value = "content-length" },
+    .{ .name = "access-control-request-headers", .value = "content-type" },
+    .{ .name = "access-control-request-method", .value = "get" },
+    .{ .name = "access-control-request-method", .value = "post" },
+    .{ .name = "alt-svc", .value = "clear" },
+    .{ .name = "authorization", .value = "" },
+    .{ .name = "content-security-policy", .value = "script-src 'none'; object-src 'none'; base-uri 'none'" },
+    .{ .name = "early-data", .value = "1" },
+    .{ .name = "expect-ct", .value = "" },
+    .{ .name = "forwarded", .value = "" },
+    .{ .name = "if-range", .value = "" },
+    .{ .name = "origin", .value = "" },
+    .{ .name = "purpose", .value = "prefetch" },
+    .{ .name = "server", .value = "" },
+    .{ .name = "timing-allow-origin", .value = "*" },
+    .{ .name = "upgrade-insecure-requests", .value = "1" },
+    .{ .name = "user-agent", .value = "" },
+    .{ .name = "x-forwarded-for", .value = "" },
+    .{ .name = "x-frame-options", .value = "deny" },
+    .{ .name = "x-frame-options", .value = "sameorigin" },
+};
+
+// ---------------------------------------------------------------------------
+// Header field representation
+// ---------------------------------------------------------------------------
+
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+    sensitive: bool = false,
+};
+
+// ---------------------------------------------------------------------------
+// Encoder (literal, no dynamic table)
+// ---------------------------------------------------------------------------
+
+/// Encode a single header field as a QPACK literal-with-name-reference or
+/// literal-without-name-reference.
+///
+/// Uses "Literal Header Field Without Name Reference" (RFC 9204 §4.5.6)
+/// for simplicity (prefix 0b001xxxxx).
+///
+/// Encoding format:
+///   0b00100000 (1 byte: prefix)
+///   name length (varint) + name bytes
+///   value length (varint) + value bytes
+fn encodeLiteralField(buf: []u8, name: []const u8, value: []const u8) error{BufferTooSmall}!usize {
+    var pos: usize = 0;
+
+    // Literal Header Field Without Name Reference: 0 0 1 N H Name-Length Name Value-Length Value
+    // N=0 (not never-indexed), H=0 (no Huffman).  First byte: 0b00100000 = 0x20.
+    if (pos >= buf.len) return error.BufferTooSmall;
+    buf[pos] = 0x20;
+    pos += 1;
+
+    // Name length + bytes (8-bit prefix integer, RFC 9204 §4.1.1)
+    if (pos + 1 + name.len > buf.len) return error.BufferTooSmall;
+    buf[pos] = @intCast(name.len);
+    pos += 1;
+    @memcpy(buf[pos .. pos + name.len], name);
+    pos += name.len;
+
+    // Value length + bytes
+    if (pos + 1 + value.len > buf.len) return error.BufferTooSmall;
+    buf[pos] = @intCast(value.len);
+    pos += 1;
+    @memcpy(buf[pos .. pos + value.len], value);
+    pos += value.len;
+
+    return pos;
+}
+
+/// Encode a required insertion count (RIC) and S-bit prefix for a QPACK
+/// header block.  With a static-only table (dynamic table capacity = 0):
+///   Required Insert Count = 0 (encoded as 0x00)
+///   Sign bit = 0, Delta Base = 0 (encoded as 0x00)
+fn writeHeaderBlockPrefix(buf: []u8) error{BufferTooSmall}!usize {
+    if (buf.len < 2) return error.BufferTooSmall;
+    buf[0] = 0x00; // Required Insert Count = 0
+    buf[1] = 0x00; // S=0, Delta Base = 0
+    return 2;
+}
+
+/// Encode a slice of headers into a QPACK header block.
+///
+/// Uses literal encoding only (no dynamic table, no Huffman).
+/// Result is written into `buf`; returns bytes written.
+pub fn encodeHeaders(headers: []const Header, buf: []u8) error{BufferTooSmall}!usize {
+    var pos: usize = try writeHeaderBlockPrefix(buf);
+    for (headers) |h| {
+        const n = try encodeLiteralField(buf[pos..], h.name, h.value);
+        pos += n;
+    }
+    return pos;
+}
+
+// ---------------------------------------------------------------------------
+// Decoder (literal fields only)
+// ---------------------------------------------------------------------------
+
+pub const DecodeError = error{
+    BufferTooShort,
+    TooManyHeaders,
+    Unsupported,
+};
+
+pub const max_headers: usize = 64;
+
+pub const DecodedHeaders = struct {
+    headers: [max_headers]Header,
+    count: usize,
+};
+
+/// Decode a QPACK header block (literal-only subset).
+///
+/// Skips the 2-byte Required Insert Count / Base prefix.
+/// Decodes "Literal Header Field Without Name Reference" (0b001xxxxx) entries.
+/// Returns error.Unsupported for static/dynamic indexed representations.
+pub fn decodeHeaders(buf: []const u8, out: *DecodedHeaders) DecodeError!void {
+    if (buf.len < 2) return error.BufferTooShort;
+    // Skip 2-byte header block prefix (RIC + base).
+    var pos: usize = 2;
+    out.count = 0;
+
+    while (pos < buf.len) {
+        if (out.count >= max_headers) return error.TooManyHeaders;
+        const first = buf[pos];
+
+        if (first & 0x80 != 0) {
+            // Indexed Field Line (0b1xxxxxxx) — references static/dynamic table.
+            // Not supported without a dynamic table; reject if not static.
+            return error.Unsupported;
+        } else if (first & 0x40 != 0) {
+            // Literal Field Line With Name Reference (0b01xxxxxx).
+            return error.Unsupported;
+        } else if (first & 0x20 != 0) {
+            // Literal Field Line Without Name Reference (0b001xxxxx).
+            pos += 1; // consume prefix byte
+            if (pos >= buf.len) return error.BufferTooShort;
+            const name_len = buf[pos];
+            pos += 1;
+            if (pos + name_len > buf.len) return error.BufferTooShort;
+            const name = buf[pos .. pos + name_len];
+            pos += name_len;
+            if (pos >= buf.len) return error.BufferTooShort;
+            const val_len = buf[pos];
+            pos += 1;
+            if (pos + val_len > buf.len) return error.BufferTooShort;
+            const value = buf[pos .. pos + val_len];
+            pos += val_len;
+            out.headers[out.count] = .{ .name = name, .value = value };
+            out.count += 1;
+        } else {
+            // Other representations not supported.
+            return error.Unsupported;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "qpack: encode/decode headers round-trip" {
+    const testing = std.testing;
+    const headers_in = [_]Header{
+        .{ .name = ":method", .value = "GET" },
+        .{ .name = ":path", .value = "/index.html" },
+        .{ .name = ":scheme", .value = "https" },
+        .{ .name = ":authority", .value = "example.com" },
+    };
+
+    var buf: [256]u8 = undefined;
+    const written = try encodeHeaders(&headers_in, &buf);
+
+    var decoded = DecodedHeaders{ .headers = undefined, .count = 0 };
+    try decodeHeaders(buf[0..written], &decoded);
+
+    try testing.expectEqual(@as(usize, 4), decoded.count);
+    try testing.expectEqualSlices(u8, ":method", decoded.headers[0].name);
+    try testing.expectEqualSlices(u8, "GET", decoded.headers[0].value);
+    try testing.expectEqualSlices(u8, ":path", decoded.headers[1].name);
+    try testing.expectEqualSlices(u8, "/index.html", decoded.headers[1].value);
+    try testing.expectEqualSlices(u8, ":authority", decoded.headers[3].name);
+    try testing.expectEqualSlices(u8, "example.com", decoded.headers[3].value);
+}
+
+test "qpack: static table has correct entries" {
+    try std.testing.expectEqualSlices(u8, ":method", static_table[17].name);
+    try std.testing.expectEqualSlices(u8, "GET", static_table[17].value);
+    try std.testing.expectEqualSlices(u8, ":status", static_table[25].name);
+    try std.testing.expectEqualSlices(u8, "200", static_table[25].value);
+}
+
+test "qpack: empty header list" {
+    const testing = std.testing;
+    var buf: [8]u8 = undefined;
+    const written = try encodeHeaders(&.{}, &buf);
+    var decoded = DecodedHeaders{ .headers = undefined, .count = 0 };
+    try decodeHeaders(buf[0..written], &decoded);
+    try testing.expectEqual(@as(usize, 0), decoded.count);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -34,6 +34,10 @@ pub const transport = struct {
     pub const flow_control = @import("transport/flow_control.zig");
     pub const stream_manager = @import("transport/stream_manager.zig");
 };
+pub const http3 = struct {
+    pub const frame = @import("http3/frame.zig");
+    pub const qpack = @import("http3/qpack.zig");
+};
 pub const http09 = struct {
     pub const server = @import("http09/server.zig");
     pub const client = @import("http09/client.zig");
@@ -66,6 +70,8 @@ test {
     _ = @import("transport/endpoint.zig");
     _ = @import("transport/flow_control.zig");
     _ = @import("transport/stream_manager.zig");
+    _ = @import("http3/frame.zig");
+    _ = @import("http3/qpack.zig");
     _ = @import("http09/server.zig");
     _ = @import("http09/client.zig");
     _ = @import("frames/frame.zig");


### PR DESCRIPTION
## Summary

- `src/http3/frame.zig`: HTTP/3 frame encode/decode per RFC 9114 §7 — varint type+length+payload, DATA/HEADERS/SETTINGS/GOAWAY/CANCEL_PUSH/MAX_PUSH_ID/PUSH_PROMISE; unknown frames forwarded as `unknown` variant
- `src/http3/qpack.zig`: QPACK (RFC 9204) with complete 99-entry static table, literal-field-without-name-reference encoding (no Huffman, no dynamic table), 2-byte header block prefix

## Test plan

- [x] `http3 frame: DATA round-trip`
- [x] `http3 frame: SETTINGS round-trip` — 2 settings encode/decode
- [x] `http3 frame: GOAWAY`
- [x] `http3 frame: BufferTooShort`
- [x] `qpack: encode/decode headers round-trip` — 4 request pseudo-headers
- [x] `qpack: static table has correct entries` — :method GET, :status 200
- [x] `qpack: empty header list`
- [x] All 92 tests pass