### PR TITLE
security: timing-safe MAC and Finished comparisons (#93)

### DIFF
--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -1107,7 +1107,8 @@ pub const ServerHandshake = struct {
             self.secrets.client_handshake,
             &peekHash(self.transcript),
         );
-        if (!std.mem.eql(u8, verify_data, &expected)) return error.BadFinishedMac;
+        const recv: [32]u8 = verify_data[0..32].*;
+        if (!std.crypto.timing_safe.eql([32]u8, recv, expected)) return error.BadFinishedMac;
 
         self.transcript.update(fin_bytes);
         self.handshake_done = true;
@@ -1296,7 +1297,8 @@ pub const ClientHandshake = struct {
                     );
                     if (msg_len != 32) return error.BadFinishedLength;
                     const vd = msg[4 .. 4 + msg_len];
-                    if (!std.mem.eql(u8, vd, &expected)) return error.BadFinishedMac;
+                    const recv: [32]u8 = vd[0..32].*;
+                    if (!std.crypto.timing_safe.eql([32]u8, recv, expected)) return error.BadFinishedMac;
                     self.transcript.update(msg);
 
                     // Derive app secrets

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1779,7 +1779,9 @@ pub const Server = struct {
         hmac.update(odcid);
         var expected_mac: [32]u8 = undefined;
         hmac.final(&expected_mac);
-        if (!std.mem.eql(u8, received_mac, &expected_mac)) return null;
+        var received: [32]u8 = undefined;
+        @memcpy(&received, received_mac);
+        if (!std.crypto.timing_safe.eql([32]u8, received, expected_mac)) return null;
         return odcid;
     }
 
@@ -2455,7 +2457,9 @@ pub const Server = struct {
                     // the peer is signalling a reset without connection state.
                     if (buf.len >= 21 and conn.stateless_reset_token_set) {
                         const tail = buf[buf.len - 16 ..];
-                        if (std.mem.eql(u8, tail, &conn.stateless_reset_token)) {
+                        var tail_arr: [16]u8 = undefined;
+                        @memcpy(&tail_arr, tail);
+                        if (std.crypto.timing_safe.eql([16]u8, tail_arr, conn.stateless_reset_token)) {
                             dbg("io: Stateless Reset detected — entering draining\n", .{});
                             conn.draining = true;
                             return;


### PR DESCRIPTION
## Summary
Uses `std.crypto.timing_safe.eql` for Retry HMAC verification, stateless reset token tail, and TLS Finished `verify_data` (issue #93).

## Base
Stack **1/5**: compare to `issue-fixes/base-v1.2.2` (tree at v1.2.2 release commit).