### PR TITLE
perf: batch up to 64 datagrams per sendmmsg/recvmmsg syscall

### DIFF
--- a/src/transport/batch_io.zig
+++ b/src/transport/batch_io.zig
@@ -163,9 +163,17 @@ fn recvLinux(rb: *RecvBatch, sock: std.posix.socket_t, blocking_first: bool) usi
         };
     }
 
-    // First call: blocking (caller already knows data is ready via poll).
-    // Subsequent calls: non-blocking to drain the remainder of the kernel recv queue.
-    const flags0: u32 = if (blocking_first) 0 else linux.MSG.DONTWAIT;
+    // MSG_WAITFORONE: block until the FIRST message arrives, then switch to
+    // MSG_DONTWAIT for the remaining slots — returning with however many
+    // datagrams were already queued in the kernel buffer.  Without this flag,
+    // recvmmsg(flags=0) would block until ALL vlen (64) messages are received,
+    // which would deadlock the server event loop.
+    // When blocking_first=false (pre-poll data already known not to be available)
+    // add MSG_DONTWAIT so the call returns immediately if nothing is ready.
+    const flags0: u32 = if (blocking_first)
+        linux.MSG.WAITFORONE
+    else
+        linux.MSG.WAITFORONE | linux.MSG.DONTWAIT;
     const rc = linux.recvmmsg(@intCast(sock), msgs[0..].ptr, BATCH_SIZE, flags0, null);
     if (rc == 0 or @as(isize, @bitCast(rc)) < 0) return 0;
     const n: usize = @intCast(rc);

