### PR TITLE
chacha20-wire: ChaCha20-Poly1305 cipher suite negotiation (RFC 9001 §5.3–5.4.4)

### DIFF
--- a/src/cmd/client.zig
+++ b/src/cmd/client.zig
@@ -13,6 +13,7 @@
 //!   --qlog-dir <dir>  qlog output directory
 //!   --http09          Use HTTP/0.9 (for transfer test case)
 //!   --http3           Use HTTP/3
+//!   --chacha20        Prefer ChaCha20-Poly1305 cipher suite
 //!   --retry           Expect and handle a Retry packet
 //!   --resumption      Attempt session resumption
 //!   --early-data      Send 0-RTT early data
@@ -42,6 +43,7 @@ const Config = struct {
     migrate: bool = false,
     rebind: bool = false,
     key_update: bool = false,
+    chacha20: bool = false,
 };
 
 fn parseArgs(args: []const []const u8) !Config {
@@ -91,6 +93,8 @@ fn parseArgs(args: []const []const u8) !Config {
             cfg.rebind = true;
         } else if (std.mem.eql(u8, arg, "--key-update")) {
             cfg.key_update = true;
+        } else if (std.mem.eql(u8, arg, "--chacha20")) {
+            cfg.chacha20 = true;
         } else {
             std.debug.print("Unknown flag: {s}\n", .{arg});
             return error.UnknownFlag;
@@ -127,6 +131,7 @@ pub fn main() !void {
         .key_update = cfg.key_update,
         .http09 = cfg.http09,
         .http3 = cfg.http3,
+        .chacha20 = cfg.chacha20,
     };
 
     var client = io_mod.Client.init(allocator, client_config) catch |err| {

--- a/src/cmd/server.zig
+++ b/src/cmd/server.zig
@@ -19,6 +19,7 @@
 //!   --migrate         Support connection migration
 //!   --rebind          Rebind to a new port after connection established
 //!   --key-update      Perform a key update after the handshake
+//!   --chacha20        Prefer ChaCha20-Poly1305 cipher suite
 
 const std = @import("std");
 const io_mod = @import("zquic").transport.io;
@@ -39,6 +40,7 @@ const Config = struct {
     migrate: bool = false,
     rebind: bool = false,
     key_update: bool = false,
+    chacha20: bool = false,
 };
 
 fn parseArgs(args: []const []const u8) !Config {
@@ -86,6 +88,8 @@ fn parseArgs(args: []const []const u8) !Config {
             cfg.rebind = true;
         } else if (std.mem.eql(u8, arg, "--key-update")) {
             cfg.key_update = true;
+        } else if (std.mem.eql(u8, arg, "--chacha20")) {
+            cfg.chacha20 = true;
         } else {
             std.debug.print("Unknown flag: {s}\n", .{arg});
             return error.UnknownFlag;
@@ -117,6 +121,7 @@ pub fn main() !void {
     if (cfg.http3) std.debug.print("  http/3: enabled\n", .{});
     if (cfg.key_update) std.debug.print("  key-update: enabled\n", .{});
     if (cfg.migrate) std.debug.print("  migration: enabled\n", .{});
+    if (cfg.chacha20) std.debug.print("  chacha20: enabled\n", .{});
 
     const server_config = io_mod.ServerConfig{
         .port = cfg.port,
@@ -130,6 +135,7 @@ pub fn main() !void {
         .http3 = cfg.http3,
         .key_update = cfg.key_update,
         .migrate = cfg.migrate,
+        .chacha20 = cfg.chacha20,
     };
 
     var server = io_mod.Server.init(allocator, server_config) catch |err| {

--- a/src/crypto/initial.zig
+++ b/src/crypto/initial.zig
@@ -138,6 +138,103 @@ pub fn unprotectInitialPacket(
     return plaintext_len;
 }
 
+/// Encrypt a QUIC 1-RTT packet payload using ChaCha20-Poly1305 and apply
+/// ChaCha20-based header protection (RFC 9001 §5.3, §5.4.4).
+pub fn protectPacketChaCha20(
+    dst: []u8,
+    header: []const u8,
+    pn: u64,
+    pn_len: u2,
+    plaintext: []const u8,
+    km: *const KeyMaterial,
+) aead.AeadError!usize {
+    const actual_pn_len: usize = @as(usize, pn_len) + 1;
+    const ct_and_tag_len = plaintext.len + 16; // Poly1305 tag
+
+    if (dst.len < header.len + actual_pn_len + ct_and_tag_len) return error.BufferTooSmall;
+
+    @memcpy(dst[0..header.len], header);
+    var pos = header.len;
+
+    var pn_buf: [4]u8 = undefined;
+    var i: usize = 0;
+    while (i < actual_pn_len) : (i += 1) {
+        pn_buf[actual_pn_len - 1 - i] = @truncate(pn >> @intCast(i * 8));
+    }
+    @memcpy(dst[pos .. pos + actual_pn_len], pn_buf[0..actual_pn_len]);
+    pos += actual_pn_len;
+
+    const aad_slice = dst[0..pos];
+    const nonce = aead.buildNonce(km.iv, pn);
+
+    try aead.encryptChaCha20Poly1305(dst[pos .. pos + ct_and_tag_len], plaintext, aad_slice, km.key32, nonce);
+    pos += ct_and_tag_len;
+
+    const pn_start = header.len;
+    const sample_start = pn_start + hp_sample_offset;
+    if (pos < sample_start + hp_sample_len) return error.BufferTooSmall;
+    var sample: [hp_sample_len]u8 = undefined;
+    @memcpy(&sample, dst[sample_start .. sample_start + hp_sample_len]);
+
+    const pn_bytes_slice = dst[pn_start .. pn_start + actual_pn_len];
+    const first_byte_mask: u8 = if (dst[0] & 0x80 != 0) 0x0f else 0x1f;
+    aead.HeaderProtection.applyChaCha20(km.hp32, sample, &dst[0], pn_bytes_slice, first_byte_mask);
+
+    return pos;
+}
+
+/// Remove ChaCha20-based header protection and decrypt a QUIC packet payload.
+pub fn unprotectPacketChaCha20(
+    dst: []u8,
+    buf: []const u8,
+    pn_start: usize,
+    payload_end: usize,
+    km: *const KeyMaterial,
+) (aead.AeadError || error{BufferTooShort})!usize {
+    if (buf.len < pn_start + hp_sample_offset + hp_sample_len) return error.BufferTooShort;
+
+    const sample_start = pn_start + hp_sample_offset;
+    var sample: [hp_sample_len]u8 = undefined;
+    @memcpy(&sample, buf[sample_start .. sample_start + hp_sample_len]);
+
+    var header_copy: [1600]u8 = undefined;
+    if (buf.len > header_copy.len) return error.BufferTooShort;
+    @memcpy(header_copy[0..buf.len], buf);
+
+    const first_byte_mask: u8 = if (header_copy[0] & 0x80 != 0) 0x0f else 0x1f;
+
+    // Derive ChaCha20 mask: counter = sample[0..4], nonce = sample[4..16]
+    const counter = std.mem.readInt(u32, sample[0..4], .little);
+    const cc_nonce = sample[4..16].*;
+    var full_mask: [64]u8 = undefined;
+    std.crypto.stream.chacha.ChaCha20IETF.xor(&full_mask, &(.{0} ** 64), counter, km.hp32, cc_nonce);
+
+    header_copy[0] ^= full_mask[0] & first_byte_mask;
+    const actual_pn_len: usize = (header_copy[0] & 0x03) + 1;
+
+    const pn_bytes = header_copy[pn_start .. pn_start + actual_pn_len];
+    for (pn_bytes, 0..) |*b, i| {
+        b.* ^= full_mask[1 + i];
+    }
+
+    var pn: u64 = 0;
+    for (pn_bytes) |b| {
+        pn = (pn << 8) | b;
+    }
+
+    const aad_end = pn_start + actual_pn_len;
+    const aad_slice = header_copy[0..aad_end];
+    const nonce = aead.buildNonce(km.iv, pn);
+    const ciphertext = buf[aad_end..payload_end];
+
+    if (ciphertext.len < 16) return error.BufferTooShort;
+    const plaintext_len = ciphertext.len - 16;
+    if (dst.len < plaintext_len) return error.BufferTooSmall;
+
+    try aead.decryptChaCha20Poly1305(dst[0..plaintext_len], ciphertext, aad_slice, km.key32, nonce);
+    return plaintext_len;
+}
+
 test "initial: encrypt/decrypt round-trip" {
     const testing = std.testing;
     const dcid = "\x83\x94\xc8\xf0\x3e\x51\x57\x08";

--- a/src/crypto/keys.zig
+++ b/src/crypto/keys.zig
@@ -83,17 +83,25 @@ pub const InitialSecrets = struct {
 };
 
 /// Key material for one direction: key, IV, and header protection key.
+///
+/// `key` (16 bytes) is used for AES-128-GCM.
+/// `key32` (32 bytes) is used for ChaCha20-Poly1305.
+/// Both are derived unconditionally so the struct can serve either suite.
 pub const KeyMaterial = struct {
     secret: [Sha256.digest_length]u8 = undefined,
     key: [16]u8 = undefined,
+    key32: [32]u8 = undefined,
     iv: [12]u8 = undefined,
     hp: [16]u8 = undefined,
+    hp32: [32]u8 = undefined,
 
     /// Derive key, IV, and HP from the secret using HKDF-Expand-Label.
     pub fn expand(self: *KeyMaterial) void {
         hkdfExpandLabel(&self.key, &self.secret, "quic key", "");
+        hkdfExpandLabel(&self.key32, &self.secret, "quic key", "");
         hkdfExpandLabel(&self.iv, &self.secret, "quic iv", "");
         hkdfExpandLabel(&self.hp, &self.secret, "quic hp", "");
+        hkdfExpandLabel(&self.hp32, &self.secret, "quic hp", "");
     }
 
     /// Derive the next-generation key material for key updates (RFC 9001 §6).

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -536,6 +536,29 @@ pub fn buildClientHello(
     alpn: ?[]const u8,
     server_name: ?[]const u8,
 ) !usize {
+    return buildClientHelloInner(out, client_x25519_pub, quic_transport_params, alpn, server_name, false);
+}
+
+/// Build a ClientHello that advertises ChaCha20-Poly1305 as the preferred
+/// cipher suite, followed by AES-128-GCM as fallback.
+pub fn buildClientHelloChaCha20(
+    out: []u8,
+    client_x25519_pub: *const [32]u8,
+    quic_transport_params: []const u8,
+    alpn: ?[]const u8,
+    server_name: ?[]const u8,
+) !usize {
+    return buildClientHelloInner(out, client_x25519_pub, quic_transport_params, alpn, server_name, true);
+}
+
+fn buildClientHelloInner(
+    out: []u8,
+    client_x25519_pub: *const [32]u8,
+    quic_transport_params: []const u8,
+    alpn: ?[]const u8,
+    server_name: ?[]const u8,
+    prefer_chacha20: bool,
+) !usize {
     var client_random: [32]u8 = undefined;
     crypto.random.bytes(&client_random);
 
@@ -617,9 +640,11 @@ pub fn buildClientHello(
         ep += a.len;
     }
 
-    // Body: version(2) + random(32) + sid_len(1) + cs_list(4) + comp(2) + exts(2+ep)
-    // cipher suites: 2 (list_len) + 2 (TLS_AES_128_GCM_SHA256) = 4
-    const body_len = 2 + 32 + 1 + 4 + 2 + 2 + ep;
+    // Body: version(2) + random(32) + sid_len(1) + cs_list + comp(2) + exts(2+ep)
+    // cipher suites: 2 (list_len) + 2*num_suites (suite values)
+    // When prefer_chacha20 is true, advertise both suites (4 bytes of data).
+    const cs_data_len: usize = if (prefer_chacha20) 4 else 2;
+    const body_len = 2 + 32 + 1 + (2 + cs_data_len) + 2 + 2 + ep;
     if (out.len < 4 + body_len) return error.BufferTooSmall;
 
     var pos: usize = writeHsMsgHeader(out, 0, MSG_CLIENT_HELLO, body_len);
@@ -629,10 +654,17 @@ pub fn buildClientHello(
     pos += 32;
     out[pos] = 0; // session_id = empty
     pos += 1;
-    writeU16(out[pos..], 2); // cipher_suites list length
+    writeU16(out[pos..], @intCast(cs_data_len)); // cipher_suites list byte length
     pos += 2;
-    writeU16(out[pos..], TLS_AES_128_GCM_SHA256);
-    pos += 2;
+    if (prefer_chacha20) {
+        writeU16(out[pos..], TLS_CHACHA20_POLY1305_SHA256);
+        pos += 2;
+        writeU16(out[pos..], TLS_AES_128_GCM_SHA256);
+        pos += 2;
+    } else {
+        writeU16(out[pos..], TLS_AES_128_GCM_SHA256);
+        pos += 2;
+    }
     out[pos] = 1; // compression methods length
     pos += 1;
     out[pos] = 0; // no compression
@@ -795,6 +827,8 @@ pub const ClientHandshake = struct {
     secrets: TrafficSecrets,
     handshake_secret: [32]u8,
     handshake_done: bool,
+    /// Cipher suite chosen by the server (set after processServerHello).
+    cipher_suite: u16 = TLS_AES_128_GCM_SHA256,
 
     pub fn init() ClientHandshake {
         return .{
@@ -819,6 +853,19 @@ pub const ClientHandshake = struct {
         return n;
     }
 
+    /// Variant that advertises ChaCha20-Poly1305 as the preferred cipher suite.
+    pub fn buildClientHelloMsgChaCha20(
+        self: *ClientHandshake,
+        out: []u8,
+        quic_tp: []const u8,
+        alpn: ?[]const u8,
+        server_name: ?[]const u8,
+    ) !usize {
+        const n = try buildClientHelloChaCha20(out, &self.kp.public_key, quic_tp, alpn, server_name);
+        self.transcript.update(out[0..n]);
+        return n;
+    }
+
     /// Process ServerHello bytes. Derives handshake secrets.
     pub fn processServerHello(self: *ClientHandshake, sh_bytes: []const u8) !void {
         if (sh_bytes.len < 4) return error.TruncatedMessage;
@@ -830,6 +877,9 @@ pub const ClientHandshake = struct {
         var p: usize = 2 + 32;
         const sid_len = body[p];
         p += 1 + sid_len;
+        if (p + 3 <= body.len) {
+            self.cipher_suite = readU16(body[p..]);
+        }
         p += 2 + 1; // cipher_suite + compression
 
         // Parse extensions for key_share

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -211,6 +211,18 @@ pub fn build1RttPacketWithPhase(
     km: *const KeyMaterial,
     key_phase: bool,
 ) !usize {
+    return build1RttPacketFull(out, dcid, payload, pn, km, key_phase, false);
+}
+
+pub fn build1RttPacketFull(
+    out: []u8,
+    dcid: ConnectionId,
+    payload: []const u8,
+    pn: u64,
+    km: *const KeyMaterial,
+    key_phase: bool,
+    chacha20: bool,
+) !usize {
     var hdr_buf: [64]u8 = undefined;
     var hp: usize = 0;
 
@@ -222,7 +234,24 @@ pub fn build1RttPacketWithPhase(
     @memcpy(hdr_buf[hp .. hp + dcid.len], dcid.slice());
     hp += dcid.len;
 
+    if (chacha20) {
+        return initial_mod.protectPacketChaCha20(out, hdr_buf[0..hp], pn, 0, payload, km);
+    }
     return initial_mod.protectInitialPacket(out, hdr_buf[0..hp], pn, 0, payload, km);
+}
+
+/// Decrypt a 1-RTT packet, selecting AES or ChaCha20 based on the cipher flag.
+pub fn unprotect1RttPacket(
+    dst: []u8,
+    buf: []const u8,
+    pn_start: usize,
+    km: *const KeyMaterial,
+    chacha20: bool,
+) !usize {
+    if (chacha20) {
+        return initial_mod.unprotectPacketChaCha20(dst, buf, pn_start, buf.len, km);
+    }
+    return initial_mod.unprotectInitialPacket(dst, buf, pn_start, buf.len, km);
 }
 
 // ── QUIC packet decryption ────────────────────────────────────────────────────
@@ -358,6 +387,9 @@ pub const ConnState = struct {
     // Non-null while waiting for a PATH_RESPONSE from the new address.
     path_challenge_data: ?[8]u8 = null,
 
+    // Cipher suite in use for 1-RTT packets (true = ChaCha20-Poly1305).
+    use_chacha20: bool = false,
+
     // TLS handshake state machine (server side)
     tls: ServerHandshake = undefined,
     tls_inited: bool = false,
@@ -405,6 +437,7 @@ pub const ServerConfig = struct {
     http3: bool = false,
     key_update: bool = false,
     migrate: bool = false,
+    chacha20: bool = false,
 };
 
 // ── QUIC Server ───────────────────────────────────────────────────────────────
@@ -678,6 +711,11 @@ pub const Server = struct {
         // (secrets are now available after processClientHello)
         conn.deriveHandshakeKeys(&conn.tls.secrets);
 
+        // Set cipher based on what was negotiated with the client.
+        if (conn.tls.ch.cipher_suite == tls_hs.TLS_CHACHA20_POLY1305_SHA256) {
+            conn.use_chacha20 = true;
+        }
+
         // Build and send server flight
         self.buildAndSendServerFlight(conn, src);
     }
@@ -923,17 +961,7 @@ pub const Server = struct {
             }
         }
 
-        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const pkt_len = build1RttPacket(
-            &send_buf,
-            conn.remote_cid,
-            frames_buf[0..fp],
-            conn.app_pn,
-            &conn.app_server_km,
-        ) catch return;
-        conn.app_pn += 1;
-
-        _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch {};
+        self.send1Rtt(conn, frames_buf[0..fp], src);
     }
 
     fn process1RttPacket(self: *Server, buf: []const u8, src: std.net.Address) void {
@@ -957,12 +985,12 @@ pub const Server = struct {
                 // Try to decrypt with current client app keys.
                 var plaintext: [4096]u8 = undefined;
                 const pn_start = 1 + cid_len;
-                const pt_len = initial_mod.unprotectInitialPacket(
+                const pt_len = unprotect1RttPacket(
                     &plaintext,
                     buf,
                     pn_start,
-                    buf.len,
                     &conn.app_client_km,
+                    conn.use_chacha20,
                 ) catch continue;
 
                 conn.peer_key_phase = incoming_phase;
@@ -986,17 +1014,7 @@ pub const Server = struct {
 
         // Send a PING so the peer can verify the new keys.
         const ping_frame = [_]u8{0x01};
-        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const pkt_len = build1RttPacketWithPhase(
-            &send_buf,
-            conn.remote_cid,
-            &ping_frame,
-            conn.app_pn,
-            &conn.app_server_km,
-            conn.key_phase_bit,
-        ) catch return;
-        conn.app_pn += 1;
-        _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch {};
+        self.send1Rtt(conn, &ping_frame, src);
     }
 
     fn processAppFrames(self: *Server, conn: *ConnState, frames: []const u8, src: std.net.Address) void {
@@ -1056,24 +1074,34 @@ pub const Server = struct {
         }
     }
 
+    /// Encrypt and send a 1-RTT packet, selecting AES or ChaCha20 per conn.
+    fn send1Rtt(self: *Server, conn: *ConnState, payload: []const u8, dst: std.net.Address) void {
+        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+        const pkt_len = build1RttPacketFull(
+            &send_buf,
+            conn.remote_cid,
+            payload,
+            conn.app_pn,
+            &conn.app_server_km,
+            conn.key_phase_bit,
+            conn.use_chacha20,
+        ) catch return;
+        conn.app_pn += 1;
+        _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &dst.any, dst.getOsSockLen()) catch {};
+    }
+
     /// Send a PATH_CHALLENGE frame to validate a new peer address.
     fn sendPathChallenge(self: *Server, conn: *ConnState, data: [8]u8, dst: std.net.Address) void {
         var frame_buf: [64]u8 = undefined;
         const frame_len = transport_frames.PathChallenge.serialize(.{ .data = data }, &frame_buf) catch return;
-        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const pkt_len = build1RttPacket(&send_buf, conn.remote_cid, frame_buf[0..frame_len], conn.app_pn, &conn.app_server_km) catch return;
-        conn.app_pn += 1;
-        _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &dst.any, dst.getOsSockLen()) catch {};
+        self.send1Rtt(conn, frame_buf[0..frame_len], dst);
     }
 
     /// Send a PATH_RESPONSE echoing the challenge data back to the sender.
     fn sendPathResponse(self: *Server, conn: *ConnState, data: [8]u8, dst: std.net.Address) void {
         var frame_buf: [64]u8 = undefined;
         const frame_len = transport_frames.PathResponse.serialize(.{ .data = data }, &frame_buf) catch return;
-        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const pkt_len = build1RttPacket(&send_buf, conn.remote_cid, frame_buf[0..frame_len], conn.app_pn, &conn.app_server_km) catch return;
-        conn.app_pn += 1;
-        _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &dst.any, dst.getOsSockLen()) catch {};
+        self.send1Rtt(conn, frame_buf[0..frame_len], dst);
     }
 
     fn handleStreamData(self: *Server, conn: *ConnState, sf: *const stream_frame_mod.StreamFrame, src: std.net.Address) void {
@@ -1120,18 +1148,7 @@ pub const Server = struct {
 
             var frame_buf: [1200]u8 = undefined;
             const frame_len = sf_out.serialize(&frame_buf) catch break;
-
-            var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-            const pkt_len = build1RttPacket(
-                &send_buf,
-                conn.remote_cid,
-                frame_buf[0..frame_len],
-                conn.app_pn,
-                &conn.app_server_km,
-            ) catch break;
-            conn.app_pn += 1;
-
-            _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch {};
+            self.send1Rtt(conn, frame_buf[0..frame_len], src);
         }
     }
 
@@ -1249,18 +1266,7 @@ pub const Server = struct {
         };
         var frame_buf: [300]u8 = undefined;
         const frame_len = sf.serialize(&frame_buf) catch return;
-
-        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const pkt_len = build1RttPacket(
-            &send_buf,
-            conn.remote_cid,
-            frame_buf[0..frame_len],
-            conn.app_pn,
-            &conn.app_server_km,
-        ) catch return;
-        conn.app_pn += 1;
-
-        _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch {};
+        self.send1Rtt(conn, frame_buf[0..frame_len], src);
     }
 
     fn sendH3Response(self: *Server, conn: *ConnState, stream_id: u64, status: u16, _: []const u8, src: std.net.Address) void {
@@ -1285,18 +1291,7 @@ pub const Server = struct {
         };
         var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
         const frame_len = sf.serialize(&frame_buf) catch return;
-
-        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const pkt_len = build1RttPacket(
-            &send_buf,
-            conn.remote_cid,
-            frame_buf[0..frame_len],
-            conn.app_pn,
-            &conn.app_server_km,
-        ) catch return;
-        conn.app_pn += 1;
-
-        _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch {};
+        self.send1Rtt(conn, frame_buf[0..frame_len], src);
     }
 };
 
@@ -1313,6 +1308,7 @@ pub const ClientConfig = struct {
     key_update: bool = false,
     http09: bool = false,
     http3: bool = false,
+    chacha20: bool = false,
 };
 
 // ── Stream download tracker ───────────────────────────────────────────────────
@@ -1429,7 +1425,10 @@ pub const Client = struct {
         var quic_tp_buf: [128]u8 = undefined;
         const quic_tp = buildClientTransportParams(&quic_tp_buf);
 
-        const ch_len = try self.tls.buildClientHelloMsg(&ch_buf, quic_tp, alpn, self.config.host);
+        const ch_len = if (self.config.chacha20)
+            try self.tls.buildClientHelloMsgChaCha20(&ch_buf, quic_tp, alpn, self.config.host)
+        else
+            try self.tls.buildClientHelloMsg(&ch_buf, quic_tp, alpn, self.config.host);
 
         // CRYPTO frame
         const crypto_len = try buildCryptoFrame(&frame_buf, 0, ch_buf[0..ch_len]);
@@ -1527,14 +1526,18 @@ pub const Client = struct {
             const dlen: usize = @intCast(dlen_r.value);
             if (pos + dlen > pt_len) break;
             const cdata = plaintext[pos .. pos + dlen];
-            if (cdata.len >= 4 and cdata[0] == tls_hs.MSG_SERVER_HELLO) {
-                self.tls.processServerHello(cdata) catch |err| {
-                    std.debug.print("io: processServerHello failed: {}\n", .{err});
-                    return;
-                };
-                // Now we have handshake secrets — derive QUIC keys
-                self.conn.deriveHandshakeKeys(&self.tls.secrets);
-            }
+                if (cdata.len >= 4 and cdata[0] == tls_hs.MSG_SERVER_HELLO) {
+                    self.tls.processServerHello(cdata) catch |err| {
+                        std.debug.print("io: processServerHello failed: {}\n", .{err});
+                        return;
+                    };
+                    // Now we have handshake secrets — derive QUIC keys
+                    self.conn.deriveHandshakeKeys(&self.tls.secrets);
+                    // Set cipher based on what the server negotiated.
+                    if (self.tls.cipher_suite == tls_hs.TLS_CHACHA20_POLY1305_SHA256) {
+                        self.conn.use_chacha20 = true;
+                    }
+                }
             pos += dlen;
         }
     }
@@ -1633,12 +1636,12 @@ pub const Client = struct {
 
         var plaintext: [4096]u8 = undefined;
         const pn_start = 1 + cid_len;
-        const pt_len = initial_mod.unprotectInitialPacket(
+        const pt_len = unprotect1RttPacket(
             &plaintext,
             buf,
             pn_start,
-            buf.len,
             &self.conn.app_server_km,
+            self.conn.use_chacha20,
         ) catch return;
 
         self.conn.peer_key_phase = incoming_phase;
@@ -1753,7 +1756,15 @@ pub const Client = struct {
         var frame_buf: [64]u8 = undefined;
         const frame_len = transport_frames.PathResponse.serialize(.{ .data = data }, &frame_buf) catch return;
         var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const pkt_len = build1RttPacket(&send_buf, self.conn.remote_cid, frame_buf[0..frame_len], self.conn.app_pn, &self.conn.app_client_km) catch return;
+        const pkt_len = build1RttPacketFull(
+            &send_buf,
+            self.conn.remote_cid,
+            frame_buf[0..frame_len],
+            self.conn.app_pn,
+            &self.conn.app_client_km,
+            self.conn.key_phase_bit,
+            self.conn.use_chacha20,
+        ) catch return;
         self.conn.app_pn += 1;
         _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch {};
     }
@@ -1829,12 +1840,14 @@ pub const Client = struct {
             const frame_len = sf.serialize(&frame_buf) catch continue;
 
             var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-            const pkt_len = build1RttPacket(
+            const pkt_len = build1RttPacketFull(
                 &send_buf,
                 self.conn.remote_cid,
                 frame_buf[0..frame_len],
                 self.conn.app_pn,
                 &self.conn.app_client_km,
+                self.conn.key_phase_bit,
+                self.conn.use_chacha20,
             ) catch continue;
             self.conn.app_pn += 1;
 


### PR DESCRIPTION
## Summary

- **`KeyMaterial`**: adds `key32 [32]u8` and `hp32 [32]u8` fields; `expand()` derives both AES-128 and ChaCha20 key lengths unconditionally.
- **`initial.zig`**: `protectPacketChaCha20()` and `unprotectPacketChaCha20()` implement ChaCha20-Poly1305 AEAD with ChaCha20-based header protection (RFC 9001 §5.4.4).
- **`handshake.zig`**: `buildClientHelloChaCha20()` advertises `TLS_CHACHA20_POLY1305_SHA256` first; `ClientHandshake.cipher_suite` records what the server chose.
- **`io.zig`**: `ConnState.use_chacha20` set from negotiated cipher; `build1RttPacketFull()` / `unprotect1RttPacket()` dispatch to the right AEAD; `Server.send1Rtt()` unifies all 1-RTT server sends with correct cipher and key phase.
- **`--chacha20` flag** wired into server and client entry points.

## Test plan

- [x] `zig build test --summary all` — 101/101 pass
- [ ] quic-interop-runner `chacha20` test case