### PR TITLE
feat: QPACK blocked streams (RFC 9204 §2.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A pure Zig implementation of the QUIC transport protocol (RFC 9000 / 9001 / 9002
 | [RFC 9001](https://www.rfc-editor.org/rfc/rfc9001) | Using TLS to Secure QUIC | complete (keys, AEAD, header protection, key update) |
 | [RFC 9002](https://www.rfc-editor.org/rfc/rfc9002) | QUIC Loss Detection and Congestion Control | RTT, PTO, New Reno |
 | [RFC 9114](https://www.rfc-editor.org/rfc/rfc9114) | HTTP/3 | framing, QPACK, server + client I/O |
-| [RFC 9204](https://www.rfc-editor.org/rfc/rfc9204) | QPACK: Header Compression for HTTP/3 | static table, dynamic table (insertions, encoder/decoder streams, Section Acks) |
+| [RFC 9204](https://www.rfc-editor.org/rfc/rfc9204) | QPACK: Header Compression for HTTP/3 | static table, dynamic table (insertions, encoder/decoder streams, Section Acks, blocked streams) |
 | [RFC 9369](https://www.rfc-editor.org/rfc/rfc9369) | QUIC Version 2 | initial secrets, packet type bits, Retry tag |
 
 ## Requirements
@@ -204,9 +204,7 @@ full test suite. The Docker image is built on every merge to `master`.
 
 ## Known Gaps
 
-| Area | What's missing |
-|------|----------------|
-| **QPACK blocked streams** | Streams blocked on dynamic table entries (SETTINGS_QPACK_BLOCKED_STREAMS > 0) are not buffered; `SETTINGS_QPACK_BLOCKED_STREAMS` is advertised as 0 |
+None at this time.
 
 ## License
 

--- a/src/http3/qpack.zig
+++ b/src/http3/qpack.zig
@@ -1419,3 +1419,56 @@ test "qpack: dynamic table encode/decode round-trip" {
     try testing.expectEqualSlices(u8, "x-custom", decoded.headers[0].name);
     try testing.expectEqualSlices(u8, "myvalue", decoded.headers[0].value);
 }
+
+// --- Blocked stream tests (RFC 9204 §2.1.2) ---
+
+test "qpack: decodeHeaders returns BlockedStream when decoder table is empty" {
+    const testing = std.testing;
+
+    // Encode a HEADERS block that references a dynamic table entry.
+    var enc_tbl = DynamicTable{};
+    enc_tbl.capacity = 4096;
+    try enc_tbl.insert(":status", "200");
+
+    var buf: [64]u8 = undefined;
+    const written = try encodeHeaders(&[_]Header{
+        .{ .name = ":status", .value = "200" },
+    }, &buf, .{ .table = &enc_tbl });
+
+    // A decoder table with no insertions cannot satisfy RIC=1 — must block.
+    var dec_tbl = DynamicTable{};
+    dec_tbl.capacity = 4096;
+    var out = DecodedHeaders{ .headers = undefined, .count = 0 };
+    const result = decodeHeaders(buf[0..written], &dec_tbl, &out);
+    try testing.expectError(error.BlockedStream, result);
+}
+
+test "qpack: decodeHeaders succeeds after decoder table catches up" {
+    const testing = std.testing;
+
+    // Encoder inserts ":custom: value", then encodes a HEADERS block using it.
+    var enc_tbl = DynamicTable{};
+    enc_tbl.capacity = 4096;
+    try enc_tbl.insert(":custom", "value");
+
+    var buf: [64]u8 = undefined;
+    const written = try encodeHeaders(&[_]Header{
+        .{ .name = ":custom", .value = "value" },
+    }, &buf, .{ .table = &enc_tbl });
+
+    // Simulated decoder table with no entries yet → stream is blocked.
+    var dec_tbl = DynamicTable{};
+    dec_tbl.capacity = 4096;
+    var out = DecodedHeaders{ .headers = undefined, .count = 0 };
+    try testing.expectError(error.BlockedStream, decodeHeaders(buf[0..written], &dec_tbl, &out));
+
+    // Simulate receiving encoder-stream instruction: decoder applies same insertion.
+    try dec_tbl.insert(":custom", "value");
+
+    // Now the decoder table has insertion_count=1 which satisfies RIC=1.
+    out = DecodedHeaders{ .headers = undefined, .count = 0 };
+    try decodeHeaders(buf[0..written], &dec_tbl, &out);
+    try testing.expectEqual(@as(usize, 1), out.count);
+    try testing.expectEqualSlices(u8, ":custom", out.headers[0].name);
+    try testing.expectEqualSlices(u8, "value", out.headers[0].value);
+}

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -659,6 +659,25 @@ const Http3OutSlot = struct {
     }
 };
 
+/// Maximum number of HTTP/3 request streams that can be blocked waiting for
+/// QPACK dynamic table insertions (RFC 9204 §2.1.2).  We advertise this value
+/// in SETTINGS_QPACK_BLOCKED_STREAMS.  Must be ≥ 1 to be non-trivial; 16 is
+/// a reasonable balance between memory and compression flexibility.
+pub const QPACK_BLOCKED_STREAMS_MAX: usize = 16;
+
+/// A buffered HTTP/3 request stream whose HEADERS block cannot yet be decoded
+/// because the decoder table has fewer insertions than the block's RIC.
+/// Retried each time new encoder stream instructions arrive.
+const QpackBlockedH3Stream = struct {
+    active: bool = false,
+    stream_id: u64 = 0,
+    /// Required Insert Count needed to decode this block.
+    required_insert_count: usize = 0,
+    /// Raw QPACK-encoded HEADERS block (copy of HeadersFrame.data[0..len]).
+    header_block: [h3_frame.max_header_block]u8 = undefined,
+    header_block_len: usize = 0,
+};
+
 const pending_1rtt_cap: usize = 8;
 
 /// Decrypted 1-RTT coalesced payload queued until the handshake is confirmed.
@@ -749,6 +768,12 @@ pub const ConnState = struct {
     // (server: stream 11; client: stream 10).  Tracks how many bytes we have
     // sent, including the leading stream-type byte (0x03).
     qpack_dec_stream_off: u64 = 0,
+
+    /// Buffered HEADERS blocks that arrived before the QPACK dynamic table had
+    /// enough insertions to decode them (RFC 9204 §2.1.2).  Retried each time
+    /// new encoder-stream instructions advance the decoder table.
+    qpack_blocked: [QPACK_BLOCKED_STREAMS_MAX]QpackBlockedH3Stream =
+        [_]QpackBlockedH3Stream{.{}} ** QPACK_BLOCKED_STREAMS_MAX,
 
     // QLOG writer for this connection.  Null when qlog_dir is not configured.
     qlog: qlog_writer.Writer = .{},
@@ -2402,7 +2427,7 @@ pub const Server = struct {
 
         // Route client-initiated unidirectional streams (control=2, QPACK enc=6, dec=10…).
         if (sf.stream_id % 4 == 2) {
-            self.handleH3ClientUniStream(conn, sf);
+            self.handleH3ClientUniStream(conn, sf, src);
             return;
         }
 
@@ -2428,7 +2453,15 @@ pub const Server = struct {
             switch (pr.frame) {
                 .headers => |hf| {
                     var decoded = h3_qpack.DecodedHeaders{ .headers = undefined, .count = 0 };
-                    h3_qpack.decodeHeaders(hf.data[0..hf.len], &conn.qpack_dec_tbl, &decoded) catch {};
+                    h3_qpack.decodeHeaders(hf.data[0..hf.len], &conn.qpack_dec_tbl, &decoded) catch |err| {
+                        if (err == error.BlockedStream) {
+                            // RFC 9204 §2.1.2: buffer the HEADERS block and retry
+                            // when new encoder-stream instructions advance the table.
+                            self.bufferBlockedH3Stream(conn, sf.stream_id, hf.data[0..hf.len]);
+                            std.debug.print("io: HEADERS stream_id={} blocked on QPACK table (insertion_count={})\n", .{ sf.stream_id, conn.qpack_dec_tbl.insertion_count });
+                        }
+                        break;
+                    };
                     // RFC 9204 §4.4.1: send a Section Acknowledgement on our
                     // QPACK decoder stream (stream 11) when the client's HEADERS
                     // block contained dynamic table references (RIC > 0).
@@ -2449,6 +2482,11 @@ pub const Server = struct {
                 },
                 else => {},
             }
+        }
+
+        // If the request was buffered as a blocked stream, defer the response.
+        for (&conn.qpack_blocked) |*slot| {
+            if (slot.active and slot.stream_id == sf.stream_id) return;
         }
 
         std.debug.print("io: http3 request stream_id={} method={s} path={s}\n", .{ sf.stream_id, method, path });
@@ -2518,8 +2556,7 @@ pub const Server = struct {
     /// The first byte of the stream payload is the stream type; subsequent bytes
     /// are the stream body.  We only dispatch on the first STREAM frame per stream
     /// (offset == 0); later frames for the same stream continue the same body.
-    fn handleH3ClientUniStream(self: *Server, conn: *ConnState, sf: *const stream_frame_mod.StreamFrame) void {
-        _ = self;
+    fn handleH3ClientUniStream(self: *Server, conn: *ConnState, sf: *const stream_frame_mod.StreamFrame, sf_src: std.net.Address) void {
         if (sf.data.len == 0) return;
 
         // The stream type byte is present only in the first frame (offset == 0).
@@ -2554,6 +2591,9 @@ pub const Server = struct {
                 std.debug.print("io: QPACK dec table capacity={} count={} after enc stream\n", .{
                     conn.qpack_dec_tbl.capacity, conn.qpack_dec_tbl.count,
                 });
+                // RFC 9204 §2.1.2: after the table advances, retry any streams
+                // that were blocked waiting for these insertions.
+                self.retryBlockedH3Streams(conn, sf_src);
             },
             0x03 => {
                 // QPACK decoder stream: Section Acks, Insert Count Increments, etc.
@@ -2567,6 +2607,124 @@ pub const Server = struct {
         }
     }
 
+    /// Buffer a HEADERS block whose Required Insert Count exceeds the current
+    /// decoder table size (RFC 9204 §2.1.2).  The block is stored in the first
+    /// free slot of `conn.qpack_blocked` and will be retried when the table
+    /// advances.  If all slots are occupied the block is silently dropped — the
+    /// peer will time out and we will close the connection.
+    fn bufferBlockedH3Stream(
+        _: *Server,
+        conn: *ConnState,
+        stream_id: u64,
+        header_block: []const u8,
+    ) void {
+        for (&conn.qpack_blocked) |*slot| {
+            if (slot.active) continue;
+            slot.active = true;
+            slot.stream_id = stream_id;
+            const copy_len = @min(header_block.len, slot.header_block.len);
+            @memcpy(slot.header_block[0..copy_len], header_block[0..copy_len]);
+            slot.header_block_len = copy_len;
+            return;
+        }
+        std.debug.print("io: QPACK blocked stream buffer full — dropping stream_id={}\n", .{stream_id});
+    }
+
+    /// After the QPACK decoder table has been advanced by new encoder-stream
+    /// instructions, attempt to decode every buffered (blocked) HEADERS block.
+    /// Streams that can now be decoded are dispatched as normal HTTP/3 requests;
+    /// streams that are still blocked remain in the buffer.
+    fn retryBlockedH3Streams(self: *Server, conn: *ConnState, src: std.net.Address) void {
+        for (&conn.qpack_blocked) |*slot| {
+            if (!slot.active) continue;
+
+            var decoded = h3_qpack.DecodedHeaders{ .headers = undefined, .count = 0 };
+            h3_qpack.decodeHeaders(
+                slot.header_block[0..slot.header_block_len],
+                &conn.qpack_dec_tbl,
+                &decoded,
+            ) catch |err| {
+                if (err == error.BlockedStream) continue; // still blocked
+                // Other decode error — discard.
+                std.debug.print("io: QPACK blocked retry err={} stream_id={} — discarding\n", .{ err, slot.stream_id });
+                slot.active = false;
+                continue;
+            };
+
+            // Successfully decoded — clear the slot and process the request.
+            const stream_id = slot.stream_id;
+            const has_dyn = h3_qpack.headerBlockHasDynamicRefs(slot.header_block[0..slot.header_block_len]);
+            slot.active = false;
+            std.debug.print("io: QPACK unblocked stream_id={}\n", .{stream_id});
+
+            // Send Section Ack if the block had dynamic references.
+            if (has_dyn) self.sendQpackDecoderInstruction(conn, stream_id, src);
+
+            // Dispatch the request.
+            var method_buf: [8]u8 = undefined;
+            var path_buf: [512]u8 = undefined;
+            var method: []const u8 = "GET";
+            var path: []const u8 = "/";
+            for (decoded.headers[0..decoded.count]) |fld| {
+                if (std.mem.eql(u8, fld.name, ":method")) {
+                    const ml = @min(fld.value.len, method_buf.len);
+                    @memcpy(method_buf[0..ml], fld.value[0..ml]);
+                    method = method_buf[0..ml];
+                } else if (std.mem.eql(u8, fld.name, ":path")) {
+                    const pl = @min(fld.value.len, path_buf.len);
+                    @memcpy(path_buf[0..pl], fld.value[0..pl]);
+                    path = path_buf[0..pl];
+                }
+            }
+            std.debug.print("io: http3 unblocked request stream_id={} method={s} path={s}\n", .{ stream_id, method, path });
+
+            if (!std.mem.eql(u8, method, "GET")) continue;
+
+            var fs_path_buf: [512]u8 = undefined;
+            const fs_path = http09_server.resolvePath(self.config.www_dir, path, &fs_path_buf) catch continue;
+            const file = std.fs.openFileAbsolute(fs_path, .{}) catch {
+                self.sendH3Response(conn, stream_id, 404, &.{}, src);
+                continue;
+            };
+            const file_end = file.getEndPos() catch {
+                file.close();
+                self.sendH3Response(conn, stream_id, 500, &.{}, src);
+                continue;
+            };
+
+            var size_buf: [20]u8 = undefined;
+            const size_str = std.fmt.bufPrint(&size_buf, "{}", .{file_end}) catch "0";
+            var header_block_out: [512]u8 = undefined;
+            const hb_len = h3_qpack.encodeHeaders(&[_]h3_qpack.Header{
+                .{ .name = ":status", .value = "200" },
+                .{ .name = "content-length", .value = size_str },
+            }, &header_block_out, .{ .table = &conn.qpack_enc_tbl }) catch {
+                file.close();
+                continue;
+            };
+            var headers_out: [600]u8 = undefined;
+            const headers_frame_len = h3_frame.writeFrame(&headers_out, @intFromEnum(h3_frame.FrameType.headers), header_block_out[0..hb_len]) catch {
+                file.close();
+                continue;
+            };
+            self.sendStreamDataH3(conn, stream_id, 0, headers_out[0..headers_frame_len], false, src);
+
+            for (&conn.http3_slots) |*http3_slot| {
+                if (http3_slot.active or http3_slot.awaiting_fin_ack) continue;
+                http3_slot.* = .{
+                    .active = true,
+                    .stream_id = stream_id,
+                    .file = file,
+                    .stream_offset = headers_frame_len,
+                    .file_end = file_end,
+                };
+                break;
+            } else {
+                file.close();
+            }
+        }
+    }
+
     fn sendH3ControlStream(self: *Server, conn: *ConnState, src: std.net.Address) void {
         // Server control stream: stream_id=3 (server-initiated unidirectional).
         // First byte identifies stream type: 0x00 = control stream.
@@ -2576,9 +2734,11 @@ pub const Server = struct {
 
         // SETTINGS: advertise non-zero QPACK_MAX_TABLE_CAPACITY so the peer
         // knows it may insert entries into our dynamic table (RFC 9204 §3.2.3).
+        // Advertise QPACK_BLOCKED_STREAMS so the peer knows we can tolerate
+        // up to QPACK_BLOCKED_STREAMS_MAX streams blocked on table insertions.
         const settings_len = h3_frame.writeSettings(buf[pos..], &[_]h3_frame.Setting{
             .{ .id = h3_frame.SETTINGS_QPACK_MAX_TABLE_CAPACITY, .value = h3_qpack.DEFAULT_DYN_TABLE_CAPACITY },
-            .{ .id = h3_frame.SETTINGS_QPACK_BLOCKED_STREAMS, .value = 0 },
+            .{ .id = h3_frame.SETTINGS_QPACK_BLOCKED_STREAMS, .value = QPACK_BLOCKED_STREAMS_MAX },
         }) catch return;
         pos += settings_len;
 
@@ -4182,7 +4342,7 @@ pub const Client = struct {
         var pos: usize = 1;
         const settings_len = h3_frame.writeSettings(buf[pos..], &[_]h3_frame.Setting{
             .{ .id = h3_frame.SETTINGS_QPACK_MAX_TABLE_CAPACITY, .value = h3_qpack.DEFAULT_DYN_TABLE_CAPACITY },
-            .{ .id = h3_frame.SETTINGS_QPACK_BLOCKED_STREAMS, .value = 0 },
+            .{ .id = h3_frame.SETTINGS_QPACK_BLOCKED_STREAMS, .value = QPACK_BLOCKED_STREAMS_MAX },
         }) catch return;
         pos += settings_len;
 


### PR DESCRIPTION
## Summary

- Advertise `SETTINGS_QPACK_BLOCKED_STREAMS=16` (was 0) in both server and client HTTP/3 control streams — peers may now send HEADERS blocks whose Required Insert Count exceeds the current decoder table size
- **Server**: when `decodeHeaders` returns `error.BlockedStream`, the raw header block is stored in `conn.qpack_blocked` (up to 16 slots via the new `QpackBlockedH3Stream` struct); after each batch of encoder-stream instructions advances the decoder table, `retryBlockedH3Streams` re-attempts decoding and dispatches newly-unblocked requests as normal HTTP/3 responses (including Section Acks and `http3_slot` registration)
- **Client**: `ConnState` carries the `qpack_blocked` buffer and advertises the setting; since the client currently skips HEADERS decoding (DATA frames only matter for downloads), no retry loop is wired up — the infrastructure is in place for future use
- **Two new tests** in `qpack.zig` verify `error.BlockedStream` when the decoder table is behind, and successful decoding once the table catches up (138 tests, all passing)
- Clears the last entry from the **Known Gaps** table in `README.md`; RFC 9204 coverage updated to mention blocked streams

## Test plan

- [x] `zig build test --summary all` → 138/138 passed
- [x] `zig fmt --check` → clean
- [x] `zig build` → success
- [ ] CI interop run (expected: 13/13 as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)