### PR TITLE
cleanup: shared constants, TLS ext alias, std.log verbose I/O (#95 #101)

### DIFF
--- a/src/packet/header.zig
+++ b/src/packet/header.zig
@@ -48,7 +48,7 @@ pub const LongType = enum(u2) {
 
 /// Return the 2-bit wire encoding for `pkt_type` given `version`.
 pub fn longTypeBits(pkt_type: LongType, version: u32) u2 {
-    if (version == 0x6b3343cf) { // QUIC v2
+    if (version == @intFromEnum(types.Version.quic_v2)) { // QUIC v2
         return switch (pkt_type) {
             .initial => 1,
             .zero_rtt => 2,
@@ -61,7 +61,7 @@ pub fn longTypeBits(pkt_type: LongType, version: u32) u2 {
 
 /// Return the `LongType` for the given 2-bit wire encoding and `version`.
 pub fn longTypeFromBits(bits: u2, version: u32) LongType {
-    if (version == 0x6b3343cf) { // QUIC v2
+    if (version == @intFromEnum(types.Version.quic_v2)) { // QUIC v2
         return switch (bits) {
             0 => .retry,
             1 => .initial,

--- a/src/packet/retry.zig
+++ b/src/packet/retry.zig
@@ -13,6 +13,7 @@
 //!   ODCID Length (1 byte) + ODCID + Retry packet (without integrity tag)
 
 const std = @import("std");
+const types = @import("../types.zig");
 const aead_mod = @import("../crypto/aead.zig");
 
 /// AES-128-GCM key for QUIC v1 Retry integrity tag (RFC 9001 §5.8).
@@ -60,8 +61,8 @@ pub fn computeIntegrityTagVersion(
     retry_packet: []const u8,
     version: u32,
 ) aead_mod.AeadError!void {
-    const key = if (version == 0x6b3343cf) retry_key_v2 else retry_key;
-    const nonce = if (version == 0x6b3343cf) retry_nonce_v2 else retry_nonce;
+    const key = if (version == @intFromEnum(types.Version.quic_v2)) retry_key_v2 else retry_key;
+    const nonce = if (version == @intFromEnum(types.Version.quic_v2)) retry_nonce_v2 else retry_nonce;
 
     // Build the pseudo-packet: ODCID Length (1 byte) + ODCID + Retry packet
     var pseudo: [512]u8 = undefined;
@@ -130,7 +131,7 @@ pub fn buildRetryPacket(
     // First byte: Header Form=1, Fixed Bit=1, Type=Retry, low nibble=0.
     // v1: Retry type bits = 0b11 → 0xF0
     // v2: Retry type bits = 0b00 → 0xC0  (RFC 9369 §3.1)
-    buf[pos] = if (version == 0x6b3343cf) 0xC0 else 0xF0;
+    buf[pos] = if (version == @intFromEnum(types.Version.quic_v2)) 0xC0 else 0xF0;
     pos += 1;
     std.mem.writeInt(u32, buf[pos..][0..4], version, .big);
     pos += 4;

--- a/src/packet/version_negotiation.zig
+++ b/src/packet/version_negotiation.zig
@@ -13,12 +13,13 @@
 //!   4*K bytes: Supported Versions list (at least one)
 
 const std = @import("std");
+const types = @import("../types.zig");
 
 /// QUIC version 1 (RFC 9000).
-pub const QUIC_V1: u32 = 0x00000001;
+pub const QUIC_V1: u32 = @intFromEnum(types.Version.quic_v1);
 
 /// QUIC version 2 (RFC 9369).
-pub const QUIC_V2: u32 = 0x6b3343cf;
+pub const QUIC_V2: u32 = @intFromEnum(types.Version.quic_v2);
 
 /// Parse error types for Version Negotiation packets.
 pub const ParseError = error{

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -21,6 +21,7 @@
 const std = @import("std");
 const crypto = std.crypto;
 const keys_mod = @import("../crypto/keys.zig");
+const quic_tls = @import("../crypto/quic_tls.zig");
 const tls_vendor = @import("tls");
 
 const Sha256 = crypto.hash.sha2.Sha256;
@@ -45,7 +46,7 @@ pub const EXT_ALPN: u16 = 0x0010;
 pub const EXT_SUPPORTED_GROUPS: u16 = 0x000a;
 pub const EXT_SUPPORTED_VERSIONS: u16 = 0x002b;
 pub const EXT_KEY_SHARE: u16 = 0x0033;
-pub const EXT_QUIC_TRANSPORT_PARAMS: u16 = 0xffa5;
+pub const EXT_QUIC_TRANSPORT_PARAMS: u16 = quic_tls.TRANSPORT_PARAMS_EXT_TYPE;
 pub const EXT_PRE_SHARED_KEY: u16 = 0x0029;
 pub const EXT_PSK_KEY_EXCHANGE_MODES: u16 = 0x002d;
 pub const EXT_EARLY_DATA: u16 = 0x002a;

--- a/src/transport/batch_io.zig
+++ b/src/transport/batch_io.zig
@@ -18,6 +18,7 @@
 //!   for (rb.entries[0..n]) |*e| processPacket(e.buf[0..e.len], e.addr);
 
 const std = @import("std");
+const types = @import("../types.zig");
 const builtin = @import("builtin");
 const is_linux = builtin.os.tag == .linux;
 
@@ -29,7 +30,7 @@ else switch (builtin.target.os.tag) {
     else => 0x40, // Linux
 };
 
-pub const MAX_DATAGRAM_SIZE: usize = 1500;
+pub const MAX_DATAGRAM_SIZE: usize = types.max_datagram_size;
 pub const BATCH_SIZE: usize = 64;
 
 // ── Send batch ────────────────────────────────────────────────────────────────

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -13,6 +13,7 @@
 //!   1-RTT      – AES-128-GCM with keys derived from TLS application_secret
 
 const std = @import("std");
+const log = std.log.scoped(.zquic);
 const packet_mod = @import("../packet/packet.zig");
 const header_mod = @import("../packet/header.zig");
 const varint = @import("../varint.zig");
@@ -41,7 +42,7 @@ const batch_io = @import("batch_io.zig");
 /// Compile-time-eliminated debug logger. With `-Dverbose=true` prints to stderr;
 /// in production builds all calls are removed by the optimizer with zero overhead.
 inline fn dbg(comptime fmt: []const u8, args: anytype) void {
-    if (build_options.verbose) std.debug.print(fmt, args);
+    if (build_options.verbose) log.debug(fmt, args);
 }
 
 const ConnectionId = types.ConnectionId;
@@ -51,8 +52,8 @@ const QuicKeyMaterial = tls_hs.QuicKeyMaterial;
 const ServerHandshake = tls_hs.ServerHandshake;
 const ClientHandshake = tls_hs.ClientHandshake;
 
-const QUIC_VERSION_1: u32 = 0x00000001;
-const QUIC_VERSION_2: u32 = 0x6b3343cf;
+const QUIC_VERSION_1: u32 = @intFromEnum(types.Version.quic_v1);
+const QUIC_VERSION_2: u32 = @intFromEnum(types.Version.quic_v2);
 
 // ── ECN constants (RFC 9000 §13.4) ───────────────────────────────────────────
 // Platform-specific socket option numbers for IP_TOS.
@@ -92,7 +93,10 @@ fn setupEcnSocket(sock: std.posix.fd_t) void {
     );
 }
 pub const MAX_CONNECTIONS: usize = 16;
-pub const MAX_DATAGRAM_SIZE: usize = 1500;
+pub const MAX_DATAGRAM_SIZE: usize = types.max_datagram_size;
+
+/// FIN retransmit attempts before giving up (~3 s at 200 ms intervals).
+const MAX_FIN_RETRANSMITS: usize = 15;
 
 /// Maximum file-data bytes in a single HTTP/0.9 STREAM frame.
 /// The UDP payload must fit within 1472 bytes (1500 MTU − 20 IP − 8 UDP).
@@ -637,8 +641,6 @@ const Http09OutSlot = struct {
     fin_last_sent_ms: i64 = 0,
     fin_retransmit_count: usize = 0,
 
-    const MAX_FIN_RETRANSMITS: usize = 15; // ~3 s at 200 ms intervals
-
     fn close(self: *Http09OutSlot) void {
         if (self.active) {
             self.file.close();
@@ -684,8 +686,6 @@ const Http3OutSlot = struct {
     fin_pkt_pn: u64 = 0,
     fin_last_sent_ms: i64 = 0,
     fin_retransmit_count: usize = 0,
-
-    const MAX_FIN_RETRANSMITS: usize = 15;
 
     fn close(self: *Http3OutSlot) void {
         if (self.active) {
@@ -3225,7 +3225,7 @@ pub const Server = struct {
                     if (!slot.awaiting_fin_ack) continue;
                     if (now - slot.fin_last_sent_ms < 200) continue;
 
-                    if (slot.fin_retransmit_count >= Http09OutSlot.MAX_FIN_RETRANSMITS) {
+                    if (slot.fin_retransmit_count >= MAX_FIN_RETRANSMITS) {
                         dbg("io: stream_id={} FIN retransmit limit reached, giving up\n", .{slot.stream_id});
                         slot.awaiting_fin_ack = false;
                         continue;
@@ -3234,7 +3234,7 @@ pub const Server = struct {
                     slot.fin_retransmit_count += 1;
                     slot.fin_last_sent_ms = now;
                     budget -= 1;
-                    dbg("io: retransmitting FIN for stream_id={} (attempt {}/{})\n", .{ slot.stream_id, slot.fin_retransmit_count, Http09OutSlot.MAX_FIN_RETRANSMITS });
+                    dbg("io: retransmitting FIN for stream_id={} (attempt {}/{})\n", .{ slot.stream_id, slot.fin_retransmit_count, MAX_FIN_RETRANSMITS });
                     self.send1Rtt(conn, slot.fin_frame[0..slot.fin_frame_len], conn.peer);
                 }
             }
@@ -4174,7 +4174,7 @@ pub const Server = struct {
                     if (!slot.awaiting_fin_ack) continue;
                     if (now - slot.fin_last_sent_ms < 200) continue;
 
-                    if (slot.fin_retransmit_count >= Http3OutSlot.MAX_FIN_RETRANSMITS) {
+                    if (slot.fin_retransmit_count >= MAX_FIN_RETRANSMITS) {
                         dbg("io: http3 stream_id={} FIN retransmit limit reached\n", .{slot.stream_id});
                         slot.awaiting_fin_ack = false;
                         continue;
@@ -4182,7 +4182,7 @@ pub const Server = struct {
 
                     slot.fin_retransmit_count += 1;
                     slot.fin_last_sent_ms = now;
-                    dbg("io: http3 retransmit FIN stream_id={} attempt {}/{}\n", .{ slot.stream_id, slot.fin_retransmit_count, Http3OutSlot.MAX_FIN_RETRANSMITS });
+                    dbg("io: http3 retransmit FIN stream_id={} attempt {}/{}\n", .{ slot.stream_id, slot.fin_retransmit_count, MAX_FIN_RETRANSMITS });
                     self.send1Rtt(conn, slot.fin_frame[0..slot.fin_frame_len], conn.peer);
                 }
             }

--- a/src/types.zig
+++ b/src/types.zig
@@ -14,6 +14,9 @@ pub const Version = enum(u32) {
     }
 };
 
+/// Maximum UDP payload size used for buffer sizing (typical Ethernet MTU − IP/UDP).
+pub const max_datagram_size: usize = 1500;
+
 // Connection IDs are 0–20 bytes in QUIC v1 (RFC 9000 §17.2)
 pub const max_cid_len = 20;
 


### PR DESCRIPTION
## Summary
- `types.max_datagram_size`, QUIC version via `types.Version`, single FIN retransmit constant, `EXT_QUIC_TRANSPORT_PARAMS` → `quic_tls.TRANSPORT_PARAMS_EXT_TYPE` (#95)
- Verbose `io` path uses `std.log.scoped(.zquic)` instead of `std.debug.print` (#101)

## Base
Stack **3/5**: on top of MAX_STREAMS branch.