### PR TITLE
ci: fix interop Docker build — separate Dockerfile.prebuilt for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Pass PREBUILT=1 so the Dockerfile skips the Zig download stage and
-      # copies the pre-built binaries from zig-out/ directly.
+      # Use Dockerfile.prebuilt which simply COPYs zig-out/bin/* — no Zig
+      # toolchain download needed inside Docker at all.
       - name: Build interop image (no push)
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: interop/Dockerfile
-          build-args: |
-            PREBUILT=1
+          file: interop/Dockerfile.prebuilt
           push: false
           tags: zquic-interop:ci
           cache-from: type=gha

--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -1,33 +1,25 @@
-# zquic interop runner image
+# zquic interop runner image — self-contained local build
 #
-# Compatible with quic-interop-runner (https://github.com/quic-interop/quic-interop-runner).
+# Downloads Zig at build time, compiles the binaries, then packages them
+# into a slim runtime image. Use this for local docker builds.
 #
-# ── Local build (multi-stage, downloads Zig at build time) ──────────────────
 #   docker build -t zquic-interop -f interop/Dockerfile .
 #
-# ── CI build (pre-built binaries supplied via --build-context) ──────────────
-#   zig build -Doptimize=ReleaseFast
-#   docker build -t zquic-interop \
-#     --build-arg PREBUILT=1 \
-#     -f interop/Dockerfile .
-#
-# The quic-interop-runner will invoke:
-#   docker run --network <...> -e TESTCASE=<...> -e ROLE=<server|client> \
-#              -e SSLKEYLOGFILE=<path> -e QLOGDIR=<path> \
-#              -v /www:/www -v /downloads:/downloads -v /certs:/certs \
-#              zquic-interop
+# For CI builds where binaries are pre-compiled on the runner, use
+# interop/Dockerfile.prebuilt instead.
 
-ARG PREBUILT=0
+# ── Stage 1: compile ────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS builder
 
-# ── Stage 1a: build with local Zig download (PREBUILT=0) ────────────────────
-FROM debian:bookworm-slim AS builder-download
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Download latest Zig 0.15.x dev tarball via the official JSON index.
+# Fetch the latest 0.15.x dev tarball URL from the official JSON index so
+# we do not hardcode a version path that may not exist yet.
 RUN set -eux; \
-    ZIG_URL=$(curl -fsSL https://ziglang.org/download/index.json \
+    INDEX=$(curl -fsSL https://ziglang.org/download/index.json); \
+    ZIG_URL=$(echo "$INDEX" \
         | grep -o '"x86_64-linux":[^}]*' \
         | grep -o '"tarball":"[^"]*"' \
         | head -1 \
@@ -44,15 +36,7 @@ WORKDIR /build
 COPY . .
 RUN zig build -Doptimize=ReleaseFast
 
-# ── Stage 1b: pre-built binaries already on disk (PREBUILT=1) ───────────────
-FROM debian:bookworm-slim AS builder-prebuilt
-WORKDIR /build
-COPY zig-out/ zig-out/
-
-# ── Stage selector ──────────────────────────────────────────────────────────
-FROM builder-${PREBUILT:-download} AS builder
-
-# ── Stage 2: minimal runtime image ──────────────────────────────────────────
+# ── Stage 2: minimal runtime ────────────────────────────────────────────────
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -64,5 +48,4 @@ COPY --from=builder /build/zig-out/bin/client /usr/local/bin/zquic-client
 COPY interop/run_endpoint.sh /run_endpoint.sh
 RUN chmod +x /run_endpoint.sh
 
-# quic-interop-runner convention: entrypoint is /run_endpoint.sh
 ENTRYPOINT ["/run_endpoint.sh"]

--- a/interop/Dockerfile.prebuilt
+++ b/interop/Dockerfile.prebuilt
@@ -1,0 +1,22 @@
+# zquic interop runner image — pre-built binaries (CI optimised)
+#
+# Expects the Zig release binaries to already exist in zig-out/bin/
+# (built on the CI runner with `zig build -Doptimize=ReleaseFast`).
+# Does NOT download or run Zig inside Docker.
+#
+# Used by .github/workflows/ci.yml:
+#   zig build -Doptimize=ReleaseFast
+#   docker build -t zquic-interop -f interop/Dockerfile.prebuilt .
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY zig-out/bin/server /usr/local/bin/zquic-server
+COPY zig-out/bin/client /usr/local/bin/zquic-client
+COPY interop/run_endpoint.sh /run_endpoint.sh
+RUN chmod +x /run_endpoint.sh
+
+ENTRYPOINT ["/run_endpoint.sh"]


### PR DESCRIPTION
## Problem

Docker does not support `ARG` interpolation in multi-stage `FROM` **aliases**. `FROM builder-${PREBUILT:-download}` with `PREBUILT=1` resolves to `FROM builder-1`, which Docker interprets as an image name and tries to pull from Docker Hub, producing:

> `pull access denied, repository does not exist: builder-1`

## Fix

Replace the single Dockerfile with a dynamic stage selector with **two separate, simple Dockerfiles**:

| File | Purpose |
|------|---------|
| `interop/Dockerfile` | **Local use** — downloads latest Zig 0.15.x dev tarball dynamically from `ziglang.org/download/index.json`, builds from source, packages into slim image |
| `interop/Dockerfile.prebuilt` | **CI** — expects `zig-out/bin/` to already exist (built on the runner via `mlugg/setup-zig`); simply `COPY`s the binaries; zero Zig toolchain download inside Docker |

CI workflow updated to point to `Dockerfile.prebuilt` (no `--build-arg` needed).

## Test plan

- [x] `zig build test --summary all` — 97/97 tests pass
- [x] `zig fmt --check .` — clean
- [x] CI `interop-image` job: runner builds binaries → `Dockerfile.prebuilt` copies them → no Docker Hub pull of phantom images