### PR TITLE
transport, crypto, packet, readme: address reviewer feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ All 13/13 [quic-interop-runner](https://github.com/quic-interop/quic-interop-run
 | `ecn` | ✅ |
 | `rebind-port` | ✅ |
 
+## Implementation notes
+
+- **Version negotiation:** Incoming Version Negotiation packets are handled in `Connection.handleVersionNegotiation` (client must see QUIC v1 in the list). Compatible upgrade to QUIC v2 is implemented in the transport I/O layer when the server’s Initial uses v2 (see `io.zig` and `connection.zig` tests).
+- **Demo `Endpoint` (`src/transport/endpoint.zig`):** `max_connections` is a small fixed array so the struct stays stack-friendly for samples and tests. Integrations that drive the stack via `io.zig` (`initFromSocket`, `feedPacket`, etc.) keep connections in their own maps.
+- **Random bytes:** Connection IDs, stateless reset tokens, and path challenge data use the OS-backed CSPRNG (`std.crypto.random`), not time-seeded PRNGs.
+
 ## Performance
 
 Loopback throughput benchmark on Apple Silicon (M-series Mac), comparing zquic

--- a/src/crypto/aead.zig
+++ b/src/crypto/aead.zig
@@ -152,6 +152,11 @@ pub const HeaderProtection = struct {
 /// Caches the AES key schedule so that `initEnc()` (10-round key expansion)
 /// is performed once at key derivation time rather than on every packet.
 /// On ARM this saves ~40 AES operations per encrypt/decrypt call.
+///
+/// AES-128-GCM is implemented by composing the standard library AES block cipher,
+/// CTR mode, and GHASH — not by calling `Aes128Gcm` directly — so the expanded
+/// key can be reused. That trades a larger audit surface for fewer per-packet
+/// key schedules; the primitives are the usual `std.crypto` building blocks.
 pub const CachedAes128Context = struct {
     const AesEncCtx = @TypeOf(Aes128.initEnc([_]u8{0} ** 16));
     const tag_length = 16;

--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -19,6 +19,7 @@
 
 const std = @import("std");
 const keys = @import("keys.zig");
+const varint = @import("../varint.zig");
 
 /// Maximum bytes we buffer for a single crypto level's send queue.
 pub const send_buf_len = 4096;
@@ -122,14 +123,14 @@ pub fn buildClientTransportParams(out: []u8) usize {
             var w_pos = p;
             // ID varint
             var id_buf: [8]u8 = undefined;
-            const id_enc = encodeVarintLocal(&id_buf, id);
+            const id_enc = varint.encode(&id_buf, id) catch unreachable;
             @memcpy(buf[w_pos .. w_pos + id_enc.len], id_enc);
             w_pos += id_enc.len;
             // Value varint (in a varint-length field)
             var val_buf: [8]u8 = undefined;
-            const val_enc = encodeVarintLocal(&val_buf, val);
+            const val_enc = varint.encode(&val_buf, val) catch unreachable;
             var len_buf: [8]u8 = undefined;
-            const len_enc = encodeVarintLocal(&len_buf, val_enc.len);
+            const len_enc = varint.encode(&len_buf, val_enc.len) catch unreachable;
             @memcpy(buf[w_pos .. w_pos + len_enc.len], len_enc);
             w_pos += len_enc.len;
             @memcpy(buf[w_pos .. w_pos + val_enc.len], val_enc);
@@ -146,25 +147,6 @@ pub fn buildClientTransportParams(out: []u8) usize {
     pos = write_param(out, pos, 0x08, 100); // initial_max_streams_bidi
     pos = write_param(out, pos, 0x09, 100); // initial_max_streams_uni
     return pos;
-}
-
-fn encodeVarintLocal(buf: []u8, v: u64) []const u8 {
-    if (v < 64) {
-        buf[0] = @intCast(v);
-        return buf[0..1];
-    } else if (v < 16384) {
-        const w: u16 = @intCast(v | (0b01 << 14));
-        std.mem.writeInt(u16, buf[0..2], w, .big);
-        return buf[0..2];
-    } else if (v < 1073741824) {
-        const w: u32 = @intCast(v | (@as(u64, 0b10) << 30));
-        std.mem.writeInt(u32, buf[0..4], w, .big);
-        return buf[0..4];
-    } else {
-        const w: u64 = v | (@as(u64, 0b11) << 62);
-        std.mem.writeInt(u64, buf[0..8], w, .big);
-        return buf[0..8];
-    }
 }
 
 /// Tracks CRYPTO stream offsets per encryption level for reassembly.

--- a/src/packet/retry.zig
+++ b/src/packet/retry.zig
@@ -84,10 +84,6 @@ pub fn verifyIntegrityTag(
     odcid: []const u8,
     retry_packet_with_tag: []const u8,
 ) bool {
-    if (retry_packet_with_tag.len < 16) return false;
-    const retry_without_tag = retry_packet_with_tag[0 .. retry_packet_with_tag.len - 16];
-    const received_tag = retry_packet_with_tag[retry_packet_with_tag.len - 16 ..][0..16];
-
     // Extract version from the packet (bytes 1–4 of the long header).
     const version: u32 = if (retry_packet_with_tag.len >= 5)
         (@as(u32, retry_packet_with_tag[1]) << 24) |
@@ -97,9 +93,23 @@ pub fn verifyIntegrityTag(
     else
         0x00000001;
 
+    // Always run tag computation (no early return on short input) so verification
+    // does not short-circuit before the AES-GCM step.
+    const body_len = retry_packet_with_tag.len -| 16;
+    const retry_without_tag = retry_packet_with_tag[0..body_len];
+
+    var received_tag: [16]u8 = [_]u8{0} ** 16;
+    if (retry_packet_with_tag.len >= 16) {
+        @memcpy(&received_tag, retry_packet_with_tag[retry_packet_with_tag.len - 16 ..][0..16]);
+    }
+
     var computed: [16]u8 = undefined;
-    computeIntegrityTagVersion(&computed, odcid, retry_without_tag, version) catch return false;
-    return std.mem.eql(u8, &computed, received_tag);
+    computeIntegrityTagVersion(&computed, odcid, retry_without_tag, version) catch {
+        @memset(&computed, 0);
+    };
+
+    const tags_match = std.crypto.timing_safe.eql([16]u8, computed, received_tag);
+    return tags_match and retry_packet_with_tag.len >= 16;
 }
 
 /// Build a complete Retry packet (including integrity tag) into `buf`.

--- a/src/transport/connection.zig
+++ b/src/transport/connection.zig
@@ -163,6 +163,7 @@ pub const Connection = struct {
 
     /// Retry token received from server (client-side only).
     /// Used in the client's retry-response Initial packet.
+    /// One opaque token; 256 is a conservative max byte length (RFC 9000 does not cap it).
     retry_token: ?[256]u8 = null,
     retry_token_len: usize = 0,
 
@@ -268,8 +269,9 @@ pub const Connection = struct {
 
     /// Handle a received Version Negotiation packet (client-side only).
     ///
-    /// Returns the list of server-supported versions so the caller can decide
-    /// whether to retry with a different version or close.
+    /// Parses the server's supported versions and fails if QUIC v1 is not listed.
+    /// The full client stack also performs compatible version negotiation when
+    /// upgrading to QUIC v2 (see `io.zig`: server Initial handling and v2 key promotion).
     ///
     /// Returns error.WrongRole for server connections.
     /// Returns error.NoCommonVersion if QUIC v1 is absent from the list.
@@ -282,10 +284,6 @@ pub const Connection = struct {
         var it = pkt.versions();
         while (it.next()) |v| {
             if (v == version_neg.QUIC_V1) {
-                // We already support this version; the server should be able to
-                // handle our packets.  In a real implementation the client would
-                // retry the connection with this version.  For now we just
-                // acknowledge that v1 is supported.
                 return;
             }
         }

--- a/src/transport/endpoint.zig
+++ b/src/transport/endpoint.zig
@@ -4,6 +4,12 @@
 //! connections keyed by destination connection ID. New incoming packets
 //! are dispatched to the appropriate connection or trigger creation of a
 //! new server-side connection.
+//!
+//! **Interop / demo only:** this type uses a small fixed-size connection
+//! table (see `max_connections`) so the struct stays stack-friendly.
+//! Production integrations should use the embedder API (`initFromSocket` /
+//! `feedPacket` in `io.zig`) and manage connection tables on the heap with
+//! whatever capacity and eviction policy they need.
 
 const std = @import("std");
 const types = @import("../types.zig");
@@ -15,8 +21,8 @@ const varint = @import("../varint.zig");
 pub const ConnectionId = types.ConnectionId;
 pub const Connection = connection.Connection;
 
-/// Maximum number of concurrent connections per endpoint (kept small to avoid
-/// large stack frames; production code should use heap-allocated connection maps).
+/// Maximum concurrent connections for this demo endpoint (fixed array → predictable
+/// stack size). Not a protocol limit. Embedders using `io.zig` manage their own maps.
 pub const max_connections = 8;
 
 /// The result of processing a received datagram.
@@ -99,8 +105,7 @@ pub const Endpoint = struct {
 
             // Server: create new connection on Initial packet
             if (self.role == .server and lh.header.packet_type == .initial) {
-                var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
-                const local_cid = ConnectionId.random(prng.random(), 8);
+                const local_cid = ConnectionId.random(std.crypto.random, 8);
                 var new_conn = Connection.init(.server, local_cid, dcid);
                 new_conn.deriveInitialKeys(dcid);
                 _ = self.addConnection(new_conn) catch return .discarded;

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1521,8 +1521,7 @@ pub const Server = struct {
     fn newConn(self: *Server, dcid: ConnectionId, scid: ConnectionId, peer: std.net.Address, is_v2: bool) ?*ConnState {
         for (&self.conns) |*slot| {
             if (slot.* == null) {
-                var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
-                const local_cid = ConnectionId.random(prng.random(), 8);
+                const local_cid = ConnectionId.random(std.crypto.random, 8);
                 slot.* = ConnState{
                     .local_cid = local_cid,
                     .remote_cid = scid,
@@ -2347,8 +2346,7 @@ pub const Server = struct {
         // NEW_CONNECTION_ID frame (RFC 9000 §19.15) — give the client an
         // alternative CID to use when it migrates (--migrate mode only).
         if (self.config.migrate) {
-            var prng2 = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp() ^ 0xdeadbeef));
-            const new_cid = ConnectionId.random(prng2.random(), 8);
+            const new_cid = ConnectionId.random(std.crypto.random, 8);
             conn.alt_local_cid = new_cid;
             if (fp + 28 <= frames_buf.len) {
                 frames_buf[fp] = 0x18;
@@ -2364,8 +2362,7 @@ pub const Server = struct {
                 // Generate a random stateless reset token (RFC 9000 §10.3) once
                 // per connection and include it with the NEW_CONNECTION_ID frame.
                 if (!conn.stateless_reset_token_set) {
-                    var prng3 = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp() ^ @as(i64, @intCast(new_cid.slice()[0]))));
-                    prng3.random().bytes(&conn.stateless_reset_token);
+                    std.crypto.random.bytes(&conn.stateless_reset_token);
                     conn.stateless_reset_token_set = true;
                 }
                 @memcpy(frames_buf[fp .. fp + 16], &conn.stateless_reset_token);
@@ -2535,8 +2532,7 @@ pub const Server = struct {
         // rebind, causing a download stall and eventual 60 s timeout.
         if (!addressEqual(conn.peer, src)) {
             var challenge: [8]u8 = undefined;
-            var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
-            prng.random().bytes(&challenge);
+            std.crypto.random.bytes(&challenge);
             // Overwrite any pending challenge — a fresh one is needed for the new path.
             conn.path_challenge_data = challenge;
             // Eagerly update peer so all subsequent sends reach the new address.
@@ -3296,8 +3292,7 @@ pub const Server = struct {
 
     /// Send a NEW_CONNECTION_ID frame offering a fresh alternative CID to the peer.
     fn sendNewConnectionId(self: *Server, conn: *ConnState, seq: u64, dst: std.net.Address) void {
-        var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp() ^ @as(i64, @bitCast(seq))));
-        const new_cid = ConnectionId.random(prng.random(), 8);
+        const new_cid = ConnectionId.random(std.crypto.random, 8);
         conn.alt_local_cid = new_cid;
         conn.alt_local_cid_seq = seq;
         var buf: [32]u8 = undefined;
@@ -3313,8 +3308,7 @@ pub const Server = struct {
         @memcpy(buf[pos .. pos + 8], new_cid.slice());
         pos += 8;
         if (!conn.stateless_reset_token_set) {
-            var prng2 = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
-            prng2.random().bytes(&conn.stateless_reset_token);
+            std.crypto.random.bytes(&conn.stateless_reset_token);
             conn.stateless_reset_token_set = true;
         }
         @memcpy(buf[pos .. pos + 16], &conn.stateless_reset_token);
@@ -4341,9 +4335,8 @@ pub const Client = struct {
         std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.SNDBUF, sk_opt) catch {};
         setupEcnSocket(sock);
 
-        var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
-        const dcid = ConnectionId.random(prng.random(), 8);
-        const scid = ConnectionId.random(prng.random(), 8);
+        const dcid = ConnectionId.random(std.crypto.random, 8);
+        const scid = ConnectionId.random(std.crypto.random, 8);
 
         const tls_client = ClientHandshake.init();
         var conn = ConnState{
@@ -4398,9 +4391,8 @@ pub const Client = struct {
         std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.SNDBUF, sk_opt) catch {};
         setupEcnSocket(sock);
 
-        var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
-        const dcid = ConnectionId.random(prng.random(), 8);
-        const scid = ConnectionId.random(prng.random(), 8);
+        const dcid = ConnectionId.random(std.crypto.random, 8);
+        const scid = ConnectionId.random(std.crypto.random, 8);
 
         const tls_client = ClientHandshake.init();
         var conn = ConnState{
@@ -4592,9 +4584,8 @@ pub const Client = struct {
         std.posix.setsockopt(self.sock, std.posix.SOL.SOCKET, std.posix.SO.SNDBUF, sk_opt) catch {};
 
         // New random connection IDs.
-        var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
-        const dcid = ConnectionId.random(prng.random(), 8);
-        const scid = ConnectionId.random(prng.random(), 8);
+        const dcid = ConnectionId.random(std.crypto.random, 8);
+        const scid = ConnectionId.random(std.crypto.random, 8);
 
         for (&self.raw_app_recv) |*slot| {
             slot.deinit(self.allocator);


### PR DESCRIPTION
## Summary

Addresses external review feedback on zquic:

- **CIDs / tokens / path challenges:** use `std.crypto.random` instead of millisecond-seeded `DefaultPrng` to avoid collisions.
- **QUIC-TLS transport params:** reuse `varint.encode` (remove duplicate `encodeVarintLocal`).
- **Retry integrity:** always compute tag before compare; use `std.crypto.timing_safe.eql` for the 16-byte tag.
- **Docs:** demo `Endpoint` connection cap, `retry_token` buffer meaning, `CachedAes128Context` tradeoff, version negotiation pointers; README implementation notes.

## Testing

`zig build test`