--- a/src/transport/batch_io.zig
+++ b/src/transport/batch_io.zig
@@ -1,0 +1,201 @@
+//! Batched UDP send/receive helpers.
+//!
+//! On Linux we use sendmmsg(2)/recvmmsg(2) to push or pull up to BATCH_SIZE
+//! datagrams with a single syscall, cutting per-packet syscall overhead by up
+//! to 64×.  On other platforms we fall back to individual sendto/recvfrom
+//! calls so the code stays portable for development on macOS.
+//!
+//! Typical usage (send side):
+//!   var batch = SendBatch{};
+//!   for (packets_to_send) |pkt| {
+//!       if (batch.enqueue(pkt.buf, pkt.addr)) batch.flush(sock);
+//!   }
+//!   batch.flush(sock);      // flush any remaining
+//!
+//! Typical usage (recv side):
+//!   var rb = RecvBatch{};
+//!   const n = rb.recv(sock);
+//!   for (rb.entries[0..n]) |*e| processPacket(e.buf[0..e.len], e.addr);
+
+const std = @import("std");
+const builtin = @import("builtin");
+const is_linux = builtin.os.tag == .linux;
+
+/// Platform-safe MSG_DONTWAIT constant (std.posix.MSG is void on some macOS builds).
+const MSG_DONTWAIT: u32 = if (@hasDecl(std.posix, "MSG") and @typeInfo(@TypeOf(std.posix.MSG)) == .@"struct")
+    MSG_DONTWAIT
+else switch (builtin.target.os.tag) {
+    .macos, .ios, .tvos, .watchos, .visionos => 0x80,
+    else => 0x40, // Linux
+};
+
+pub const MAX_DATAGRAM_SIZE: usize = 1500;
+pub const BATCH_SIZE: usize = 64;
+
+// ── Send batch ────────────────────────────────────────────────────────────────
+
+/// One slot in the send queue.
+pub const SendEntry = struct {
+    buf: [MAX_DATAGRAM_SIZE]u8 = undefined,
+    len: usize = 0,
+    addr: std.net.Address = undefined,
+};
+
+/// Accumulate outgoing UDP datagrams and flush them in a single syscall.
+pub const SendBatch = struct {
+    entries: [BATCH_SIZE]SendEntry = [_]SendEntry{.{}} ** BATCH_SIZE,
+    count: usize = 0,
+
+    /// Enqueue one datagram.  Returns true when the batch is full; the caller
+    /// should then call flush() before enqueuing more.
+    pub fn enqueue(self: *SendBatch, buf: []const u8, addr: std.net.Address) bool {
+        if (self.count >= BATCH_SIZE) return true;
+        const e = &self.entries[self.count];
+        const n = @min(buf.len, MAX_DATAGRAM_SIZE);
+        @memcpy(e.buf[0..n], buf[0..n]);
+        e.len = n;
+        e.addr = addr;
+        self.count += 1;
+        return self.count >= BATCH_SIZE;
+    }
+
+    /// Send all queued datagrams.  On Linux a single sendmmsg(2) call is made;
+    /// on other platforms a tight loop of sendto(2) calls is used.
+    pub fn flush(self: *SendBatch, sock: std.posix.socket_t) void {
+        const cnt = self.count;
+        self.count = 0;
+        if (cnt == 0) return;
+
+        if (is_linux) {
+            flushLinux(sock, self.entries[0..cnt]);
+        } else {
+            for (self.entries[0..cnt]) |*e| {
+                _ = std.posix.sendto(sock, e.buf[0..e.len], 0, &e.addr.any, e.addr.getOsSockLen()) catch {};
+            }
+        }
+    }
+
+    pub fn len(self: *const SendBatch) usize {
+        return self.count;
+    }
+};
+
+fn flushLinux(sock: std.posix.socket_t, entries: []SendEntry) void {
+    const linux = std.os.linux;
+
+    // One iovec per message (each datagram is a single contiguous buffer).
+    var iovecs: [BATCH_SIZE]std.posix.iovec_const = undefined;
+    var msgs: [BATCH_SIZE]linux.mmsghdr_const = undefined;
+
+    var sent: usize = 0;
+    while (sent < entries.len) {
+        const batch_end = @min(sent + BATCH_SIZE, entries.len);
+        const batch = entries[sent..batch_end];
+
+        for (batch, 0..) |*e, i| {
+            iovecs[i] = .{ .base = e.buf[0..e.len].ptr, .len = e.len };
+            msgs[i] = .{
+                .hdr = .{
+                    .name = @ptrCast(@constCast(&e.addr.any)),
+                    .namelen = e.addr.getOsSockLen(),
+                    .iov = @ptrCast(&iovecs[i]),
+                    .iovlen = 1,
+                    .control = null,
+                    .controllen = 0,
+                    .flags = 0,
+                },
+                .len = 0,
+            };
+        }
+
+        const rc = linux.sendmmsg(@intCast(sock), msgs[0..batch.len].ptr, @intCast(batch.len), 0);
+        _ = rc; // ignore partial-send; packets are loss-tolerant
+        sent += batch.len;
+    }
+}
+
+// ── Receive batch ─────────────────────────────────────────────────────────────
+
+pub const RecvEntry = struct {
+    buf: [MAX_DATAGRAM_SIZE]u8 = undefined,
+    len: usize = 0,
+    addr: std.net.Address = undefined,
+};
+
+/// Receive up to BATCH_SIZE UDP datagrams in a single syscall.
+pub const RecvBatch = struct {
+    entries: [BATCH_SIZE]RecvEntry = [_]RecvEntry{.{}} ** BATCH_SIZE,
+
+    /// Receive as many datagrams as are ready (up to BATCH_SIZE), non-blocking
+    /// (MSG_DONTWAIT) for calls after the first.
+    /// `blocking_first` — if true, the first message is received with a
+    /// blocking call (suitable after poll() indicates data is available).
+    /// Returns the number of messages received.
+    pub fn recv(self: *RecvBatch, sock: std.posix.socket_t, blocking_first: bool) usize {
+        if (is_linux) {
+            return recvLinux(self, sock, blocking_first);
+        } else {
+            return recvPortable(self, sock, blocking_first);
+        }
+    }
+};
+
+fn recvLinux(rb: *RecvBatch, sock: std.posix.socket_t, blocking_first: bool) usize {
+    const linux = std.os.linux;
+
+    var iovecs: [BATCH_SIZE]std.posix.iovec = undefined;
+    var addrs: [BATCH_SIZE]std.posix.sockaddr.storage = undefined;
+    var msgs: [BATCH_SIZE]linux.mmsghdr = undefined;
+
+    for (0..BATCH_SIZE) |i| {
+        iovecs[i] = .{ .base = &rb.entries[i].buf, .len = MAX_DATAGRAM_SIZE };
+        msgs[i] = .{
+            .hdr = .{
+                .name = @ptrCast(&addrs[i]),
+                .namelen = @sizeOf(std.posix.sockaddr.storage),
+                .iov = @ptrCast(&iovecs[i]),
+                .iovlen = 1,
+                .control = null,
+                .controllen = 0,
+                .flags = 0,
+            },
+            .len = 0,
+        };
+    }
+
+    // First call: blocking (caller already knows data is ready via poll).
+    // Subsequent calls: non-blocking to drain the remainder of the kernel recv queue.
+    const flags0: u32 = if (blocking_first) 0 else linux.MSG.DONTWAIT;
+    const rc = linux.recvmmsg(@intCast(sock), msgs[0..].ptr, BATCH_SIZE, flags0, null);
+    if (rc == 0 or @as(isize, @bitCast(rc)) < 0) return 0;
+    const n: usize = @intCast(rc);
+
+    for (0..n) |i| {
+        rb.entries[i].len = msgs[i].len;
+        rb.entries[i].addr = .{ .any = @as(*const std.posix.sockaddr, @ptrCast(&addrs[i])).* };
+    }
+    return n;
+}
+
+fn recvPortable(rb: *RecvBatch, sock: std.posix.socket_t, blocking_first: bool) usize {
+    var count: usize = 0;
+    while (count < BATCH_SIZE) {
+        var src_addr: std.posix.sockaddr.storage = undefined;
+        var src_len: std.posix.socklen_t = @sizeOf(@TypeOf(src_addr));
+        const flags: u32 = if (count == 0 and blocking_first) 0 else MSG_DONTWAIT;
+        const n = std.posix.recvfrom(
+            sock,
+            &rb.entries[count].buf,
+            flags,
+            @ptrCast(&src_addr),
+            &src_len,
+        ) catch |err| {
+            if (count > 0 and err == error.WouldBlock) break;
+            break;
+        };
+        rb.entries[count].len = n;
+        rb.entries[count].addr = .{ .any = @as(*const std.posix.sockaddr, @ptrCast(&src_addr)).* };
+        count += 1;
+    }
+    return count;
+}

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -36,6 +36,7 @@ const version_neg_mod = @import("../packet/version_negotiation.zig");
 const congestion = @import("../loss/congestion.zig");
 const recovery = @import("../loss/recovery.zig");
 const build_options = @import("build_options");
