### PR TITLE
docs,build: examples folder, expanded README, clarified interop CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,13 @@ jobs:
         with:
           version: "0.15.0"
 
-      - name: Build
+      - name: Build library and binaries
         run: zig build
 
-      - name: Test
+      - name: Build examples
+        run: zig build examples
+
+      - name: Run unit tests
         run: zig build test --summary all
 
   lint:
@@ -41,14 +44,15 @@ jobs:
   interop-image:
     name: Interop Docker Image
     runs-on: ubuntu-latest
-    # Only build the Docker image on pushes to master and on PRs to master.
+    # Build the Docker image on every push to master and on every PR
+    # targeting master so images are always ready for interop testing.
     if: github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
 
-      # Build the Zig binaries on the runner (avoids downloading Zig inside
-      # the Docker build context, which fails when ziglang.org blocks or when
-      # the version is still a dev build).
+      # Build the Zig binaries on the Actions runner. This avoids
+      # downloading Zig inside the Docker build context (which fails when
+      # ziglang.org is unreachable or the version is a pre-release).
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
@@ -60,8 +64,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Use Dockerfile.prebuilt which simply COPYs zig-out/bin/* — no Zig
-      # toolchain download needed inside Docker at all.
+      # Dockerfile.prebuilt simply COPYs zig-out/bin/* — no Zig toolchain
+      # download happens inside Docker.
       - name: Build interop image (no push)
         uses: docker/build-push-action@v5
         with:
@@ -71,3 +75,54 @@ jobs:
           tags: zquic-interop:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ── Interop runner ──────────────────────────────────────────────────────────
+  # Runs the actual quic-interop-runner test suite against the built image.
+  # Triggered only on pushes to master (not on PRs) because:
+  #   • The runner needs Docker images from two implementations to compare.
+  #   • It takes ~10–30 minutes per test case.
+  #   • PRs get the image build above as a fast sanity check.
+  #
+  # To enable: set the INTEROP_RUNNER_ENABLED repository variable to "true"
+  # and ensure the runner host has docker-compose and quic-interop-runner
+  # checked out at $QUIC_INTEROP_RUNNER_PATH.
+  #
+  # Uncomment the block below once the UDP I/O loop is wired up and the
+  # implementation can complete a real handshake.
+  #
+  # interop-run:
+  #   name: Interop Runner
+  #   runs-on: [self-hosted, interop]
+  #   needs: [test, interop-image]
+  #   if: >
+  #     github.ref == 'refs/heads/master' &&
+  #     vars.INTEROP_RUNNER_ENABLED == 'true'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - name: Setup Zig
+  #       uses: mlugg/setup-zig@v2
+  #       with:
+  #         version: "0.15.0"
+  #
+  #     - name: Build release binaries
+  #       run: zig build -Doptimize=ReleaseFast
+  #
+  #     - name: Build and tag interop image
+  #       run: |
+  #         docker build -t zquic -f interop/Dockerfile.prebuilt .
+  #
+  #     - name: Run quic-interop-runner
+  #       working-directory: ${{ env.QUIC_INTEROP_RUNNER_PATH }}
+  #       run: |
+  #         python3 run.py \
+  #           --client zquic \
+  #           --server zquic \
+  #           --test handshake,transfer,retry,resumption,zerortt,http3,keyupdate,connectionmigration,multiconnect \
+  #           --output results/
+  #
+  #     - name: Upload interop results
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: interop-results
+  #         path: ${{ env.QUIC_INTEROP_RUNNER_PATH }}/results/

--- a/README.md
+++ b/README.md
@@ -1,62 +1,216 @@
 # zquic
 
-A pure Zig implementation of the QUIC transport protocol.
+A pure Zig implementation of the QUIC transport protocol (RFC 9000 / 9001 / 9002).
+
+[![CI](https://github.com/ch4r10t33r/zquic/actions/workflows/ci.yml/badge.svg)](https://github.com/ch4r10t33r/zquic/actions/workflows/ci.yml)
 
 ## Protocol Coverage
 
-| RFC | Title |
-|-----|-------|
-| [RFC 9000](https://www.rfc-editor.org/rfc/rfc9000) | QUIC: A UDP-Based Multiplexed and Secure Transport |
-| [RFC 9001](https://www.rfc-editor.org/rfc/rfc9001) | Using TLS to Secure QUIC |
-| [RFC 9002](https://www.rfc-editor.org/rfc/rfc9002) | QUIC Loss Detection and Congestion Control |
-| [RFC 9114](https://www.rfc-editor.org/rfc/rfc9114) | HTTP/3 |
-| [RFC 9204](https://www.rfc-editor.org/rfc/rfc9204) | QPACK: Header Compression for HTTP/3 |
+| RFC | Title | Status |
+|-----|-------|--------|
+| [RFC 9000](https://www.rfc-editor.org/rfc/rfc9000) | QUIC: A UDP-Based Multiplexed and Secure Transport | core modules complete |
+| [RFC 9001](https://www.rfc-editor.org/rfc/rfc9001) | Using TLS to Secure QUIC | keys, AEAD, header protection, adapter |
+| [RFC 9002](https://www.rfc-editor.org/rfc/rfc9002) | QUIC Loss Detection and Congestion Control | RTT, PTO, New Reno |
+| [RFC 9114](https://www.rfc-editor.org/rfc/rfc9114) | HTTP/3 | framing complete |
+| [RFC 9204](https://www.rfc-editor.org/rfc/rfc9204) | QPACK: Header Compression for HTTP/3 | literal encoding (no dynamic table yet) |
 
 ## Requirements
 
-- Zig 0.15.x
+- Zig **0.15.x**
 
 ## Building
 
 ```sh
-zig build          # build library + binaries
-zig build test     # run unit tests
+zig build               # build library + server/client binaries
+zig build test          # run all 97 unit tests
+zig build examples      # build the example programs
 ```
 
-## Design
+## Examples
+
+Three self-contained examples live in `examples/`. Build and run them with:
+
+```sh
+zig build examples
+./zig-out/bin/echo_server        # crypto primitives walkthrough
+./zig-out/bin/parse_packet       # parse a QUIC Initial packet header
+./zig-out/bin/session_resumption # session tickets and 0-RTT key derivation
+```
+
+### Derive Initial secrets (RFC 9001 §5.2)
+
+```zig
+const zquic = @import("zquic");
+const crypto_keys = zquic.crypto.keys;
+const types = zquic.types;
+
+const dcid = try types.ConnectionId.fromSlice(&[_]u8{
+    0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08,
+});
+const secrets = crypto_keys.InitialSecrets.derive(dcid.slice());
+// secrets.client.key  — AES-128-GCM write key
+// secrets.client.iv   — AEAD base IV
+// secrets.client.hp   — header protection key
+```
+
+### Encode / decode a variable-length integer (RFC 9000 §16)
+
+```zig
+const varint = zquic.varint;
+
+var buf: [8]u8 = undefined;
+const encoded = try varint.encode(&buf, 15293); // → 2 bytes: 0x7b 0xbd
+const decoded = try varint.decode(encoded);
+// decoded.value == 15293
+```
+
+### Parse a Long Header packet
+
+```zig
+const header_mod = zquic.packet.header;
+
+const result = try header_mod.parseLong(raw_bytes);
+// result.header.packet_type  — .initial / .handshake / .zero_rtt / .retry
+// result.header.dcid         — ConnectionId
+// result.header.version      — u32
+// result.consumed            — bytes consumed
+```
+
+### AES-128-GCM encrypt / decrypt
+
+```zig
+const aead_mod = zquic.crypto.aead;
+
+var ciphertext: [plaintext.len + 16]u8 = undefined;
+try aead_mod.encryptAes128Gcm(&ciphertext, plaintext, aad, key, nonce);
+
+var recovered: [plaintext.len]u8 = undefined;
+try aead_mod.decryptAes128Gcm(&recovered, &ciphertext, aad, key, nonce);
+```
+
+### Session tickets and 0-RTT
+
+```zig
+const session = zquic.crypto.session;
+
+// Store a ticket received from the server.
+var store = session.TicketStore{};
+store.store(ticket);
+
+// On the next connection, retrieve and derive 0-RTT keys.
+if (store.get(now_ms)) |t| {
+    const keys = session.deriveEarlyKeys(t);
+    // keys.key / keys.iv / keys.hp  — ready for 0-RTT AEAD
+}
+```
+
+### HTTP/3 framing
+
+```zig
+const h3 = zquic.http3.frame;
+
+// Write a HEADERS frame.
+var buf: [256]u8 = undefined;
+const written = try h3.writeFrame(&buf, @intFromEnum(h3.FrameType.headers), encoded_header_block);
+
+// Parse any frame.
+const result = try h3.parseFrame(buf[0..written]);
+// result.frame.headers.data / result.frame.data / result.frame.settings …
+```
+
+## Module Map
 
 ```
 src/
-  varint.zig          Variable-length integer codec (RFC 9000 §16)
-  types.zig           Core types: ConnectionId, StreamId, TransportError, …
-  packet/             Packet header parsing and serialization
-  crypto/             Key derivation, AEAD, header protection, TLS adapter
-  frames/             All QUIC frame types
-  transport/          Connection state machine, endpoint, streams, flow control
-  loss/               Loss detection and congestion control (RFC 9002)
-  http09/             HTTP/0.9 for interop tests
-  http3/              HTTP/3 framing and QPACK
-  cmd/                server and client binaries for interop runner
-vendor/tls/           tls.zig vendored @ 34248f38c189 (Zig 0.15 compatible)
-interop/              Docker image and run_endpoint.sh for quic-interop-runner
+  varint.zig              Variable-length integer codec (RFC 9000 §16)
+  types.zig               ConnectionId, StreamId, TransportError, …
+  packet/
+    header.zig            Long/Short header parse + serialize
+    number.zig            Packet number encode/decode (RFC 9000 §A.3)
+    packet.zig            Initial, Retry, Version Negotiation builders
+    retry.zig             Retry integrity tag (RFC 9001 §5.8)
+    version_negotiation.zig  Version Negotiation parse/build
+  crypto/
+    keys.zig              HKDF-Expand-Label, Initial secret derivation
+    aead.zig              AES-128-GCM + ChaCha20-Poly1305, header protection
+    initial.zig           Initial packet protect/unprotect helpers
+    quic_tls.zig          QUIC-TLS adapter (nonblock ↔ CRYPTO frames)
+    session.zig           Session tickets, PSK store, 0-RTT key derivation
+    key_update.zig        Key update (RFC 9001 §6), KeyPhaseState
+  frames/
+    frame.zig             Frame union + parseOne dispatcher
+    ack.zig               ACK frame with ECN
+    crypto_frame.zig      CRYPTO frame
+    stream.zig            STREAM frame
+    transport.zig         RESET_STREAM, MAX_DATA, PATH_CHALLENGE, …
+  transport/
+    connection.zig        Connection state machine + ACK manager
+    endpoint.zig          UDP socket dispatch
+    stream_manager.zig    Stream multiplexing + in-order receive buffer
+    flow_control.zig      Connection + stream flow control
+    migration.zig         Path validation, connection migration (RFC 9000 §9)
+  loss/
+    recovery.zig          RTT estimation, PTO, loss detection (RFC 9002)
+    congestion.zig        New Reno congestion control
+  http09/
+    server.zig            HTTP/0.9 request parser + path resolver
+    client.zig            HTTP/0.9 request builder + download path helper
+  http3/
+    frame.zig             HTTP/3 frame codec (RFC 9114 §7)
+    qpack.zig             QPACK static table + literal header encode/decode
+  cmd/
+    server.zig            QUIC server binary (interop runner entry point)
+    client.zig            QUIC client binary (interop runner entry point)
+vendor/tls/               ianic/tls.zig @ 34248f38c189 (Zig 0.15 compatible)
+interop/
+  Dockerfile              Self-contained local build (downloads Zig at build time)
+  Dockerfile.prebuilt     CI-optimised image from pre-built binaries
+  run_endpoint.sh         quic-interop-runner entry point
+examples/
+  echo_server.zig         Crypto primitives walkthrough
+  parse_packet.zig        Parse a QUIC Initial packet
+  session_resumption.zig  Session tickets and 0-RTT
 ```
 
 ## TLS Integration
 
-QUIC uses TLS 1.3 in a non-standard way: the TLS record layer is replaced by
-QUIC's own packet protection (RFC 9001). The library vendors
-[tls.zig](https://github.com/ianic/tls.zig) at a Zig 0.15-compatible commit
-and uses its `nonblock` API. A thin adapter strips/adds TLS record headers
-so that raw handshake bytes flow through QUIC CRYPTO frames.
+QUIC uses TLS 1.3 without the TLS record layer (RFC 9001). A thin adapter
+in `src/crypto/quic_tls.zig` strips/adds the 5-byte TLS record header so
+raw handshake bytes flow through QUIC CRYPTO frames. The vendored
+[ianic/tls.zig](https://github.com/ianic/tls.zig) `nonblock` API is used.
+
+## Pending / In Progress
+
+| Area | What's missing |
+|------|---------------|
+| **UDP I/O loop** | `src/cmd/server.zig` and `client.zig` parse flags correctly but the actual send/recv loop (wiring `Endpoint` to a real UDP socket) is not yet written |
+| **Full TLS handshake** | `quic_tls.Endpoint` drives the `nonblock` API but the integration path from `Connection` → `Endpoint` → OS socket is not wired end-to-end |
+| **SSLKEYLOGFILE** | TLS session key export for Wireshark is not yet implemented |
+| **qlog** | Structured QUIC event logging to `$QLOGDIR` is not yet written |
+| **ALPN negotiation** | `h3` / `hq-interop` ALPN selection is planned but not wired |
+| **QUIC v2** | RFC 9369 (version 0x6b3343cf) — interop runner test case `v2` exits 127 |
+| **ChaCha20 interop** | `chacha20` test case: cipher suite negotiation not yet wired |
+| **QPACK dynamic table** | `decodeHeaders` rejects indexed field lines; dynamic table capacity is 0 |
+| **Connection migration I/O** | `MigrationManager` state machine is complete; OS-level socket rebind is not |
 
 ## QUIC Interop Runner
 
-This implementation targets the full [quic-interop-runner](https://github.com/quic-interop/quic-interop-runner)
-test suite:
+This implementation targets the [quic-interop-runner](https://github.com/quic-interop/quic-interop-runner)
+full test suite. The Docker image is built on every merge to `master`.
 
-`handshake`, `transfer`, `chacha20`, `keyupdate`, `retry`, `resumption`,
-`zerortt`, `http3`, `multiconnect`, `v2`, `rebind-port`, `rebind-addr`,
-`connectionmigration`
+| Test case | Status |
+|-----------|--------|
+| `handshake` | 🔧 framework ready, UDP I/O pending |
+| `transfer` | 🔧 HTTP/0.9 helpers ready, I/O pending |
+| `retry` | 🔧 Retry integrity tag complete, server trigger pending |
+| `resumption` | 🔧 ticket store + PSK ready, handshake wire-up pending |
+| `zerortt` | 🔧 0-RTT keys derivable, early data sending pending |
+| `http3` | 🔧 framing + QPACK ready, I/O pending |
+| `keyupdate` | 🔧 `KeyPhaseState` complete, trigger pending |
+| `connectionmigration` | 🔧 `MigrationManager` complete, socket rebind pending |
+| `multiconnect` | 🔧 connection manager ready, I/O pending |
+| `chacha20` | ⏳ cipher suite negotiation not wired |
+| `v2` | ❌ not supported (exits 127) |
 
 ## License
 

--- a/build.zig
+++ b/build.zig
@@ -61,4 +61,28 @@ pub fn build(b: *std.Build) void {
     const run_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_tests.step);
+
+    // Examples
+    const examples_step = b.step("examples", "Build all examples");
+    const example_files = [_][]const u8{
+        "examples/echo_server.zig",
+        "examples/parse_packet.zig",
+        "examples/session_resumption.zig",
+    };
+    for (example_files) |src| {
+        // Derive binary name from filename without extension.
+        const base = std.fs.path.stem(src);
+        const ex_mod = b.createModule(.{
+            .root_source_file = b.path(src),
+            .target = target,
+            .optimize = optimize,
+        });
+        ex_mod.addImport("zquic", zquic_mod);
+        const ex = b.addExecutable(.{
+            .name = base,
+            .root_module = ex_mod,
+        });
+        const ex_install = b.addInstallArtifact(ex, .{});
+        examples_step.dependOn(&ex_install.step);
+    }
 }

--- a/examples/echo_server.zig
+++ b/examples/echo_server.zig
@@ -1,0 +1,82 @@
+//! Example: QUIC cryptographic primitives
+//!
+//! Demonstrates using zquic's library modules to:
+//!   1. Derive Initial packet keys from a destination connection ID.
+//!   2. Encode and decode a variable-length integer.
+//!   3. Encrypt and decrypt a payload with AES-128-GCM.
+//!
+//! Build:
+//!   zig build examples
+//!
+//! Run:
+//!   ./zig-out/bin/echo_server
+
+const std = @import("std");
+const zquic = @import("zquic");
+
+const varint = zquic.varint;
+const types = zquic.types;
+const crypto_keys = zquic.crypto.keys;
+const aead_mod = zquic.crypto.aead;
+
+fn printHex(label: []const u8, bytes: []const u8) void {
+    std.debug.print("{s}: ", .{label});
+    for (bytes) |b| std.debug.print("{x:0>2}", .{b});
+    std.debug.print("\n", .{});
+}
+
+pub fn main() !void {
+    std.debug.print("zquic crypto-primitives example\n", .{});
+    std.debug.print("────────────────────────────────\n", .{});
+
+    // ── 1. Connection ID and Initial key derivation ─────────────────────────
+    // In a real server the DCID comes from the client's first Initial packet.
+    const dcid_bytes = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const dcid = try types.ConnectionId.fromSlice(&dcid_bytes);
+    printHex("DCID      ", dcid.slice());
+
+    // Derive Initial packet secrets (RFC 9001 §5.2).
+    const secrets = crypto_keys.InitialSecrets.derive(dcid.slice());
+    printHex("Client key", &secrets.client.key);
+    printHex("Client IV ", &secrets.client.iv);
+    printHex("Server key", &secrets.server.key);
+
+    // ── 2. Variable-length integer codec ────────────────────────────────────
+    var buf: [8]u8 = undefined;
+    const encoded = try varint.encode(&buf, 15293);
+    std.debug.print("varint(15293) → {} bytes: ", .{encoded.len});
+    for (encoded) |b| std.debug.print("{x:0>2}", .{b});
+    std.debug.print("\n", .{});
+
+    const decoded = try varint.decode(encoded);
+    std.debug.assert(decoded.value == 15293);
+    std.debug.print("decoded back  → {}\n", .{decoded.value});
+
+    // ── 3. AES-128-GCM encrypt / decrypt round-trip ─────────────────────────
+    const plaintext = "hello quic";
+    const nonce = [_]u8{0x00} ** 12;
+    const aad = "additional data";
+
+    var ciphertext: [26]u8 = undefined; // 10 plaintext + 16 tag
+    try aead_mod.encryptAes128Gcm(
+        &ciphertext,
+        plaintext,
+        aad,
+        secrets.client.key,
+        nonce,
+    );
+    printHex("Ciphertext", &ciphertext);
+
+    var recovered: [10]u8 = undefined;
+    try aead_mod.decryptAes128Gcm(
+        &recovered,
+        &ciphertext,
+        aad,
+        secrets.client.key,
+        nonce,
+    );
+    std.debug.print("Decrypted  → {s}\n", .{recovered});
+    std.debug.assert(std.mem.eql(u8, &recovered, plaintext));
+
+    std.debug.print("\nAll primitives working correctly.\n", .{});
+}

--- a/examples/parse_packet.zig
+++ b/examples/parse_packet.zig
@@ -1,0 +1,77 @@
+//! Example: parse a raw QUIC Initial packet header
+//!
+//! Demonstrates using zquic to:
+//!   1. Detect packet type from the first byte.
+//!   2. Parse a Long Header (Initial packet) using parseLong.
+//!   3. Derive Initial secrets from the parsed DCID.
+//!
+//! The example uses the RFC 9001 Appendix A sample DCID so it produces
+//! deterministic output you can verify against the spec.
+//!
+//! Build:
+//!   zig build examples
+//!
+//! Run:
+//!   ./zig-out/bin/parse_packet
+
+const std = @import("std");
+const zquic = @import("zquic");
+
+const header_mod = zquic.packet.header;
+const crypto_keys = zquic.crypto.keys;
+
+fn printHex(label: []const u8, bytes: []const u8) void {
+    std.debug.print("{s}: ", .{label});
+    for (bytes) |b| std.debug.print("{x:0>2}", .{b});
+    std.debug.print("\n", .{});
+}
+
+pub fn main() !void {
+    std.debug.print("zquic parse-packet example\n", .{});
+    std.debug.print("──────────────────────────\n", .{});
+
+    // Manually constructed Long Header Initial packet (partial).
+    // Header format: 1 byte flags | 4 bytes version | 1 byte DCID len |
+    //                8 bytes DCID | 1 byte SCID len | ...
+    const raw: []const u8 = &[_]u8{
+        // Long header byte: Initial packet type (0xc0) | pn_len=2 (0x03)
+        0xc3,
+        // Version: QUIC v1
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        // DCID length (8) + DCID (RFC 9001 Appendix A sample)
+        0x08,
+        0x83,
+        0x94,
+        0xc8,
+        0xf0,
+        0x3e,
+        0x51,
+        0x57,
+        0x08,
+        // SCID length (0)
+        0x00,
+        // Token length (0) — note: parseLong stops at SCID end
+        0x00,
+    };
+
+    // parseLong returns { header: LongHeader, consumed: usize }
+    const result = try header_mod.parseLong(raw);
+    const hdr = result.header;
+    std.debug.print("Packet type  : {}\n", .{hdr.packet_type});
+    std.debug.print("Version      : 0x{x:0>8}\n", .{hdr.version});
+    std.debug.print("DCID length  : {}\n", .{hdr.dcid.len});
+    printHex("DCID         ", hdr.dcid.slice());
+    std.debug.print("SCID length  : {}\n", .{hdr.scid.len});
+    std.debug.print("Bytes consumed: {}\n", .{result.consumed});
+
+    // Derive Initial secrets from DCID (RFC 9001 §5.2).
+    const secrets = crypto_keys.InitialSecrets.derive(hdr.dcid.slice());
+    printHex("Client key   ", &secrets.client.key);
+    printHex("Client IV    ", &secrets.client.iv);
+    printHex("Client HP    ", &secrets.client.hp);
+
+    std.debug.print("\nPacket parsed successfully.\n", .{});
+}

--- a/examples/session_resumption.zig
+++ b/examples/session_resumption.zig
@@ -1,0 +1,77 @@
+//! Example: session ticket store and 0-RTT key derivation
+//!
+//! Shows how to:
+//!   1. Create and store a session ticket (as received from a server).
+//!   2. Retrieve a valid ticket from the store.
+//!   3. Derive 0-RTT AEAD keys from the ticket's resumption secret.
+//!   4. Serialise/deserialise a ticket for persistent storage.
+//!
+//! Build:
+//!   zig build examples
+//!
+//! Run:
+//!   ./zig-out/bin/session_resumption
+
+const std = @import("std");
+const zquic = @import("zquic");
+
+const session = zquic.crypto.session;
+
+fn printHex(label: []const u8, bytes: []const u8) void {
+    std.debug.print("{s}: ", .{label});
+    for (bytes) |b| std.debug.print("{x:0>2}", .{b});
+    std.debug.print("\n", .{});
+}
+
+pub fn main() !void {
+    std.debug.print("zquic session-resumption example\n", .{});
+    std.debug.print("─────────────────────────────────\n", .{});
+
+    // Simulate a session ticket received from the server after the first
+    // handshake.  In a real implementation this is parsed from a TLS
+    // NewSessionTicket message inside a QUIC CRYPTO frame.
+    const ticket = session.SessionTicket{
+        .lifetime_s = 3600, // 1-hour lifetime
+        .nonce = [_]u8{0x42} ** 32,
+        .nonce_len = 8,
+        .ticket = [_]u8{0xab} ** session.max_ticket_len,
+        .ticket_len = 64,
+        // Resumption secret derived during the first handshake.
+        .resumption_secret = [_]u8{0x7f} ** 48,
+        .resumption_secret_len = 32,
+        .max_early_data_size = 16384, // server allows 0-RTT
+        .received_at_ms = 1_700_000_000_000,
+    };
+
+    std.debug.print("Ticket lifetime : {}s\n", .{ticket.lifetime_s});
+    std.debug.print("0-RTT allowed   : {}\n", .{ticket.earlyDataAllowed()});
+    std.debug.print("Max early data  : {} bytes\n", .{ticket.max_early_data_size});
+
+    // ── Store the ticket ────────────────────────────────────────────────────
+    var store = session.TicketStore{};
+    store.store(ticket);
+
+    // ── Retrieve on next connection ─────────────────────────────────────────
+    const now_ms: u64 = 1_700_000_001_000; // 1 second later — still valid
+    const retrieved = store.get(now_ms) orelse {
+        std.debug.print("No valid ticket found\n", .{});
+        return;
+    };
+    std.debug.print("Retrieved ticket (valid: {})\n", .{retrieved.isValid(now_ms)});
+
+    // ── Derive 0-RTT keys ───────────────────────────────────────────────────
+    const early_keys = session.deriveEarlyKeys(retrieved);
+    printHex("0-RTT key ", &early_keys.key);
+    printHex("0-RTT iv  ", &early_keys.iv);
+    printHex("0-RTT hp  ", &early_keys.hp);
+
+    // ── Serialise for persistent storage ───────────────────────────────────
+    var wire_buf: [2048]u8 = undefined;
+    const wire_len = try ticket.serialise(&wire_buf);
+    std.debug.print("Serialised ticket: {} bytes\n", .{wire_len});
+
+    const restored = try session.SessionTicket.deserialise(wire_buf[0..wire_len]);
+    std.debug.assert(restored.lifetime_s == ticket.lifetime_s);
+    std.debug.print("Restored ticket lifetime: {}s\n", .{restored.lifetime_s});
+    std.debug.print("\nSession resumption flow complete.\n", .{});
+}


### PR DESCRIPTION
## Summary

### `examples/` — three runnable programs

| Binary | Shows |
|--------|-------|
| `echo_server` | Initial key derivation, varint codec, AES-128-GCM round-trip |
| `parse_packet` | `header.parseLong`, DCID extraction, Initial secret derivation |
| `session_resumption` | `TicketStore`, 0-RTT key derivation, ticket serialise/deserialise |

Build with `zig build examples`, run from `zig-out/bin/`.

### `README.md` — complete rewrite

- Protocol coverage table with per-RFC status
- Runnable code snippets for every major API area
- Full module map
- **Pending features table** (UDP I/O loop, full TLS handshake wire-up, SSLKEYLOGFILE, qlog, ALPN, QUIC v2, ChaCha20, QPACK dynamic table)
- **Interop runner test case status** (🔧 framework ready / ⏳ not started / ❌ not supported)

### CI changes

- `test` job now also runs `zig build examples` so example compilation is always verified
- Added a commented-out `interop-run` job that shows exactly how to wire `quic-interop-runner` on a self-hosted runner once the UDP I/O loop is complete (controlled by `INTEROP_RUNNER_ENABLED` repo variable)

## Test plan

- [x] `zig build examples` → three binaries in `zig-out/bin/`
- [x] All three examples run and produce correct output
- [x] `zig build test --summary all` → 97/97 tests pass
- [x] `zig fmt --check .` → clean