### PR TITLE
fix: varint lengths to usize, fallible transport params (#94 #99)

### DIFF
--- a/src/crypto/aead.zig
+++ b/src/crypto/aead.zig
@@ -191,6 +191,7 @@ pub const CachedAes128Context = struct {
         aes.encrypt(&t, &j);
 
         const ct = dst[0..plaintext.len];
+        // Divisor is the 16-byte GHASH block (non-zero); divCeil only fails if divisor is 0.
         const block_count = (std.math.divCeil(usize, aad.len, Ghash.block_length) catch unreachable) +
             (std.math.divCeil(usize, ct.len, Ghash.block_length) catch unreachable) + 1;
         var mac = Ghash.initForBlockCount(&h, block_count);
@@ -238,6 +239,7 @@ pub const CachedAes128Context = struct {
         std.mem.writeInt(u32, j[nonce_length..][0..4], 1, .big);
         aes.encrypt(&t, &j);
 
+        // Ghash.block_length is 16; divCeil only fails on divisor 0.
         const block_count = (std.math.divCeil(usize, aad.len, Ghash.block_length) catch unreachable) +
             (std.math.divCeil(usize, ct.len, Ghash.block_length) catch unreachable) + 1;
         var mac = Ghash.initForBlockCount(&h, block_count);

--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -112,25 +112,25 @@ pub const TRANSPORT_PARAMS_EXT_TYPE: u16 = 0xffa5;
 
 /// Build a minimal QUIC transport parameters extension for the client.
 /// Returns bytes written to `out`.
-pub fn buildClientTransportParams(out: []u8) usize {
+pub fn buildClientTransportParams(out: []u8) (varint.EncodeError || varint.DecodeError)!usize {
     // Transport parameters (also used in Encrypted Extensions for the server role).
     // Flow-control limits must cover interop "transfer" (multi-megabyte files on
     // several client-initiated bidirectional streams at once).
     var pos: usize = 0;
 
     const write_param = struct {
-        fn call(buf: []u8, p: usize, id: u64, val: u64) usize {
+        fn call(buf: []u8, p: usize, id: u64, val: u64) (varint.EncodeError || varint.DecodeError)!usize {
             var w_pos = p;
             // ID varint
             var id_buf: [8]u8 = undefined;
-            const id_enc = varint.encode(&id_buf, id) catch unreachable;
+            const id_enc = try varint.encode(&id_buf, id);
             @memcpy(buf[w_pos .. w_pos + id_enc.len], id_enc);
             w_pos += id_enc.len;
             // Value varint (in a varint-length field)
             var val_buf: [8]u8 = undefined;
-            const val_enc = varint.encode(&val_buf, val) catch unreachable;
+            const val_enc = try varint.encode(&val_buf, val);
             var len_buf: [8]u8 = undefined;
-            const len_enc = varint.encode(&len_buf, val_enc.len) catch unreachable;
+            const len_enc = try varint.encode(&len_buf, val_enc.len);
             @memcpy(buf[w_pos .. w_pos + len_enc.len], len_enc);
             w_pos += len_enc.len;
             @memcpy(buf[w_pos .. w_pos + val_enc.len], val_enc);
@@ -139,13 +139,13 @@ pub fn buildClientTransportParams(out: []u8) usize {
         }
     }.call;
 
-    pos = write_param(out, pos, 0x01, 30_000); // max_idle_timeout
-    pos = write_param(out, pos, 0x04, 67_108_864); // initial_max_data (64 MiB)
-    pos = write_param(out, pos, 0x05, 16_777_216); // initial_max_stream_data_bidi_local (16 MiB)
-    pos = write_param(out, pos, 0x06, 16_777_216); // initial_max_stream_data_bidi_remote (16 MiB)
-    pos = write_param(out, pos, 0x07, 16_777_216); // initial_max_stream_data_uni (16 MiB)
-    pos = write_param(out, pos, 0x08, 100); // initial_max_streams_bidi
-    pos = write_param(out, pos, 0x09, 100); // initial_max_streams_uni
+    pos = try write_param(out, pos, 0x01, 30_000); // max_idle_timeout
+    pos = try write_param(out, pos, 0x04, 67_108_864); // initial_max_data (64 MiB)
+    pos = try write_param(out, pos, 0x05, 16_777_216); // initial_max_stream_data_bidi_local (16 MiB)
+    pos = try write_param(out, pos, 0x06, 16_777_216); // initial_max_stream_data_bidi_remote (16 MiB)
+    pos = try write_param(out, pos, 0x07, 16_777_216); // initial_max_stream_data_uni (16 MiB)
+    pos = try write_param(out, pos, 0x08, 100); // initial_max_streams_bidi
+    pos = try write_param(out, pos, 0x09, 100); // initial_max_streams_uni
     return pos;
 }
 
@@ -312,7 +312,7 @@ test "wrap_strip: record round-trip" {
 
 test "transport_params: builds non-empty" {
     var buf: [256]u8 = undefined;
-    const n = buildClientTransportParams(&buf);
+    const n = try buildClientTransportParams(&buf);
     try std.testing.expect(n > 0);
 }
 

--- a/src/frames/crypto_frame.zig
+++ b/src/frames/crypto_frame.zig
@@ -23,7 +23,8 @@ pub const CryptoFrame = struct {
         var r = varint.Reader.init(buf);
         const offset = try r.readVarint();
         const length = try r.readVarint();
-        const data = try r.readBytes(@intCast(length));
+        const len_usize = try varint.lenToUsize(length);
+        const data = try r.readBytes(len_usize);
         return .{
             .frame = .{ .offset = offset, .data = data },
             .consumed = r.pos,

--- a/src/frames/stream.zig
+++ b/src/frames/stream.zig
@@ -37,7 +37,8 @@ pub const StreamFrame = struct {
 
         const data: []const u8 = if (has_length) blk: {
             const length = try r.readVarint();
-            break :blk try r.readBytes(@intCast(length));
+            const len_usize = try varint.lenToUsize(length);
+            break :blk try r.readBytes(len_usize);
         } else blk: {
             // Data extends to the end of the packet payload.
             break :blk r.buf[r.pos..];

--- a/src/frames/transport.zig
+++ b/src/frames/transport.zig
@@ -52,7 +52,8 @@ pub const NewToken = struct {
     pub fn parse(buf: []const u8) varint.DecodeError!struct { frame: NewToken, consumed: usize } {
         var r = varint.Reader.init(buf);
         const len = try r.readVarint();
-        const token = try r.readBytes(@intCast(len));
+        const len_usize = try varint.lenToUsize(len);
+        const token = try r.readBytes(len_usize);
         return .{ .frame = .{ .token = token }, .consumed = r.pos };
     }
 };
@@ -180,7 +181,8 @@ pub const ConnectionClose = struct {
         const code = try r.readVarint();
         const ft: u64 = if (!is_app) try r.readVarint() else 0;
         const reason_len = try r.readVarint();
-        const reason = try r.readBytes(@intCast(reason_len));
+        const reason_usize = try varint.lenToUsize(reason_len);
+        const reason = try r.readBytes(reason_usize);
         return .{
             .frame = .{
                 .is_application = is_app,

--- a/src/packet/version_negotiation.zig
+++ b/src/packet/version_negotiation.zig
@@ -101,7 +101,8 @@ pub fn build(
     dcid: []const u8,
     scid: []const u8,
     supported_versions: []const u32,
-) error{BufferTooSmall}!usize {
+) error{ BufferTooSmall, InvalidCidLength }!usize {
+    if (dcid.len > types.max_cid_len or scid.len > types.max_cid_len) return error.InvalidCidLength;
     const needed = 1 + 4 + 1 + dcid.len + 1 + scid.len + 4 * supported_versions.len;
     if (buf.len < needed) return error.BufferTooSmall;
 

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1935,7 +1935,10 @@ pub const Server = struct {
         // Append original_destination_connection_id (id=0x00) when a Retry was
         // accepted — RFC 9000 §7.3 requires it so the client can verify.
         var tp_buf: [512]u8 = undefined;
-        var tp_len = quic_tls_mod.buildClientTransportParams(&tp_buf);
+        var tp_len = quic_tls_mod.buildClientTransportParams(&tp_buf) catch |err| {
+            dbg("io: transport params encode failed: {}\n", .{err});
+            return;
+        };
         if (conn.retry_odcid_len > 0) {
             const odcid = conn.retry_odcid[0..conn.retry_odcid_len];
             // Encode: id=0x00 (1 byte) | length varint (1 byte) | odcid bytes
@@ -4835,7 +4838,7 @@ pub const Client = struct {
             // First send: build the ClientHello and save it for any future rebuild.
             const alpn = clientTlsAlpn(&self.config);
             var quic_tp_buf: [128]u8 = undefined;
-            const quic_tp = buildClientTransportParams(&quic_tp_buf);
+            const quic_tp = try buildClientTransportParams(&quic_tp_buf);
 
             // Choose ClientHello variant based on flags.
             const now_ms: u64 = @intCast(std.time.milliTimestamp());
@@ -6381,8 +6384,8 @@ inline fn readU24(b: []const u8) u32 {
     return (@as(u32, b[0]) << 16) | (@as(u32, b[1]) << 8) | @as(u32, b[2]);
 }
 
-fn buildClientTransportParams(buf: []u8) []const u8 {
-    const n = quic_tls_mod.buildClientTransportParams(buf);
+fn buildClientTransportParams(buf: []u8) (varint.EncodeError || varint.DecodeError)![]const u8 {
+    const n = try quic_tls_mod.buildClientTransportParams(buf);
     return buf[0..n];
 }
 

--- a/src/varint.zig
+++ b/src/varint.zig
@@ -11,7 +11,13 @@ const std = @import("std");
 pub const max_value: u64 = (1 << 62) - 1;
 
 pub const EncodeError = error{ValueTooLarge};
-pub const DecodeError = error{BufferTooShort};
+pub const DecodeError = error{ BufferTooShort, VarintLengthTooLarge };
+
+/// Cast a varint-decoded length to `usize` without silent truncation on small usize targets.
+pub fn lenToUsize(len: u64) DecodeError!usize {
+    if (len > std.math.maxInt(usize)) return error.VarintLengthTooLarge;
+    return @intCast(len);
+}
 
 /// Returns the number of bytes needed to encode `v`.
 pub fn encodedLen(v: u64) u4 {


### PR DESCRIPTION
## Summary
- `varint.lenToUsize` / `VarintLengthTooLarge` for frame parsers; VN build CID length check (#94)
- `buildClientTransportParams` propagates varint errors; GHASH `divCeil` comments (#99)

## Base
Stack **4/5**: on top of constants/logging branch.