### PR TITLE
perf: CUBIC CC, packet coalescing, replay cache TTL

### DIFF
--- a/src/crypto/session.zig
+++ b/src/crypto/session.zig
@@ -278,8 +278,18 @@ pub fn deriveEarlyKeys(ticket: *const SessionTicket) EarlyDataKeys {
 ///   if (!server.nonce_cache.checkAndInsert(key)) {
 ///       // Replay detected — do not activate early keys.
 ///   }
+/// Maximum age (ms) for a nonce cache entry.  Entries older than this are
+/// considered expired and silently evicted.  10 seconds covers typical
+/// 0-RTT replay windows while limiting the cache's effective memory.
+const NONCE_TTL_MS: i64 = 10_000;
+
 pub const NonceCache = struct {
-    entries: [64][8]u8 = [_][8]u8{[_]u8{0} ** 8} ** 64,
+    const Entry = struct {
+        key: [8]u8 = .{0} ** 8,
+        inserted_ms: i64 = 0,
+    };
+
+    entries: [64]Entry = [_]Entry{.{}} ** 64,
     /// Number of valid entries (saturates at 64).
     count: usize = 0,
     /// Next write position in the ring.
@@ -287,14 +297,22 @@ pub const NonceCache = struct {
 
     /// Check whether `key` has been seen before.
     /// Returns `true` (new) if the key is fresh and inserts it.
-    /// Returns `false` (replay) if the key already exists.
+    /// Returns `false` (replay) if the key already exists and is not expired.
     pub fn checkAndInsert(self: *NonceCache, key: [8]u8) bool {
+        const now_ms = std.time.milliTimestamp();
+        return self.checkAndInsertAt(key, now_ms);
+    }
+
+    /// Testable version that accepts an explicit timestamp.
+    pub fn checkAndInsertAt(self: *NonceCache, key: [8]u8, now_ms: i64) bool {
         const n = @min(self.count, 64);
         for (0..n) |i| {
-            if (std.mem.eql(u8, &self.entries[i], &key)) return false; // replay
+            // Skip expired entries.
+            if (now_ms - self.entries[i].inserted_ms > NONCE_TTL_MS) continue;
+            if (std.mem.eql(u8, &self.entries[i].key, &key)) return false; // replay
         }
         // Fresh key — insert at head.
-        self.entries[self.head] = key;
+        self.entries[self.head] = .{ .key = key, .inserted_ms = now_ms };
         self.head = (self.head + 1) % 64;
         if (self.count < 64) self.count += 1;
         return true;
@@ -417,4 +435,15 @@ test "nonce_cache: ring eviction" {
     // (cache ring wrapped around).  We just verify no panic occurs.
     const evicted: [8]u8 = .{0} ** 8;
     _ = cache.checkAndInsert(evicted);
+}
+
+test "nonce_cache: expired entries allow re-use" {
+    const testing = std.testing;
+    var cache = NonceCache{};
+    const key: [8]u8 = .{ 0xaa, 0xbb, 0xcc, 0xdd, 0x00, 0x00, 0x00, 0x01 };
+    const t0: i64 = 1_000_000;
+    try testing.expect(cache.checkAndInsertAt(key, t0)); // fresh
+    try testing.expect(!cache.checkAndInsertAt(key, t0 + 5_000)); // still within TTL
+    // After TTL expires, the same key should be accepted again.
+    try testing.expect(cache.checkAndInsertAt(key, t0 + 10_001));
 }

--- a/src/http3/frame.zig
+++ b/src/http3/frame.zig
@@ -13,6 +13,12 @@
 //!   PUSH_PROMISE(0x05) – server push promise
 //!   GOAWAY      (0x07) – graceful shutdown
 //!   MAX_PUSH_ID (0x0d) – upper bound on push IDs
+//!
+//! Note: Server Push (PUSH_PROMISE / CANCEL_PUSH / MAX_PUSH_ID) is
+//! intentionally not implemented.  Server push is optional per RFC 9114 §4.6,
+//! has been deprecated by all major browsers, and introduces significant
+//! complexity with minimal real-world benefit.  The frame types are parsed for
+//! protocol correctness but never generated.
 
 const std = @import("std");
 const varint = @import("../varint.zig");

--- a/src/loss/congestion.zig
+++ b/src/loss/congestion.zig
@@ -92,6 +92,68 @@ pub const NewReno = struct {
     }
 };
 
+/// Tagged union wrapping available congestion controllers.
+/// All variants expose the same interface so callers use `cc.onAck(...)` etc.
+pub const CongestionController = union(enum) {
+    new_reno: NewReno,
+    cubic: @import("cubic.zig").Cubic,
+
+    pub fn init(comptime tag: std.meta.Tag(CongestionController)) CongestionController {
+        return switch (tag) {
+            .new_reno => .{ .new_reno = NewReno.init() },
+            .cubic => .{ .cubic = @import("cubic.zig").Cubic.init() },
+        };
+    }
+
+    pub fn onAck(self: *CongestionController, bytes_acked: u64) void {
+        switch (self.*) {
+            inline else => |*cc| cc.onAck(bytes_acked),
+        }
+    }
+
+    pub fn onLoss(self: *CongestionController, largest_lost_pn: u64) void {
+        switch (self.*) {
+            inline else => |*cc| cc.onLoss(largest_lost_pn),
+        }
+    }
+
+    pub fn onPacketSent(self: *CongestionController, bytes: u64) void {
+        switch (self.*) {
+            inline else => |*cc| cc.onPacketSent(bytes),
+        }
+    }
+
+    pub fn sendCredit(self: *const CongestionController) u64 {
+        switch (self.*) {
+            inline else => |*cc| return cc.sendCredit(),
+        }
+    }
+
+    pub fn canSend(self: *const CongestionController, packet_size: u64) bool {
+        switch (self.*) {
+            inline else => |*cc| return cc.canSend(packet_size),
+        }
+    }
+
+    pub fn getBytesInFlight(self: *const CongestionController) u64 {
+        switch (self.*) {
+            inline else => |cc| return cc.bytes_in_flight,
+        }
+    }
+
+    pub fn setBytesInFlight(self: *CongestionController, val: u64) void {
+        switch (self.*) {
+            inline else => |*cc| cc.bytes_in_flight = val,
+        }
+    }
+
+    pub fn subBytesInFlight(self: *CongestionController, val: u64) void {
+        switch (self.*) {
+            inline else => |*cc| cc.bytes_in_flight -|= val,
+        }
+    }
+};
+
 test "new_reno: slow start growth" {
     const testing = std.testing;
     var cc = NewReno.init();
@@ -138,4 +200,25 @@ test "new_reno: can_send check" {
     try testing.expect(!cc.canSend(1));
     cc.onAck(mss);
     try testing.expect(cc.canSend(mss));
+}
+
+test "congestion_controller: tagged union dispatches correctly" {
+    const testing = std.testing;
+
+    // NewReno variant
+    var nr = CongestionController.init(.new_reno);
+    nr.onPacketSent(mss);
+    try testing.expectEqual(@as(u64, mss), nr.getBytesInFlight());
+    try testing.expect(nr.canSend(mss));
+    nr.onAck(mss);
+    try testing.expectEqual(@as(u64, 0), nr.getBytesInFlight());
+
+    // CUBIC variant
+    var cubic = CongestionController.init(.cubic);
+    cubic.onPacketSent(mss);
+    try testing.expectEqual(@as(u64, mss), cubic.getBytesInFlight());
+    try testing.expect(cubic.canSend(mss));
+    cubic.onLoss(1);
+    // After loss, CUBIC sets cwnd = cwnd × β (0.7).
+    try testing.expect(cubic.canSend(mss));
 }

--- a/src/loss/cubic.zig
+++ b/src/loss/cubic.zig
@@ -1,0 +1,232 @@
+//! CUBIC congestion control (RFC 9438 / RFC 8312).
+//!
+//! CUBIC uses a cubic function for window growth in congestion avoidance,
+//! achieving better throughput on high-BDP paths than NewReno while remaining
+//! TCP-friendly.  The window function is:
+//!
+//!   W(t) = C × (t − K)³ + W_max
+//!
+//! where:
+//!   C     = 0.4 (scaling constant)
+//!   K     = ∛(W_max × β / C)  (time to reach W_max after loss)
+//!   β     = 0.7  (multiplicative decrease factor)
+//!   W_max = cwnd at the time of the last loss event
+//!   t     = elapsed time since the last loss event
+//!
+//! This module implements the same interface as NewReno so the connection
+//! can switch between controllers via a tagged union.
+
+const std = @import("std");
+const nr = @import("congestion.zig");
+
+pub const mss: u64 = nr.mss;
+const max_cwnd: u64 = 64 * 1024 * 1024;
+
+/// CUBIC scaling constant C = 0.4.
+/// We use fixed-point: C_NUM/C_DEN = 4/10 = 0.4.
+const C_NUM: u64 = 4;
+const C_DEN: u64 = 10;
+
+/// Multiplicative decrease factor β = 0.7.
+/// BETA_NUM/BETA_DEN = 7/10 = 0.7.
+const BETA_NUM: u64 = 7;
+const BETA_DEN: u64 = 10;
+
+pub const Cubic = struct {
+    /// Congestion window in bytes.
+    cwnd: u64 = 10 * mss,
+    /// Slow start threshold.
+    ssthresh: u64 = max_cwnd,
+    /// Bytes in flight.
+    bytes_in_flight: u64 = 0,
+    /// State.
+    state: nr.CcState = .slow_start,
+    /// W_max: window size (in MSS) at the last loss event.
+    w_max: u64 = 0,
+    /// Epoch start: timestamp (ms) when the current congestion avoidance epoch started.
+    epoch_start_ms: ?i64 = null,
+    /// K: time (ms) for the cubic function to reach W_max.
+    k_ms: u64 = 0,
+    /// Largest ACKed packet number in the current recovery period.
+    end_of_recovery: ?u64 = null,
+    /// TCP-friendly estimate of cwnd (for the TCP-friendliness check).
+    tcp_cwnd: u64 = 0,
+    /// Bytes ACKed in current congestion avoidance epoch (for TCP-friendly estimate).
+    bytes_acked_ca: u64 = 0,
+
+    pub fn init() Cubic {
+        return .{};
+    }
+
+    /// Called when packets are acknowledged.
+    pub fn onAck(self: *Cubic, bytes_acked: u64) void {
+        self.bytes_in_flight -|= bytes_acked;
+
+        if (self.state == .recovery) {
+            self.state = .congestion_avoidance;
+            self.end_of_recovery = null;
+        }
+
+        if (self.state == .slow_start) {
+            self.cwnd +|= bytes_acked;
+            if (self.cwnd >= self.ssthresh) {
+                self.state = .congestion_avoidance;
+                self.epoch_start_ms = null; // reset epoch on entering CA
+            }
+        } else if (self.state == .congestion_avoidance) {
+            self.updateCubic(bytes_acked);
+        }
+    }
+
+    fn updateCubic(self: *Cubic, bytes_acked: u64) void {
+        const now_ms = std.time.milliTimestamp();
+
+        // Start a new epoch if needed.
+        if (self.epoch_start_ms == null) {
+            self.epoch_start_ms = now_ms;
+            if (self.cwnd < self.w_max * mss) {
+                // Compute K = ∛(W_max × (1 - β) / C) in milliseconds.
+                // K = ∛((w_max * (1 - 0.7) / 0.4)) seconds → convert to ms.
+                // K = ∛(w_max * 3 / 4) seconds (since (1-0.7)/0.4 = 0.75).
+                // We compute in integer: K_s³ = w_max * 3 / 4 (in MSS units).
+                const w_max_mss = self.w_max;
+                const val = w_max_mss * 3 / 4; // (1-β)/C = 0.3/0.4 = 0.75
+                self.k_ms = intCbrt(val) * 1000; // seconds to ms
+            } else {
+                self.k_ms = 0;
+            }
+            self.tcp_cwnd = self.cwnd;
+        }
+
+        const epoch_start = self.epoch_start_ms orelse now_ms;
+        const t_ms: u64 = @intCast(@max(now_ms - epoch_start, 0));
+
+        // W_cubic(t) = C × (t - K)³ + W_max  (in MSS units, t in seconds)
+        // We compute in integer with ms precision:
+        //   W = C_NUM/C_DEN × ((t_ms - k_ms)/1000)³ + w_max  (MSS units)
+        // Rearranged to avoid floating point:
+        //   diff = t_ms - k_ms (signed, in ms)
+        //   W_mss = C_NUM × diff³ / (C_DEN × 1000³) + w_max
+        const diff: i64 = @as(i64, @intCast(t_ms)) - @as(i64, @intCast(self.k_ms));
+        const diff_cubed: i64 = @divTrunc(diff * diff * diff, 1_000_000_000); // diff³/10⁹
+        const cubic_mss: i64 = @as(i64, @intCast(self.w_max)) + @divTrunc(diff_cubed * @as(i64, @intCast(C_NUM)), @as(i64, @intCast(C_DEN)));
+
+        const w_cubic: u64 = if (cubic_mss > 0)
+            @min(@as(u64, @intCast(cubic_mss)) * mss, max_cwnd)
+        else
+            self.cwnd;
+
+        // TCP-friendly estimate: NewReno-like linear growth.
+        self.bytes_acked_ca += bytes_acked;
+        while (self.bytes_acked_ca >= self.tcp_cwnd) {
+            self.bytes_acked_ca -= self.tcp_cwnd;
+            self.tcp_cwnd = @min(self.tcp_cwnd + mss, max_cwnd);
+        }
+
+        // Use the larger of CUBIC and TCP-friendly estimates (RFC 9438 §4.4).
+        const target = @max(w_cubic, self.tcp_cwnd);
+        if (target > self.cwnd) {
+            self.cwnd = target;
+        }
+    }
+
+    /// Called on packet loss.
+    pub fn onLoss(self: *Cubic, largest_lost_pn: u64) void {
+        // Only react to loss once per flight (RFC 9002 §7.3.2).
+        if (self.end_of_recovery) |eor| {
+            if (largest_lost_pn <= eor) return;
+        }
+
+        self.end_of_recovery = largest_lost_pn;
+        // Save W_max before reducing (in MSS units).
+        self.w_max = self.cwnd / mss;
+        // Multiplicative decrease: cwnd = cwnd × β.
+        self.ssthresh = @max(self.cwnd * BETA_NUM / BETA_DEN, 2 * mss);
+        self.cwnd = self.ssthresh;
+        self.state = .recovery;
+        // Reset epoch so next congestion avoidance starts fresh.
+        self.epoch_start_ms = null;
+        self.bytes_acked_ca = 0;
+    }
+
+    /// Called when a packet is sent.
+    pub fn onPacketSent(self: *Cubic, bytes: u64) void {
+        self.bytes_in_flight +|= bytes;
+    }
+
+    /// Returns the send credit (bytes allowed to be in flight).
+    pub fn sendCredit(self: *const Cubic) u64 {
+        return self.cwnd -| self.bytes_in_flight;
+    }
+
+    /// True if we may send more data (sender-side congestion check).
+    pub fn canSend(self: *const Cubic, packet_size: u64) bool {
+        return self.bytes_in_flight + packet_size <= self.cwnd;
+    }
+};
+
+/// Integer cube root via Newton's method.
+fn intCbrt(n: u64) u64 {
+    if (n == 0) return 0;
+    if (n < 8) return 1;
+    var x: u64 = n;
+    var y: u64 = (2 * x + n / (x * x)) / 3;
+    while (y < x) {
+        x = y;
+        // Guard against division by zero from very small x.
+        const x_sq = x *| x;
+        if (x_sq == 0) break;
+        y = (2 * x + n / x_sq) / 3;
+    }
+    return x;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "cubic: slow start growth" {
+    const testing = std.testing;
+    var cc = Cubic.init();
+    try testing.expectEqual(nr.CcState.slow_start, cc.state);
+    const initial_cwnd = cc.cwnd;
+
+    cc.onPacketSent(mss);
+    cc.onAck(mss);
+    try testing.expectEqual(initial_cwnd + mss, cc.cwnd);
+}
+
+test "cubic: loss triggers recovery with β=0.7" {
+    const testing = std.testing;
+    var cc = Cubic.init();
+    cc.cwnd = 100 * mss;
+    cc.bytes_in_flight = 50 * mss;
+
+    cc.onLoss(5);
+    try testing.expectEqual(nr.CcState.recovery, cc.state);
+    // ssthresh = cwnd × 0.7 = 100 × 0.7 = 70 MSS
+    try testing.expectEqual(@as(u64, 70 * mss), cc.ssthresh);
+    try testing.expectEqual(@as(u64, 70 * mss), cc.cwnd);
+    // W_max should be saved.
+    try testing.expectEqual(@as(u64, 100), cc.w_max);
+}
+
+test "cubic: integer cube root" {
+    const testing = std.testing;
+    try testing.expectEqual(@as(u64, 0), intCbrt(0));
+    try testing.expectEqual(@as(u64, 1), intCbrt(1));
+    try testing.expectEqual(@as(u64, 2), intCbrt(8));
+    try testing.expectEqual(@as(u64, 3), intCbrt(27));
+    try testing.expectEqual(@as(u64, 10), intCbrt(1000));
+    try testing.expectEqual(@as(u64, 10), intCbrt(1100)); // floor
+}
+
+test "cubic: can_send check" {
+    const testing = std.testing;
+    var cc = Cubic.init();
+    cc.cwnd = 2 * mss;
+    cc.bytes_in_flight = 2 * mss;
+    try testing.expect(!cc.canSend(1));
+    cc.onAck(mss);
+    try testing.expect(cc.canSend(mss));
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,6 +27,7 @@ pub const crypto = struct {
 pub const loss = struct {
     pub const recovery = @import("loss/recovery.zig");
     pub const congestion = @import("loss/congestion.zig");
+    pub const cubic = @import("loss/cubic.zig");
 };
 pub const tls = struct {
     pub const handshake = @import("tls/handshake.zig");
@@ -75,6 +76,7 @@ test {
     _ = @import("tls/handshake.zig");
     _ = @import("loss/recovery.zig");
     _ = @import("loss/congestion.zig");
+    _ = @import("loss/cubic.zig");
     _ = @import("transport/connection.zig");
     _ = @import("transport/endpoint.zig");
     _ = @import("transport/flow_control.zig");

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -4635,11 +4635,33 @@ pub const Client = struct {
 
         if (buf[0] & 0x80 != 0) {
             const lh = header_mod.parseLong(buf) catch return;
+            // Determine this packet's total length for coalesced packet handling
+            // (RFC 9000 §12.2).  For Initial packets the Length field starts after
+            // the token; for Handshake packets it starts right after the header.
+            const pkt_end: usize = blk: {
+                var pos = lh.consumed;
+                if (lh.header.packet_type == .initial) {
+                    // Skip token_len + token.
+                    const tok_r = varint.decode(buf[pos..]) catch break :blk buf.len;
+                    pos += tok_r.len + @as(usize, @intCast(tok_r.value));
+                }
+                if (lh.header.packet_type == .initial or lh.header.packet_type == .handshake) {
+                    if (pos >= buf.len) break :blk buf.len;
+                    const len_r = varint.decode(buf[pos..]) catch break :blk buf.len;
+                    pos += len_r.len + @as(usize, @intCast(len_r.value));
+                    break :blk @min(pos, buf.len);
+                }
+                break :blk buf.len;
+            };
             switch (lh.header.packet_type) {
-                .initial => self.processInitialPacket(buf),
-                .handshake => self.processHandshakePacket(buf),
+                .initial => self.processInitialPacket(buf[0..pkt_end]),
+                .handshake => self.processHandshakePacket(buf[0..pkt_end]),
                 .retry => self.processRetryPacket(buf),
                 else => {},
+            }
+            // RFC 9000 §12.2: process remaining coalesced packets in same datagram.
+            if (pkt_end < buf.len) {
+                self.processPacket(buf[pkt_end..]);
             }
         } else {
             self.process1RttPacket(buf);

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -938,8 +938,8 @@ pub const ConnState = struct {
     ecn_ce_recv: u64 = 0,
 
     // ── Congestion control + loss detection (RFC 9002) ────────────────────────
-    // New Reno CC: cwnd, ssthresh, bytes_in_flight.
-    cc: congestion.NewReno = congestion.NewReno.init(),
+    // Congestion controller: NewReno (default) or CUBIC (configurable).
+    cc: congestion.CongestionController = congestion.CongestionController.init(.new_reno),
     // RTT estimator: smoothed RTT, RTT variance, min RTT.
     rtt: recovery.RttEstimator = .{},
     // Loss detector: tracks in-flight packets by PN, detects loss via packet threshold.
@@ -1020,6 +1020,8 @@ pub const ServerConfig = struct {
     /// Also suppresses Version Negotiation for QUIC_V2 packets regardless of
     /// this flag, so the server auto-negotiates down to v1 if needed.
     v2: bool = false,
+    /// Use CUBIC congestion control instead of NewReno (RFC 9438).
+    cubic: bool = false,
     /// Directory to write qlog files into.  When non-null, one `<cid>.sqlog`
     /// file is created per connection.  Set via --qlog-dir on the command line.
     qlog_dir: ?[]const u8 = null,
@@ -1384,6 +1386,9 @@ pub const Server = struct {
                     .use_v2 = is_v2,
                 };
                 const conn = &(slot.*.?);
+                if (self.config.cubic) {
+                    conn.cc = congestion.CongestionController.init(.cubic);
+                }
                 conn.deriveInitialKeys(dcid);
                 // Open qlog file named after the original destination CID (ODCID).
                 if (self.config.qlog_dir) |qd| {
@@ -1805,12 +1810,110 @@ pub const Server = struct {
         // App secrets are now derived inside buildServerFlight; derive QUIC keys.
         conn.deriveAppKeys(&conn.tls.secrets);
 
-        // Send Initial packet with ServerHello CRYPTO frame
-        self.sendInitialServerHello(conn, src);
-        // Send Handshake packet with server flight CRYPTO frame
-        self.sendHandshakeServerFlight(conn, src);
+        // Coalesce Initial + Handshake packets into a single UDP datagram
+        // (RFC 9000 §12.2).  Fall back to separate sends for any remainder.
+        self.sendCoalescedServerFlight(conn, src);
 
         conn.phase = .waiting_finished;
+    }
+
+    /// Coalesce Initial + Handshake packets into as few UDP datagrams as
+    /// possible (RFC 9000 §12.2).  The first datagram packs the Initial
+    /// (ServerHello) plus as many Handshake CRYPTO chunks as fit within
+    /// MAX_DATAGRAM_SIZE.  Any remaining Handshake chunks are sent as
+    /// separate datagrams via sendHandshakeServerFlight.
+    fn sendCoalescedServerFlight(self: *Server, conn: *ConnState, src: std.net.Address) void {
+        var coalesced_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+        var coalesced_len: usize = 0;
+
+        // ── Build Initial packet (ServerHello) ──────────────────────────────
+        {
+            var frames_buf: [1024]u8 = undefined;
+            var fp: usize = 0;
+            if (conn.init_recv_pn) |pn| {
+                const ack_len = buildAckFrame(frames_buf[fp..], pn, 0) catch return;
+                fp += ack_len;
+            }
+            const crypto_len = buildCryptoFrame(frames_buf[fp..], 0, conn.sh_bytes[0..conn.sh_len]) catch return;
+            fp += crypto_len;
+
+            const init_km = conn.init_keys orelse return;
+            const pkt_len = buildInitialPacket(
+                &coalesced_buf,
+                conn.remote_cid,
+                conn.local_cid,
+                &.{},
+                frames_buf[0..fp],
+                conn.init_pn,
+                &init_km.server,
+                conn.quicVersion(),
+            ) catch return;
+
+            if (!conn.address_validated and conn.anti_amp_bytes_sent + pkt_len > conn.anti_amp_bytes_recv * 3) {
+                dbg("io: amplification limit reached, deferring Initial ServerHello\n", .{});
+                return;
+            }
+            conn.init_pn += 1;
+            conn.anti_amp_bytes_sent += pkt_len;
+            coalesced_len = pkt_len;
+        }
+
+        // ── Append Handshake packet(s) into the same datagram ───────────────
+        if (conn.has_hs_keys) {
+            const flight = conn.flight_bytes[0..conn.flight_len];
+            const max_crypto_per_pkt = 1100;
+            var offset: usize = 0;
+
+            while (offset < flight.len) {
+                var frames_buf: [8192]u8 = undefined;
+                const chunk_len = @min(flight.len - offset, max_crypto_per_pkt);
+                const crypto_len = buildCryptoFrame(
+                    &frames_buf,
+                    @intCast(offset),
+                    flight[offset .. offset + chunk_len],
+                ) catch break;
+
+                // Try to fit this Handshake packet into the coalesced datagram.
+                const remaining = coalesced_buf[coalesced_len..];
+                const pkt_len = buildHandshakePacket(
+                    remaining,
+                    conn.remote_cid,
+                    conn.local_cid,
+                    frames_buf[0..crypto_len],
+                    conn.hs_pn,
+                    &conn.hs_server_km,
+                    conn.quicVersion(),
+                ) catch break; // not enough room — send what we have, rest goes separately
+
+                if (!conn.address_validated and conn.anti_amp_bytes_sent + pkt_len > conn.anti_amp_bytes_recv * 3) {
+                    dbg("io: amplification limit reached, deferring Handshake flight\n", .{});
+                    break;
+                }
+                conn.hs_pn += 1;
+                conn.anti_amp_bytes_sent += pkt_len;
+                coalesced_len += pkt_len;
+                offset += chunk_len;
+            }
+
+            // Flush the coalesced datagram.
+            if (coalesced_len > 0) {
+                _ = std.posix.sendto(self.sock, coalesced_buf[0..coalesced_len], 0, &src.any, src.getOsSockLen()) catch |err| {
+                    dbg("io: sendto coalesced flight failed: {}\n", .{err});
+                };
+            }
+
+            // Send any remaining Handshake chunks that did not fit as separate datagrams.
+            if (offset < flight.len) {
+                self.sendHandshakeServerFlightFrom(conn, src, offset);
+            }
+        } else {
+            // No handshake keys yet — just send the Initial packet alone.
+            if (coalesced_len > 0) {
+                _ = std.posix.sendto(self.sock, coalesced_buf[0..coalesced_len], 0, &src.any, src.getOsSockLen()) catch |err| {
+                    dbg("io: sendto Initial failed: {}\n", .{err});
+                };
+            }
+        }
     }
 
     fn sendInitialServerHello(self: *Server, conn: *ConnState, src: std.net.Address) void {
@@ -1855,16 +1958,21 @@ pub const Server = struct {
     }
 
     fn sendHandshakeServerFlight(self: *Server, conn: *ConnState, src: std.net.Address) void {
+        self.sendHandshakeServerFlightFrom(conn, src, 0);
+    }
+
+    /// Send Handshake CRYPTO frames starting from `start_offset` in the
+    /// server flight buffer, one packet per UDP datagram.
+    fn sendHandshakeServerFlightFrom(self: *Server, conn: *ConnState, src: std.net.Address, start_offset: usize) void {
         if (!conn.has_hs_keys) return;
 
         var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
         var frames_buf: [8192]u8 = undefined;
         var fp: usize = 0;
 
-        // CRYPTO frame with server flight (may need to be split across packets)
         const flight = conn.flight_bytes[0..conn.flight_len];
-        const max_crypto_per_pkt = 1100; // leave room for headers + AEAD tag
-        var offset: usize = 0;
+        const max_crypto_per_pkt = 1100;
+        var offset: usize = start_offset;
 
         while (offset < flight.len) {
             fp = 0;
@@ -1886,7 +1994,6 @@ pub const Server = struct {
                 conn.quicVersion(),
             ) catch return;
 
-            // Anti-amplification (RFC 9000 §8.1): do not exceed 3× received bytes.
             if (!conn.address_validated and conn.anti_amp_bytes_sent + pkt_len > conn.anti_amp_bytes_recv * 3) {
                 dbg("io: amplification limit reached, deferring Handshake flight\n", .{});
                 return;
@@ -2336,7 +2443,10 @@ pub const Server = struct {
             // path change.  bytes_in_flight from the old path is stale — those
             // packets will never be ACKed on the new path — so we must clear it
             // or the CC gate will block retransmissions indefinitely.
-            conn.cc = congestion.NewReno.init();
+            conn.cc = switch (conn.cc) {
+                .new_reno => congestion.CongestionController.init(.new_reno),
+                .cubic => congestion.CongestionController.init(.cubic),
+            };
             conn.rtt = .{};
             conn.ld = .{};
         }
@@ -2411,7 +2521,7 @@ pub const Server = struct {
                 // Remove lost-packet bytes from bytes_in_flight (RFC 9002 §7.5:
                 // lost packets are no longer "in flight").
                 if (ld_result.lost_bytes > 0) {
-                    conn.cc.bytes_in_flight -|= ld_result.lost_bytes;
+                    conn.cc.subBytesInFlight(ld_result.lost_bytes);
                 }
                 // Signal loss events to CC and rewind any affected HTTP/0.9
                 // stream slots so lost data is retransmitted (RFC 9000 §3.3).
@@ -2914,7 +3024,7 @@ pub const Server = struct {
             if (conn.draining) continue;
             // Only probe when there are packets in flight (otherwise there is
             // nothing to recover and no need to elicit an ACK).
-            if (conn.cc.bytes_in_flight == 0) continue;
+            if (conn.cc.getBytesInFlight() == 0) continue;
             // Require at least one ACK to have been received so we have a
             // meaningful RTT estimate; before that, last_ack_ms == 0.
             if (conn.last_ack_ms == 0) continue;
@@ -2928,7 +3038,7 @@ pub const Server = struct {
                 conn.last_pto_ms = now_ms;
                 conn.pto_count +|= 1;
                 dbg("io: PTO probe sent pn={} pto_count={} pto_delay={}ms bif={}\n", .{
-                    conn.app_pn - 1, conn.pto_count, pto_delay, conn.cc.bytes_in_flight,
+                    conn.app_pn - 1, conn.pto_count, pto_delay, conn.cc.getBytesInFlight(),
                 });
             }
         }
@@ -3893,6 +4003,8 @@ pub const ClientConfig = struct {
     migrate: bool = false,
     /// Use QUIC v2 (RFC 9369) for this connection.
     v2: bool = false,
+    /// Use CUBIC congestion control instead of NewReno (RFC 9438).
+    cubic: bool = false,
     /// Directory to write qlog files into.  When non-null, one `<cid>.sqlog`
     /// file is created for the connection.  Set via --qlog-dir on the command line.
     qlog_dir: ?[]const u8 = null,
@@ -3997,6 +4109,9 @@ pub const Client = struct {
             // once the server's v2 Initial is successfully decrypted.
             .use_v2 = false,
         };
+        if (config.cubic) {
+            conn.cc = congestion.CongestionController.init(.cubic);
+        }
         conn.init_keys = InitialSecrets.derive(dcid.slice());
         if (config.v2) {
             // Pre-derive v2 keys so processInitialPacket can detect and handle
@@ -4107,6 +4222,9 @@ pub const Client = struct {
             .remote_cid = dcid,
             .peer = server_addr,
         };
+        if (self.config.cubic) {
+            self.conn.cc = congestion.CongestionController.init(.cubic);
+        }
         self.conn.init_keys = InitialSecrets.derive(dcid.slice());
 
         // Fresh TLS handshake state.


### PR DESCRIPTION
## Summary

Merges perf/v1-remaining into master (PR #86 was merged into fix/v1-polish by mistake).

- **CUBIC congestion control (RFC 9438):** Tagged union `CongestionController` wrapping NewReno and CUBIC, selectable via `cubic: true`
- **Packet coalescing (RFC 9000 §12.2):** Server coalesces Initial + Handshake into single UDP datagram; client parses coalesced datagrams
- **0-RTT replay cache TTL:** NonceCache entries expire after 10 seconds
- **Server push documentation:** Intentional non-support noted in HTTP/3 frame module

## Test plan

- [x] All CI jobs passed on perf/v1-remaining (5/5 including 13/13 interop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)