+const batch_io = @import("batch_io.zig");
 
 /// Compile-time-eliminated debug logger. With `-Dverbose=true` prints to stderr;
 /// in production builds all calls are removed by the optimizer with zero overhead.
@@ -1016,6 +1017,9 @@ pub const Server = struct {
     /// Pacing timestamp for http09RetransmitPendingFins: at most one burst per 50ms.
     http09_retransmit_last_ms: i64 = 0,
     /// (Removed: was a 50ms pacing gate for HTTP/3. CC-based rate-limiting is now sufficient.)
+    /// Batched-send buffer: outgoing datagrams are enqueued here and flushed in
+    /// a single sendmmsg(2) call (Linux) or a tight sendto(2) loop (other OS).
+    send_batch: batch_io.SendBatch = .{},
     /// Initialize server: load cert/key and create UDP socket.
     pub fn init(allocator: std.mem.Allocator, config: ServerConfig) !*Server {
         // Heap-allocate the Server to avoid blowing the stack: the conns array
@@ -1126,7 +1130,6 @@ pub const Server = struct {
 
     /// Run the server event loop (blocking).
     pub fn run(self: *Server) !void {
-        var recv_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
         var idle_secs: u32 = 0;
 
         while (true) {
@@ -1173,6 +1176,7 @@ pub const Server = struct {
                 self.http09RetransmitPendingFins();
                 self.flushPendingHttp3Responses();
                 self.http3RetransmitPendingFins();
+                self.flushSendBatch();
                 continue;
             };
             if (ready == 0) {
@@ -1187,6 +1191,7 @@ pub const Server = struct {
                 self.http09RetransmitPendingFins();
                 self.flushPendingHttp3Responses();
                 self.http3RetransmitPendingFins();
+                self.flushSendBatch();
                 self.reapDrainedConnections();
                 continue;
             }
@@ -1219,31 +1224,16 @@ pub const Server = struct {
                 }
             }
 
-            // Read from main UDP socket — first datagram blocking (matches POLL.IN),
-            // then drain the rest with DONTWAIT so ACK batches are not processed
-            // one wakeup per datagram.
+            // Receive from main UDP socket using a batch recv call: up to
+            // batch_io.BATCH_SIZE datagrams per syscall (recvmmsg on Linux,
+            // tight recvfrom loop on other OS).  This drains the kernel recv
+            // queue in one shot so ACK batches are not processed piecemeal.
             if (fds[0].revents & std.posix.POLL.IN != 0) {
-                var drained: usize = 0;
-                while (true) {
-                    var src_addr: std.posix.sockaddr.storage = undefined;
-                    var src_len: std.posix.socklen_t = @sizeOf(@TypeOf(src_addr));
-                    const flags: u32 = if (drained == 0) 0 else MSG_DONTWAIT;
-                    const n = std.posix.recvfrom(
-                        self.sock,
-                        &recv_buf,
-                        flags,
-                        @ptrCast(&src_addr),
-                        &src_len,
-                    ) catch |err| {
-                        if (drained > 0 and err == error.WouldBlock) break;
-                        dbg("io: recvfrom error: {}\n", .{err});
-                        break;
-                    };
-                    drained += 1;
-                    dbg("io: server recvfrom OK n={} src_len={}\n", .{ n, src_len });
-
-                    const src = std.net.Address{ .any = @as(*const std.posix.sockaddr, @ptrCast(&src_addr)).* };
-                    self.processPacket(recv_buf[0..n], src);
+                var rb = batch_io.RecvBatch{};
+                const n_recv = rb.recv(self.sock, true);
+                dbg("io: server recvBatch n={}\n", .{n_recv});
+                for (rb.entries[0..n_recv]) |*e| {
+                    self.processPacket(e.buf[0..e.len], e.addr);
                 }
             }
 
@@ -1251,6 +1241,8 @@ pub const Server = struct {
             self.http09RetransmitPendingFins();
             self.flushPendingHttp3Responses();
             self.http3RetransmitPendingFins();
+            // Flush all enqueued outgoing packets in one sendmmsg(2) syscall.
+            self.flushSendBatch();
             self.reapDrainedConnections();
         }
     }
@@ -2589,10 +2581,13 @@ pub const Server = struct {
         if (has_fin) {
             dbg("io: server SENDING FIN PACKET pkt_len={} payload_len={} pn={}\n", .{ pkt_len, effective_payload.len, conn.app_pn - 1 });
         }
-        const send_result = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &dst.any, dst.getOsSockLen()) catch |err| {
-            dbg("io: sendto error pkt_len={}: {}\n", .{ pkt_len, err });
-            return;
-        };
+        // Enqueue in the outgoing batch.  The packet is physically transmitted
+        // when the batch is flushed (either because it is now full or because
+        // flushSendBatch() is called at the end of the event-loop iteration).
+        if (self.send_batch.enqueue(send_buf[0..pkt_len], dst)) {
+            // Batch full — flush immediately before enqueuing more.
+            self.send_batch.flush(self.sock);
+        }
         // Congestion control: update bytes in flight.
         conn.cc.onPacketSent(@intCast(pkt_len));
         // Loss detection: record this packet.
@@ -2604,8 +2599,15 @@ pub const Server = struct {
             .in_flight = true,
         });
         if (has_fin) {
-            dbg("io: server FIN PACKET sent {} bytes\n", .{send_result});
+            dbg("io: server FIN PACKET enqueued {} bytes\n", .{pkt_len});
         }
+    }
+
+    /// Flush all buffered outgoing packets via a single sendmmsg(2) call
+    /// (Linux) or a tight sendto(2) loop (other OS).  Call this once per
+    /// event-loop iteration after all sends for the current cycle are queued.
+    fn flushSendBatch(self: *Server) void {
+        self.send_batch.flush(self.sock);
     }
 
     /// Send the next STREAM chunk for one queued HTTP/0.9 response.


### PR DESCRIPTION
## Summary

- Adds `src/transport/batch_io.zig` with `SendBatch` and `RecvBatch` types that reduce per-packet syscall overhead by up to 64× on Linux using `sendmmsg(2)` / `recvmmsg(2)`. Non-Linux platforms (macOS) fall back to a tight `sendto`/`recvfrom` loop so development builds stay portable.
- **Send side**: `Server.send1Rtt` enqueues packets into `send_batch` instead of calling `sendto` directly. The batch auto-flushes when full (64 slots). `flushSendBatch()` is called once at the end of every event-loop iteration so all outgoing packets for a cycle go out in one `sendmmsg()` syscall.
- **Receive side**: The server's per-packet `recvfrom` drain loop is replaced by a single `RecvBatch.recv()` call that invokes `recvmmsg()` to pull up to 64 datagrams at once.

## Expected improvement

~50–60 syscalls/ms → ~1 syscall/ms at typical NS3 burst rates, freeing CPU cycles for the crypto and framing path.

## Test plan

- [ ] `zig build` compiles cleanly on macOS (portable fallback path)
- [ ] `zig build test` passes all unit tests
- [ ] CI interop suite passes on Linux (sendmmsg/recvmmsg path)
- [ ] `zig build bench-e2e` shows measurable throughput improvement vs `perf/qpack-static-table` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)