### PR TITLE
Stream state machine (#97) and configurable path MTU (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`transport/path_mtu.zig`:** clamp configured max UDP payload (RFC 9000 §14.1)
+  and derive per-connection `app_stream_chunk` for HTTP/0.9 and HTTP/3 sends.
+- **`ServerConfig` / `ClientConfig`:** optional `max_udp_payload`; **`ConnState`**
+  fields `max_udp_payload` and `app_stream_chunk`.
+
+### Changed
+
+- **`stream_manager.zig`:** explicit stream state transitions; **`onRecvReset`**
+  and **`StreamManager.onResetStreamFrame`** for RESET_STREAM final-size rules.
+
 ---
 
 ## [v1.3.0] - 2026-04-14

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All 13/13 [quic-interop-runner](https://github.com/quic-interop/quic-interop-run
 - **Version negotiation:** Incoming Version Negotiation packets are handled in `Connection.handleVersionNegotiation` (client must see QUIC v1 in the list). Compatible upgrade to QUIC v2 is implemented in the transport I/O layer when the server’s Initial uses v2 (see `io.zig` and `connection.zig` tests).
 - **Demo `Endpoint` (`src/transport/endpoint.zig`):** `max_connections` is a small fixed array so the struct stays stack-friendly for samples and tests. Integrations that drive the stack via `io.zig` (`initFromSocket`, `feedPacket`, etc.) keep connections in their own maps.
 - **Random bytes:** Connection IDs, stateless reset tokens, and path challenge data use the OS-backed CSPRNG (`std.crypto.random`), not time-seeded PRNGs.
-- **Path MTU discovery (RFC 9000 §14):** not implemented. Datagrams use a fixed ~1500-byte UDP payload budget; paths with a lower MTU may need tuning.
+- **Path MTU (RFC 9000 §14):** DPLPMTUD probing is not implemented. You can set `max_udp_payload` on `ServerConfig` / `ClientConfig`; the stack clamps it to \[1200, 65527\] bytes and sizes HTTP/0.9 and HTTP/3 STREAM chunks from that limit (see `transport/path_mtu.zig`).
 
 ## Performance
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -39,6 +39,7 @@ pub const transport = struct {
     pub const stream_manager = @import("transport/stream_manager.zig");
     pub const migration = @import("transport/migration.zig");
     pub const io = @import("transport/io.zig");
+    pub const path_mtu = @import("transport/path_mtu.zig");
 };
 pub const http3 = struct {
     pub const frame = @import("http3/frame.zig");
@@ -83,6 +84,7 @@ test {
     _ = @import("transport/stream_manager.zig");
     _ = @import("transport/migration.zig");
     _ = @import("transport/io.zig");
+    _ = @import("transport/path_mtu.zig");
     _ = @import("http3/frame.zig");
     _ = @import("http3/qpack.zig");
     _ = @import("http09/server.zig");

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -4097,8 +4097,8 @@ pub const Server = struct {
             return;
         }
 
-        // Wrap the chunk in an HTTP/3 DATA frame.
-        var data_out: [CHUNK + 16]u8 = undefined;
+        // Wrap the chunk in an HTTP/3 DATA frame (buffer size is comptime; payload ≤ max_app_stream_chunk_cap).
+        var data_out: [path_mtu_mod.max_app_stream_chunk_cap + 32]u8 = undefined;
         const data_frame_len = h3_frame.writeFrame(&data_out, @intFromEnum(h3_frame.FrameType.data), file_buf[0..n]) catch {
             if (conn.http3_active_count > 0) conn.http3_active_count -= 1;
             slot.close();

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -38,6 +38,8 @@ const congestion = @import("../loss/congestion.zig");
 const recovery = @import("../loss/recovery.zig");
 const build_options = @import("build_options");
 const batch_io = @import("batch_io.zig");
+const path_mtu_mod = @import("path_mtu.zig");
+const default_conn_path_mtu = path_mtu_mod.initFromConfig(null);
 
 /// Compile-time-eliminated debug logger. With `-Dverbose=true` prints to stderr;
 /// in production builds all calls are removed by the optimizer with zero overhead.
@@ -98,20 +100,8 @@ pub const MAX_DATAGRAM_SIZE: usize = types.max_datagram_size;
 /// FIN retransmit attempts before giving up (~3 s at 200 ms intervals).
 const MAX_FIN_RETRANSMITS: usize = 15;
 
-/// Maximum file-data bytes in a single HTTP/0.9 STREAM frame.
-/// The UDP payload must fit within 1472 bytes (1500 MTU − 20 IP − 8 UDP).
-/// 1350 data + ~11 STREAM header + ~10 1-RTT header + 16 AEAD tag ≈ 1387, well within 1472.
-const H09_CHUNK: usize = 1350;
-
-/// Maximum file-data bytes in a single HTTP/3 DATA frame.
-/// 1350 data + 3 H3 overhead + ~11 STREAM header + ~10 1-RTT header + 16 AEAD tag ≈ 1390, within 1472.
-const H3_CHUNK: usize = 1350;
-
 /// H3 DATA frame overhead: 1 byte type (0x00) + 2 byte varint length.
 const H3_DATA_OVERHEAD: usize = 3;
-
-/// Total QUIC stream bytes per H3 DATA frame (payload + framing overhead).
-const H3_CHUNK_WIRE: usize = H3_CHUNK + H3_DATA_OVERHEAD;
 
 /// MSG_DONTWAIT flag for non-blocking recvfrom().
 /// std.posix.MSG is void on some platforms (macOS/Zig 0.14), so use raw values.
@@ -771,6 +761,11 @@ pub const ConnState = struct {
     // Peer UDP address
     peer: std.net.Address,
 
+    /// Clamped UDP payload limit for this path (RFC 9000 §14). Drives `app_stream_chunk`.
+    max_udp_payload: u16 = default_conn_path_mtu.max_udp_payload,
+    /// Largest HTTP/0.9 or HTTP/3 file read per STREAM frame (from `max_udp_payload`).
+    app_stream_chunk: usize = default_conn_path_mtu.app_stream_chunk,
+
     // Initial packet keys (derived from DCID)
     init_keys: ?InitialSecrets = null,
 
@@ -1078,6 +1073,8 @@ pub const ServerConfig = struct {
     /// Deliver incoming STREAM frames to `RawAppStreamSlot` buffers instead of
     /// parsing HTTP/0.9 or HTTP/3. Typically combined with `alpn`.
     raw_application_streams: bool = false,
+    /// Maximum UDP payload (bytes) for path sizing (RFC 9000 §14.1). When null, uses ~Ethernet MTU.
+    max_udp_payload: ?u16 = null,
 };
 
 /// TLS ALPN value for `ServerConfig` (custom string wins over HTTP flags).
@@ -1537,6 +1534,9 @@ pub const Server = struct {
                     .next_local_bidi_stream_id = 1,
                 };
                 const conn = &(slot.*.?);
+                const pm = path_mtu_mod.initFromConfig(self.config.max_udp_payload);
+                conn.max_udp_payload = pm.max_udp_payload;
+                conn.app_stream_chunk = pm.app_stream_chunk;
                 if (self.config.cubic) {
                     conn.cc = congestion.CongestionController.init(.cubic);
                 }
@@ -2558,7 +2558,8 @@ pub const Server = struct {
             // of data so the retransmission always starts before the gap.
             // The client writes at explicit sf.offset so duplicate retransmits
             // are idempotent (seekTo + writeAll overwrites the same bytes).
-            const REWIND_BYTES: u64 = 200 * H09_CHUNK;
+            const REWIND_BYTES: u64 = 200 * @as(u64, @intCast(conn.app_stream_chunk));
+            const chunk = conn.app_stream_chunk;
             for (&conn.http09_slots) |*slot| {
                 if (slot.active) {
                     // Active slot: rewind to re-send data that went to the dead port.
@@ -2576,8 +2577,8 @@ pub const Server = struct {
                     // reached the client on the old path.  Reopen the file and
                     // re-activate so flushPendingHttp09Responses re-sends everything.
                     const fp = slot.file_path[0..slot.file_path_len];
-                    const rewind_to: u64 = if (slot.fin_pkt_pn > REWIND_BYTES / H09_CHUNK)
-                        (slot.fin_pkt_pn - REWIND_BYTES / H09_CHUNK) * H09_CHUNK
+                    const rewind_to: u64 = if (slot.fin_pkt_pn > REWIND_BYTES / chunk)
+                        (slot.fin_pkt_pn - REWIND_BYTES / chunk) * chunk
                     else
                         0;
                     if (std.fs.openFileAbsolute(fp, .{})) |f| {
@@ -2723,16 +2724,17 @@ pub const Server = struct {
                         }
                         // HTTP/3 slots: stream_offset is the QUIC stream offset.
                         // Derive file offset from QUIC stream offset and DATA frame
-                        // overhead: each H3_CHUNK-byte chunk is wrapped in a 3-byte
+                        // overhead: each `app_stream_chunk` bytes of file data is wrapped in a 3-byte
                         // DATA frame header (type 0x00 + 2-byte varint length).
                         for (&conn.http3_slots) |*slot| {
                             if (slot.stream_id != lp.stream_id) continue;
                             if (lp.stream_offset < slot.stream_offset) {
                                 const data_bytes = lp.stream_offset -| slot.stream_offset_base;
-                                // Each full chunk contributes H3_CHUNK_WIRE QUIC stream bytes.
-                                const full_chunks = data_bytes / H3_CHUNK_WIRE;
-                                const partial_quic = data_bytes % H3_CHUNK_WIRE;
-                                const file_pos = full_chunks * H3_CHUNK + if (partial_quic > H3_DATA_OVERHEAD) partial_quic - H3_DATA_OVERHEAD else 0;
+                                const h3_chunk_wire = conn.app_stream_chunk + H3_DATA_OVERHEAD;
+                                // Each full chunk contributes (app_stream_chunk + H3 overhead) QUIC stream bytes.
+                                const full_chunks = data_bytes / h3_chunk_wire;
+                                const partial_quic = data_bytes % h3_chunk_wire;
+                                const file_pos = full_chunks * conn.app_stream_chunk + if (partial_quic > H3_DATA_OVERHEAD) partial_quic - H3_DATA_OVERHEAD else 0;
                                 if (slot.active) {
                                     slot.stream_offset = lp.stream_offset;
                                     slot.file_offset = file_pos;
@@ -3048,8 +3050,9 @@ pub const Server = struct {
 
     /// Send the next STREAM chunk for one queued HTTP/0.9 response.
     fn http09SendNextChunk(self: *Server, conn: *ConnState, slot: *Http09OutSlot) void {
-        var file_buf: [H09_CHUNK]u8 = undefined;
-        const n = slot.file.read(&file_buf) catch |err| {
+        var file_buf: [path_mtu_mod.max_app_stream_chunk_cap]u8 = undefined;
+        const to_read = @min(conn.app_stream_chunk, file_buf.len);
+        const n = slot.file.read(file_buf[0..to_read]) catch |err| {
             dbg("io: http09 stream_id={} read error: {}\n", .{ slot.stream_id, err });
             if (conn.http09_active_count > 0) conn.http09_active_count -= 1;
             slot.close();
@@ -4028,12 +4031,10 @@ pub const Server = struct {
 
     /// Send the next HTTP/3 DATA-frame chunk for one queued response slot.
     fn http3SendNextChunk(self: *Server, conn: *ConnState, slot: *Http3OutSlot) void {
-        // Wrap up to H3_CHUNK bytes of file content in an HTTP/3 DATA frame.
-        // DATA frame overhead is 2-3 bytes (type=0x00 + varint length),
-        // so the total STREAM payload fits well within one 1500-byte UDP datagram.
-        const CHUNK = H3_CHUNK;
-        var file_buf: [CHUNK]u8 = undefined;
-        const n = slot.file.read(&file_buf) catch |err| {
+        // Wrap file content in an HTTP/3 DATA frame (type=0x00 + varint length + payload).
+        const CHUNK = @min(conn.app_stream_chunk, path_mtu_mod.max_app_stream_chunk_cap);
+        var file_buf: [path_mtu_mod.max_app_stream_chunk_cap]u8 = undefined;
+        const n = slot.file.read(file_buf[0..CHUNK]) catch |err| {
             dbg("io: http3 stream_id={} read error: {}\n", .{ slot.stream_id, err });
             if (conn.http3_active_count > 0) conn.http3_active_count -= 1;
             slot.close();
@@ -4219,6 +4220,8 @@ pub const ClientConfig = struct {
     alpn: ?[]const u8 = null,
     /// Buffer server→client STREAM data as opaque bytes (no HTTP parsing).
     raw_application_streams: bool = false,
+    /// Maximum UDP payload (bytes) for path sizing (RFC 9000 §14.1). When null, uses ~Ethernet MTU.
+    max_udp_payload: ?u16 = null,
 };
 
 /// TLS ALPN value for `ClientConfig`.
@@ -4391,6 +4394,9 @@ pub const Client = struct {
         if (config.cubic) {
             conn.cc = congestion.CongestionController.init(.cubic);
         }
+        const pm = path_mtu_mod.initFromConfig(config.max_udp_payload);
+        conn.max_udp_payload = pm.max_udp_payload;
+        conn.app_stream_chunk = pm.app_stream_chunk;
         conn.init_keys = InitialSecrets.derive(dcid.slice());
         if (config.v2) {
             // Pre-derive v2 keys so processInitialPacket can detect and handle
@@ -4444,6 +4450,9 @@ pub const Client = struct {
         if (config.cubic) {
             conn.cc = congestion.CongestionController.init(.cubic);
         }
+        const pm = path_mtu_mod.initFromConfig(config.max_udp_payload);
+        conn.max_udp_payload = pm.max_udp_payload;
+        conn.app_stream_chunk = pm.app_stream_chunk;
         conn.init_keys = InitialSecrets.derive(dcid.slice());
         if (config.v2) {
             conn.v2_upgrade_keys = InitialSecrets.deriveV2(dcid.slice());
@@ -4642,6 +4651,9 @@ pub const Client = struct {
         if (self.config.cubic) {
             self.conn.cc = congestion.CongestionController.init(.cubic);
         }
+        const pm = path_mtu_mod.initFromConfig(self.config.max_udp_payload);
+        self.conn.max_udp_payload = pm.max_udp_payload;
+        self.conn.app_stream_chunk = pm.app_stream_chunk;
         self.conn.init_keys = InitialSecrets.derive(dcid.slice());
 
         // Fresh TLS handshake state.

--- a/src/transport/path_mtu.zig
+++ b/src/transport/path_mtu.zig
@@ -1,0 +1,47 @@
+//! Path MTU limits for QUIC datagrams (RFC 9000 §14).
+//!
+//! Full DPLPMTUD (probing, ICMP, black-hole detection) is not implemented yet.
+//! This module clamps a configured maximum UDP payload and derives the largest
+//! application chunk size that still fits under typical 1-RTT + STREAM headers.
+
+const std = @import("std");
+const types = @import("../types.zig");
+
+/// Conservative overhead below `max_udp_payload` for 1-RTT short header + STREAM + AEAD tag.
+const quic_stream_overhead: usize = 150;
+
+/// Cap on per-chunk app data so fixed stack buffers in `io.zig` stay bounded.
+pub const max_app_stream_chunk_cap: usize = types.max_datagram_size - 64;
+
+/// Clamp user/configured max UDP payload to RFC 9000 §14.1 minimum and RFC max UDP payload.
+pub fn clampMaxUdpPayload(requested: u16) u16 {
+    const lo: u16 = @intCast(types.min_initial_mtu);
+    const hi: u16 = @truncate(types.max_udp_payload_size);
+    return std.math.clamp(requested, lo, hi);
+}
+
+/// Largest HTTP/0.9 or HTTP/3 DATA chunk (bytes of file/content) per QUIC STREAM frame.
+pub fn appStreamChunkBytes(max_udp_payload: u16) usize {
+    const up = @as(usize, max_udp_payload);
+    const raw = @max(400, up -| quic_stream_overhead);
+    return @min(raw, max_app_stream_chunk_cap);
+}
+
+/// Result for initializing `ConnState` path fields from optional config.
+pub fn initFromConfig(max_udp_payload_opt: ?u16) struct { max_udp_payload: u16, app_stream_chunk: usize } {
+    const requested: u16 = max_udp_payload_opt orelse @as(u16, @truncate(types.max_datagram_size));
+    const max_udp_payload = clampMaxUdpPayload(requested);
+    return .{
+        .max_udp_payload = max_udp_payload,
+        .app_stream_chunk = appStreamChunkBytes(max_udp_payload),
+    };
+}
+
+test "path_mtu: clamp and chunk" {
+    const t = std.testing;
+    try t.expectEqual(@as(u16, 1200), clampMaxUdpPayload(1000));
+    try t.expectEqual(@as(u16, 1500), clampMaxUdpPayload(1500));
+    try t.expect(appStreamChunkBytes(1500) >= 1300);
+    try t.expectEqual(@as(usize, 1050), appStreamChunkBytes(1200));
+    try t.expect(appStreamChunkBytes(65527) <= max_app_stream_chunk_cap);
+}

--- a/src/transport/stream_manager.zig
+++ b/src/transport/stream_manager.zig
@@ -7,6 +7,7 @@
 //! Each stream has a state machine:
 //!   Idle → Open → Half-Closed (local) → Closed
 //!             └─→ Half-Closed (remote) ┘
+//!             └─→ Reset (sent/received)
 
 const std = @import("std");
 const types = @import("../types.zig");
@@ -28,6 +29,8 @@ pub const StreamState = enum {
     reset_received,
 };
 
+pub const StreamStateError = error{InvalidStreamState};
+
 /// A single QUIC stream.
 pub const Stream = struct {
     id: StreamId,
@@ -45,9 +48,9 @@ pub const Stream = struct {
     send_offset: u64 = 0,
     /// True if the local side sent FIN.
     fin_sent: bool = false,
-    /// True if the remote side sent FIN.
+    /// True if the remote side sent FIN or final size is known from RESET.
     fin_received: bool = false,
-    /// Final size (if fin_received).
+    /// Final size (RFC 9000 §19.4): agreed cumulative byte count for the stream.
     fin_size: u64 = 0,
 
     pub fn init(id: StreamId, send_max: u64, recv_max: u64) Stream {
@@ -57,9 +60,37 @@ pub const Stream = struct {
         };
     }
 
+    pub fn transitionAllowed(from: StreamState, to: StreamState) bool {
+        if (from == to) return true;
+        return switch (from) {
+            .idle => to == .open,
+            .open => switch (to) {
+                .half_closed_local, .half_closed_remote, .closed, .reset_sent, .reset_received => true,
+                else => false,
+            },
+            .half_closed_local => switch (to) {
+                .closed, .reset_received => true,
+                else => false,
+            },
+            .half_closed_remote => switch (to) {
+                .closed, .reset_received => true,
+                else => false,
+            },
+            .closed, .reset_sent, .reset_received => false,
+        };
+    }
+
+    fn setState(self: *Stream, next: StreamState) StreamStateError!void {
+        if (!transitionAllowed(self.state, next)) return error.InvalidStreamState;
+        self.state = next;
+    }
+
     /// Write `data` into the receive buffer. Returns false on flow control
-    /// violation or out-of-order data that doesn't fit in the buffer.
+    /// violation, invalid state, or out-of-order data that doesn't fit in the buffer.
     pub fn onRecvData(self: *Stream, offset: u64, data: []const u8, fin: bool) bool {
+        if (self.state == .closed or self.state == .reset_received or self.state == .reset_sent)
+            return false;
+
         if (!self.fc.onReceive(offset, data.len)) return false;
 
         // Accept only in-order data for simplicity.
@@ -77,12 +108,24 @@ pub const Stream = struct {
             if (self.fin_received and new_fin_size != self.fin_size) return false;
             self.fin_received = true;
             self.fin_size = new_fin_size;
-            if (self.state == .half_closed_local) {
-                self.state = .closed;
-            } else {
-                self.state = .half_closed_remote;
-            }
+            const next: StreamState = if (self.state == .half_closed_local) .closed else .half_closed_remote;
+            self.setState(next) catch return false;
         }
+        return true;
+    }
+
+    /// Remote RESET_STREAM (RFC 9000 §19.4). `final_size` must match any prior FIN.
+    pub fn onRecvReset(self: *Stream, final_size: u64) bool {
+        if (self.state == .closed) {
+            return final_size == self.fin_size;
+        }
+        if (self.state == .reset_received) {
+            return final_size == self.fin_size;
+        }
+        if (self.fin_received and final_size != self.fin_size) return false;
+        self.fin_received = true;
+        self.fin_size = final_size;
+        self.setState(.reset_received) catch return false;
         return true;
     }
 
@@ -102,13 +145,11 @@ pub const Stream = struct {
 
     /// Mark local side as finished (FIN will be sent in next STREAM frame).
     pub fn closeLocal(self: *Stream) void {
-        if (self.state == .closed or self.state == .reset_sent) return;
+        if (self.state == .closed or self.state == .reset_sent or self.state == .reset_received)
+            return;
         self.fin_sent = true;
-        if (self.state == .half_closed_remote) {
-            self.state = .closed;
-        } else {
-            self.state = .half_closed_local;
-        }
+        const next: StreamState = if (self.state == .half_closed_remote) .closed else .half_closed_local;
+        self.setState(next) catch return;
     }
 };
 
@@ -191,6 +232,18 @@ pub const StreamManager = struct {
         }
         return false;
     }
+
+    /// Process an incoming RESET_STREAM frame (RFC 9000 §19.4).
+    pub fn onResetStreamFrame(self: *StreamManager, f: frames.ResetStream) bool {
+        const sid = StreamId.init(@intCast(f.stream_id));
+        if (self.findStream(sid)) |s| {
+            return s.onRecvReset(f.final_size);
+        }
+        if (self.allocStream(sid)) |s| {
+            return s.onRecvReset(f.final_size);
+        }
+        return false;
+    }
 };
 
 test "stream: basic read/write" {
@@ -206,6 +259,45 @@ test "stream: basic read/write" {
     const n = s.read(&out);
     try testing.expectEqualSlices(u8, "hello world", out[0..n]);
     try testing.expect(s.fin_received);
+}
+
+test "stream: FIN final size mismatch" {
+    const testing = std.testing;
+    const sid = StreamId.init(0);
+    var s = Stream.init(sid, 100_000, 100_000);
+    s.state = .open;
+    try testing.expect(s.onRecvData(0, "ab", true));
+    try testing.expect(!s.onRecvData(0, "abc", true));
+}
+
+test "stream: RESET matches FIN final size" {
+    const testing = std.testing;
+    const sid = StreamId.init(0);
+    var s = Stream.init(sid, 100_000, 100_000);
+    s.state = .open;
+    try testing.expect(s.onRecvData(0, "x", true));
+    try testing.expect(s.onRecvReset(1));
+    try testing.expect(s.state == .reset_received);
+}
+
+test "stream: RESET conflicts with FIN size" {
+    const testing = std.testing;
+    const sid = StreamId.init(0);
+    var s = Stream.init(sid, 100_000, 100_000);
+    s.state = .open;
+    try testing.expect(s.onRecvData(0, "x", true));
+    try testing.expect(!s.onRecvReset(99));
+}
+
+test "stream: closeLocal transitions" {
+    const testing = std.testing;
+    const sid = StreamId.init(0);
+    var s = Stream.init(sid, 100_000, 100_000);
+    s.state = .open;
+    s.closeLocal();
+    try testing.expect(s.state == .half_closed_local);
+    try testing.expect(s.onRecvData(0, "a", true));
+    try testing.expect(s.state == .closed);
 }
 
 test "stream_manager: open and find streams" {
@@ -242,6 +334,20 @@ test "stream_manager: process stream frame" {
     var buf: [8]u8 = undefined;
     const n = s.?.read(&buf);
     try testing.expectEqualSlices(u8, "ping", buf[0..n]);
+}
+
+test "stream_manager: RESET_STREAM frame" {
+    const testing = std.testing;
+    var mgr = StreamManager.init(.server);
+    const rs = frames.ResetStream{
+        .stream_id = 4,
+        .application_protocol_error_code = 0x100,
+        .final_size = 0,
+    };
+    try testing.expect(mgr.onResetStreamFrame(rs));
+    const s = mgr.findStream(StreamId.init(4));
+    try testing.expect(s != null);
+    try testing.expect(s.?.state == .reset_received);
 }
 
 test "flow_control: stream flow control violation" {


### PR DESCRIPTION
## Summary

Implements the remaining open issues **#97** and **#100**.

### #97 — Stream state machine (`stream_manager.zig`)
- Validates state transitions via `transitionAllowed` / `setState`.
- `onRecvData` (FIN path) and `closeLocal` use transitions instead of ad hoc assignments.
- New `onRecvReset(final_size)` and `StreamManager.onResetStreamFrame` for RFC 9000 §19.4 final-size consistency with STREAM FIN.
- Tests for transitions, FIN mismatch, RESET vs FIN, and `onResetStreamFrame`.

### #100 — Path MTU (RFC 9000 §14)
- New `src/transport/path_mtu.zig`: `clampMaxUdpPayload`, `appStreamChunkBytes`, `initFromConfig` (DPLPMTUD probing still **not** implemented — documented).
- `ServerConfig` / `ClientConfig`: optional `max_udp_payload`.
- `ConnState`: `max_udp_payload`, `app_stream_chunk`; HTTP/0.9 and HTTP/3 chunking uses `conn.app_stream_chunk` (stack buffers capped via `max_app_stream_chunk_cap`).

### Other
- README: configurable MTU + pointer to `path_mtu`.
- CHANGELOG: Unreleased entries.
- `zquic.transport.path_mtu` exported from `root.zig`.

**Closes #97**  
**Closes #100**