### PR TITLE
fix: 3× amplification limit, error logging, client CRYPTO reorder

### DIFF
--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -177,15 +177,29 @@ pub const CryptoStream = struct {
     recv_buf: ByteBuffer = .{},
     /// Bytes ready to send
     send_buf: ByteBuffer = .{},
+    /// Reorder buffer for out-of-order CRYPTO fragments.
+    reorder: CryptoReorderBuf = .{},
 
     /// Feed received CRYPTO frame data into the stream.
+    /// Out-of-order fragments are buffered in `reorder` and drained
+    /// automatically once the gap is filled.
     pub fn feedRecv(self: *CryptoStream, offset: u64, data: []const u8) error{Full}!void {
-        // Simple in-order reassembly — accept only contiguous data
-        if (offset == self.recv_offset) {
-            try self.recv_buf.write(data);
-            self.recv_offset += data.len;
+        if (offset != self.recv_offset) {
+            // Out-of-order: buffer for later reassembly.
+            self.reorder.insert(offset, data);
+            return;
         }
-        // Out-of-order data is dropped for now (TODO: proper reorder buffer)
+        // In-order segment: commit to recv_buf and advance offset.
+        try self.recv_buf.write(data);
+        self.recv_offset += data.len;
+        // Drain any now-contiguous buffered segments.
+        var drain_buf: [REORDER_SLOT_SIZE]u8 = undefined;
+        while (true) {
+            const n = self.reorder.take(self.recv_offset, &drain_buf);
+            if (n == 0) break;
+            self.recv_buf.write(drain_buf[0..n]) catch break; // buffer full
+            self.recv_offset += n;
+        }
     }
 
     /// Enqueue bytes to send as CRYPTO frames.
@@ -368,4 +382,22 @@ test "crypto_reorder_buf: drain sequence" {
 
     try testing.expectEqual(@as(u64, 10), expected_offset);
     try testing.expectEqual(@as(usize, 0), rb.take(expected_offset, &out));
+}
+
+test "crypto_stream: out-of-order feedRecv with reorder" {
+    const testing = std.testing;
+    var cs = CryptoStream{};
+    // Feed segment at offset 3 first (out-of-order).
+    try cs.feedRecv(3, "def");
+    // recv_offset should NOT advance (gap at 0).
+    try testing.expectEqual(@as(u64, 0), cs.recv_offset);
+    try testing.expectEqual(@as(usize, 0), cs.recv_buf.len());
+    // Now feed the missing segment at offset 0.
+    try cs.feedRecv(0, "abc");
+    // Both segments should now be delivered contiguously.
+    try testing.expectEqual(@as(u64, 6), cs.recv_offset);
+    try testing.expectEqual(@as(usize, 6), cs.recv_buf.len());
+    var out: [16]u8 = undefined;
+    const n = cs.recv_buf.read(&out);
+    try testing.expectEqualSlices(u8, "abcdef", out[0..n]);
 }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -219,7 +219,9 @@ fn writeKeylog(path: []const u8, client_random: [32]u8, secrets: *const tls_hs.T
         const line = std.fmt.bufPrint(&line_buf, "{s} {s} {s}\n", .{
             label, rand_hex, secret_hex,
         }) catch continue;
-        file.writeAll(line) catch {};
+        file.writeAll(line) catch |err| {
+            dbg("io: keylog write failed: {}\n", .{err});
+        };
     }
 }
 
@@ -872,6 +874,15 @@ pub const ConnState = struct {
     peer_bidi_stream_count: u64 = 0,
     peer_uni_stream_count: u64 = 0,
 
+    // ── Anti-amplification (RFC 9000 §8.1) ─────────────────────────────────────
+    // Before the peer's address is validated (Retry token accepted or handshake
+    // completed), the server MUST NOT send more than 3× the bytes received.
+    // These counters track raw UDP payload bytes exchanged during the handshake.
+    // Once address_validated is set, the limit no longer applies.
+    anti_amp_bytes_recv: u64 = 0,
+    anti_amp_bytes_sent: u64 = 0,
+    address_validated: bool = false,
+
     // ── Connection-level flow control (RFC 9000 §4) ───────────────────────────
     // Both sides advertise initial_max_data = 64 MiB in transport parameters.
     // fc_send_max tracks how many cumulative bytes we may send (peer's window);
@@ -1442,6 +1453,11 @@ pub const Server = struct {
             conn.retry_odcid_len = olen;
         }
 
+        // Anti-amplification (RFC 9000 §8.1): track received bytes.
+        conn.anti_amp_bytes_recv += buf.len;
+        // If Retry was accepted, the address is already validated.
+        if (verified_odcid != null) conn.address_validated = true;
+
         if (conn.init_keys == null) conn.deriveInitialKeys(ip.dcid);
         const init_km = &conn.init_keys.?;
 
@@ -1823,7 +1839,15 @@ pub const Server = struct {
             &init_km.server,
             conn.quicVersion(),
         ) catch return;
+
+        // Anti-amplification (RFC 9000 §8.1): do not exceed 3× received bytes.
+        if (!conn.address_validated and conn.anti_amp_bytes_sent + pkt_len > conn.anti_amp_bytes_recv * 3) {
+            dbg("io: amplification limit reached, deferring Initial ServerHello\n", .{});
+            return;
+        }
+
         conn.init_pn += 1;
+        conn.anti_amp_bytes_sent += pkt_len;
 
         _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch |err| {
             dbg("io: sendto Initial failed: {}\n", .{err});
@@ -1861,7 +1885,15 @@ pub const Server = struct {
                 &conn.hs_server_km,
                 conn.quicVersion(),
             ) catch return;
+
+            // Anti-amplification (RFC 9000 §8.1): do not exceed 3× received bytes.
+            if (!conn.address_validated and conn.anti_amp_bytes_sent + pkt_len > conn.anti_amp_bytes_recv * 3) {
+                dbg("io: amplification limit reached, deferring Handshake flight\n", .{});
+                return;
+            }
+
             conn.hs_pn += 1;
+            conn.anti_amp_bytes_sent += pkt_len;
 
             _ = std.posix.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch |err| {
                 dbg("io: sendto Handshake failed: {}\n", .{err});
@@ -1882,6 +1914,9 @@ pub const Server = struct {
         // Find connection by DCID
         const conn = self.findConn(lh.header.dcid) orelse return;
         if (!conn.has_hs_keys) return;
+
+        // Anti-amplification: track Handshake bytes received (RFC 9000 §8.1).
+        conn.anti_amp_bytes_recv += buf.len;
 
         // If already connected, the client may be retransmitting its Finished because
         // our HANDSHAKE_DONE was lost. Re-send it so the client can make progress.
@@ -1968,6 +2003,8 @@ pub const Server = struct {
 
         dbg("io: handshake complete for connection\n", .{});
         conn.phase = .connected;
+        // Handshake complete → peer address is validated (RFC 9000 §8.1).
+        conn.address_validated = true;
 
         const pending_n = conn.pending_1rtt_n;
         conn.pending_1rtt_n = 0;
@@ -2265,7 +2302,10 @@ pub const Server = struct {
                     // Active slot: rewind to re-send data that went to the dead port.
                     const rewind_to: u64 = if (slot.stream_offset > REWIND_BYTES) slot.stream_offset - REWIND_BYTES else 0;
                     if (rewind_to < slot.stream_offset) {
-                        slot.file.seekTo(rewind_to) catch {};
+                        slot.file.seekTo(rewind_to) catch |err| {
+                            dbg("io: path change: seekTo failed stream_id={}: {}\n", .{ slot.stream_id, err });
+                            continue;
+                        };
                         slot.stream_offset = rewind_to;
                         dbg("io: path change: rewound stream_id={} to offset={}\n", .{ slot.stream_id, rewind_to });
                     }
@@ -2388,8 +2428,11 @@ pub const Server = struct {
                             if (slot.active) {
                                 // Normal case: slot is still sending; rewind offset.
                                 if (lp.stream_offset < slot.stream_offset) {
+                                    slot.file.seekTo(lp.stream_offset) catch |err| {
+                                        dbg("io: retransmit seekTo failed stream_id={}: {}\n", .{ lp.stream_id, err });
+                                        break;
+                                    };
                                     slot.stream_offset = lp.stream_offset;
-                                    slot.file.seekTo(lp.stream_offset) catch {};
                                     dbg("io: retransmit h09 stream_id={} rewind to offset={}\n", .{ lp.stream_id, lp.stream_offset });
                                 }
                             } else if (slot.awaiting_fin_ack and slot.file_path_len > 0) {
@@ -2428,7 +2471,10 @@ pub const Server = struct {
                                 if (slot.active) {
                                     slot.stream_offset = lp.stream_offset;
                                     slot.file_offset = file_pos;
-                                    slot.file.seekTo(file_pos) catch {};
+                                    slot.file.seekTo(file_pos) catch |err| {
+                                        dbg("io: retransmit h3 seekTo failed stream_id={}: {}\n", .{ lp.stream_id, err });
+                                        break;
+                                    };
                                     dbg("io: retransmit h3 stream_id={} rewind quic_off={} file_pos={}\n", .{ lp.stream_id, lp.stream_offset, file_pos });
                                 } else if (slot.awaiting_fin_ack and slot.file_path_len > 0) {
                                     const fp = slot.file_path[0..slot.file_path_len];
@@ -2772,7 +2818,9 @@ pub const Server = struct {
         if (!conn.cc.canSend(congestion.mss)) {
             // Rewind offset — we didn't actually send this chunk.
             slot.stream_offset -= @intCast(n);
-            slot.file.seekTo(slot.stream_offset) catch {};
+            slot.file.seekTo(slot.stream_offset) catch |err| {
+                dbg("io: http09 seekTo rewind failed stream_id={}: {}\n", .{ slot.stream_id, err });
+            };
             return;
         }
         self.send1Rtt(conn, frame_buf[0..frame_len], conn.peer);
@@ -3536,7 +3584,9 @@ pub const Server = struct {
         // Mirror the insertion into our encoder table so encodeHeaders can emit
         // a 1-byte dynamic indexed field line instead of a 2-byte static reference.
         conn.qpack_enc_tbl.setCapacity(h3_qpack.DEFAULT_DYN_TABLE_CAPACITY);
-        conn.qpack_enc_tbl.insert(":status", "200") catch {};
+        conn.qpack_enc_tbl.insert(":status", "200") catch |err| {
+            dbg("io: QPACK insert ':status' failed: {}\n", .{err});
+        };
         conn.qpack_enc_stream_off = enc_pos; // save offset for any future inserts
         const enc_sf = stream_frame_mod.StreamFrame{
             .stream_id = 7, // server QPACK encoder stream
@@ -3603,7 +3653,7 @@ pub const Server = struct {
         var frame_buf: [300]u8 = undefined;
         const frame_len = sf.serialize(&frame_buf) catch return;
         self.send1Rtt(conn, frame_buf[0..frame_len], src);
-        conn.qpack_enc_tbl.insert(name, value) catch {};
+        conn.qpack_enc_tbl.insert(name, value) catch {}; // non-critical: dynamic table full
         conn.qpack_enc_stream_off += ins_len;
         dbg("io: QPACK encoder insert name={s} value={s}\n", .{ name, value });
     }
@@ -3754,7 +3804,9 @@ pub const Server = struct {
         };
         // Congestion control: only send if cwnd allows.  Rewind file position if blocked.
         if (!conn.cc.canSend(congestion.mss)) {
-            slot.file.seekTo(slot.file_offset) catch {};
+            slot.file.seekTo(slot.file_offset) catch |err| {
+                dbg("io: h3 seekTo rewind failed stream_id={}: {}\n", .{ slot.stream_id, err });
+            };
             return;
         }
         const old_stream_offset = slot.stream_offset;
@@ -5189,8 +5241,14 @@ pub const Client = struct {
                     // Write at the exact stream offset so retransmitted or
                     // out-of-order STREAM frames (possible after a NAT rebind
                     // triggers server-side retransmit) land at the right place.
-                    s.file.seekTo(sf.offset) catch {};
-                    s.file.writeAll(sf.data) catch {};
+                    s.file.seekTo(sf.offset) catch |err| {
+                        dbg("io: client seekTo failed stream_id={}: {}\n", .{ sf.stream_id, err });
+                        return;
+                    };
+                    s.file.writeAll(sf.data) catch |err| {
+                        dbg("io: client writeAll failed stream_id={}: {}\n", .{ sf.stream_id, err });
+                        return;
+                    };
                     if (sf.fin) {
                         s.file.close();
                         s.active = false;
@@ -5283,7 +5341,9 @@ pub const Client = struct {
                     s.h3_quic_offset += @intCast(pr.consumed);
                 },
                 .data => |d| {
-                    _ = s.file.write(d) catch {};
+                    _ = s.file.write(d) catch |err| {
+                        dbg("io: h3 stream_id={} write failed: {}\n", .{ s.stream_id, err });
+                    };
                     dbg("io: h3 stream_id={} DATA {} bytes written\n", .{ s.stream_id, d.len });
                     // Track consumed QUIC stream bytes so duplicate frames are rejected.
                     s.h3_quic_offset += @intCast(pr.consumed);
@@ -5414,10 +5474,10 @@ pub const Client = struct {
         // Mirror insertions into our encoder table so encodeHeaders emits
         // compact dynamic indexed field lines.
         self.conn.qpack_enc_tbl.setCapacity(h3_qpack.DEFAULT_DYN_TABLE_CAPACITY);
-        self.conn.qpack_enc_tbl.insert(":method", "GET") catch {};
-        self.conn.qpack_enc_tbl.insert(":scheme", "https") catch {};
+        self.conn.qpack_enc_tbl.insert(":method", "GET") catch {}; // non-critical: dynamic table full
+        self.conn.qpack_enc_tbl.insert(":scheme", "https") catch {}; // non-critical: dynamic table full
         if (self.config.host.len <= h3_qpack.MAX_DYN_ENTRY_BYTES) {
-            self.conn.qpack_enc_tbl.insert(":authority", self.config.host) catch {};
+            self.conn.qpack_enc_tbl.insert(":authority", self.config.host) catch {}; // non-critical: dynamic table full
         }
         self.conn.qpack_enc_stream_off = enc_pos; // save for any future inserts
         const enc_sf = stream_frame_mod.StreamFrame{


### PR DESCRIPTION
## Summary

Three v1.0.0 polish fixes to close the remaining gaps identified in the RFC compliance audit:

- **Anti-amplification limit (RFC 9000 §8.1)**: Before address validation (Retry token or handshake completion), the server now enforces the 3× bytes-sent/bytes-received ratio. `ConnState` gains `anti_amp_bytes_recv`, `anti_amp_bytes_sent`, and `address_validated` fields. `sendInitialServerHello` and `sendHandshakeServerFlight` defer packets that would exceed the budget. This prevents DDoS amplification attacks via forged source addresses.

- **Error observability**: All file I/O `catch {}` (seekTo, writeAll, write) in stream handlers converted to `catch |err| { dbg(...); }` so failures appear in debug logs. Covers: HTTP/0.9 migration rewind, loss retransmit seeks, congestion-control file rewind, client file writes, H3 DATA writes, keylog writes. UDP sendto and setsockopt left as-is (inherently lossy / best-effort). QPACK dynamic table inserts annotated as non-critical.

- **Client-side CRYPTO reorder**: `CryptoStream.feedRecv()` in `quic_tls.zig` now buffers out-of-order fragments using `CryptoReorderBuf` and drains them automatically when the gap is filled — completing the reorder support for both client and server paths.

## Test plan

- [x] `zig build` compiles cleanly
- [x] `zig build test` passes all unit tests (including new out-of-order `CryptoStream.feedRecv` test)
- [x] CI: 13/13 interop tests pass
- [x] End-to-End Throughput Benchmark passes
- [x] Amplification limit does not break normal handshake flow (retry + non-retry paths both pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)