### PR TITLE
tls: mutual TLS client flight on QUIC (v1.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v1.6.3] - 2026-05-08
+
+### Added
+
+- **Mutual TLS 1.3 on QUIC (client certificate flight).** When `ClientConfig.client_cert_path` and
+  `client_key_path` are both non-empty, the client sends `Certificate` + `CertificateVerify` + `Finished`
+  after the server flight. The server verifies the client `CertificateVerify` and optional `Finished`-only
+  clients remain supported.
+- **`transport.io.serverConnPeerLeafCertificateDer`** — read the captured client leaf DER from a server
+  `ConnState` after handshake completion when mutual TLS was used.
+
+### Changed
+
+- **`ServerHandshake.processClientHandshakeInbound`** replaces Finished-only handling in the QUIC server
+  CRYPTO path (`handleHandshakeCrypto`).
+- **Client handshake tail retransmit** may send multiple Handshake packets (chunked CRYPTO) when the
+  mutual TLS payload exceeds one datagram.
+
+---
+
 ## [v1.6.2] - 2026-05-09
 
 ### Added

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zquic,
     .fingerprint = 0x947d823dd45c34db,
-    .version = "1.6.2",
+    .version = "1.6.3",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .paths = .{

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -31,6 +31,7 @@ const HkdfSha256 = crypto.kdf.hkdf.HkdfSha256;
 const X25519 = crypto.dh.X25519;
 const EcdsaP256Sha256 = crypto.sign.ecdsa.EcdsaP256Sha256;
 const EcdsaP384Sha384 = crypto.sign.ecdsa.EcdsaP384Sha384;
+const Certificate = std.crypto.Certificate;
 
 // TLS 1.3 handshake message types
 pub const MSG_CLIENT_HELLO: u8 = 0x01;
@@ -538,10 +539,33 @@ pub fn buildCertificateVerify(
     transcript_hash: *const [32]u8,
     private_key: *const tls_vendor.config.PrivateKey,
 ) !usize {
+    return buildCertificateVerifyWithContext(out, transcript_hash, private_key, CV_PREFIX_SERVER);
+}
+
+/// Same as [`buildCertificateVerify`] but uses the client CertificateVerify transcript prefix (RFC 8446 §4.4.3).
+pub fn buildClientCertificateVerify(
+    out: []u8,
+    transcript_hash: *const [32]u8,
+    private_key: *const tls_vendor.config.PrivateKey,
+) !usize {
+    return buildCertificateVerifyWithContext(out, transcript_hash, private_key, CV_PREFIX_CLIENT);
+}
+
+fn buildCertificateVerifyWithContext(
+    out: []u8,
+    transcript_hash: *const [32]u8,
+    private_key: *const tls_vendor.config.PrivateKey,
+    context_prefix: []const u8,
+) !usize {
+    comptime {
+        std.debug.assert(CV_PREFIX_SERVER.len == CV_PREFIX_CLIENT.len);
+    }
+    std.debug.assert(context_prefix.len == CV_PREFIX_SERVER.len);
+
     // Content to sign
     var to_sign: [64 + 34 + 32]u8 = undefined;
-    _ = put(&to_sign, 0, CV_PREFIX_SERVER);
-    @memcpy(to_sign[CV_PREFIX_SERVER.len..], transcript_hash);
+    _ = put(&to_sign, 0, context_prefix);
+    @memcpy(to_sign[context_prefix.len..][0..32], transcript_hash);
 
     // sig_der_buf is 104 bytes — max DER size for P-384 (P-256 is 72).
     var sig_der_buf: [104]u8 = undefined;
@@ -586,6 +610,45 @@ pub fn buildCertificateVerify(
     @memcpy(out[pos .. pos + sig_bytes.len], sig_bytes);
     pos += sig_bytes.len;
     return pos;
+}
+
+/// Verify a TLS 1.3 client `CertificateVerify` handshake message using the leaf SPKI from the preceding `Certificate` message.
+pub fn verifyClientCertificateVerifyMessage(
+    msg: []const u8,
+    leaf_der: []const u8,
+    transcript_hash: *const [32]u8,
+) !void {
+    if (msg.len < 4) return error.TruncatedMessage;
+    if (msg[0] != MSG_CERTIFICATE_VERIFY) return error.BadMessageType;
+    const body_len = readU24(msg[1..4]);
+    if (4 + body_len > msg.len) return error.TruncatedMessage;
+    const body = msg[4 .. 4 + body_len];
+    if (body.len < 4) return error.TruncatedMessage;
+    const sig_scheme = readU16(body);
+    const sig_len = readU16(body[2..]);
+    if (4 + sig_len > body.len) return error.TruncatedMessage;
+    const sig_der = body[4 .. 4 + sig_len];
+
+    var to_sign: [64 + 34 + 32]u8 = undefined;
+    _ = put(&to_sign, 0, CV_PREFIX_CLIENT);
+    @memcpy(to_sign[CV_PREFIX_CLIENT.len..][0..32], transcript_hash);
+
+    const parsed = try (Certificate{ .buffer = leaf_der, .index = 0 }).parse();
+    const spki = parsed.pubKey();
+
+    switch (sig_scheme) {
+        SIG_ECDSA_SECP256R1_SHA256 => {
+            const pk = try EcdsaP256Sha256.PublicKey.fromSec1(spki);
+            const sig = try EcdsaP256Sha256.Signature.fromDer(sig_der);
+            try sig.verify(&to_sign, pk);
+        },
+        SIG_ECDSA_SECP384R1_SHA384 => {
+            const pk = try EcdsaP384Sha384.PublicKey.fromSec1(spki);
+            const sig = try EcdsaP384Sha384.Signature.fromDer(sig_der);
+            try sig.verify(&to_sign, pk);
+        },
+        else => return error.UnsupportedSignatureScheme,
+    }
 }
 
 // ── Finished builder ─────────────────────────────────────────────────────────
@@ -981,6 +1044,9 @@ fn buildClientHelloInner(
 
 // ── Server handshake state machine ───────────────────────────────────────────
 
+/// Upper bound for captured peer leaf certificate (TLS mutual auth / libp2p).
+pub const max_peer_leaf_cert_bytes: usize = 16384;
+
 /// Server-side TLS 1.3 handshake state for QUIC.
 pub const ServerHandshake = struct {
     /// Ephemeral X25519 key pair (one per connection).
@@ -1002,6 +1068,9 @@ pub const ServerHandshake = struct {
     /// in the ServerHello.  When true, buildServerFlight skips Certificate and
     /// CertificateVerify (RFC 8446 §4.2.11 / §4.4).
     accept_psk: bool,
+    /// Client leaf (DER) when the client sends a `Certificate` message (mutual TLS).
+    peer_leaf_cert_der: [max_peer_leaf_cert_bytes]u8 = undefined,
+    peer_leaf_cert_der_len: u16 = 0,
 
     pub fn init() ServerHandshake {
         return .{
@@ -1130,6 +1199,47 @@ pub const ServerHandshake = struct {
         return deriveTrafficSecret(master, "res master", &final_hash);
     }
 
+    /// Process the client's post-server-flight TLS messages: either a single `Finished`
+    /// (HTTP-style zquic clients) or `Certificate` + `CertificateVerify` + `Finished` (mutual TLS).
+    pub fn processClientHandshakeInbound(self: *ServerHandshake, data: []const u8) !void {
+        if (data.len >= 4 and data[0] == MSG_CERTIFICATE) {
+            var p: usize = 0;
+            while (p + 4 <= data.len) {
+                const msg_type = data[p];
+                const msg_len = readU24(data[p + 1 ..]);
+                const msg_end = p + 4 + msg_len;
+                if (msg_end > data.len) return error.TruncatedMessage;
+                const msg = data[p..msg_end];
+                switch (msg_type) {
+                    MSG_CERTIFICATE => {
+                        self.transcript.update(msg);
+                        if (self.peer_leaf_cert_der_len == 0) {
+                            const leaf = try leafCertificateDerFromCertificateHandshakeMessage(msg);
+                            if (leaf.len > max_peer_leaf_cert_bytes) return error.PeerLeafCertificateTooLarge;
+                            @memcpy(self.peer_leaf_cert_der[0..leaf.len], leaf);
+                            self.peer_leaf_cert_der_len = @intCast(leaf.len);
+                        }
+                    },
+                    MSG_CERTIFICATE_VERIFY => {
+                        if (self.peer_leaf_cert_der_len == 0) return error.BadCertificateVerify;
+                        const th = peekHash(self.transcript);
+                        const leaf = self.peer_leaf_cert_der[0..self.peer_leaf_cert_der_len];
+                        try verifyClientCertificateVerifyMessage(msg, leaf, &th);
+                        self.transcript.update(msg);
+                    },
+                    MSG_FINISHED => {
+                        try self.processClientFinished(msg);
+                        return;
+                    },
+                    else => return error.BadMessageType,
+                }
+                p = msg_end;
+            }
+            return error.TruncatedMessage;
+        }
+        try self.processClientFinished(data);
+    }
+
     /// Verify the client's Finished message (raw bytes).
     pub fn processClientFinished(self: *ServerHandshake, fin_bytes: []const u8) !void {
         if (fin_bytes.len < 4) return error.TruncatedMessage;
@@ -1153,8 +1263,11 @@ pub const ServerHandshake = struct {
 
 // ── Client handshake state machine ───────────────────────────────────────────
 
-/// Upper bound for the captured server leaf certificate on [`ClientHandshake`] (libp2p TLS identity).
-pub const max_peer_leaf_cert_bytes: usize = 16384;
+/// Optional client certificate + key for TLS 1.3 mutual authentication (e.g. libp2p QUIC).
+pub const ClientMutualTlsCredentials = struct {
+    cert_der: []const u8,
+    private_key: *const tls_vendor.config.PrivateKey,
+};
 
 /// Client-side TLS 1.3 handshake state for QUIC.
 pub const ClientHandshake = struct {
@@ -1315,11 +1428,13 @@ pub const ClientHandshake = struct {
 
     /// Process server Handshake messages (EncryptedExtensions, Certificate,
     /// CertificateVerify, Finished). Certificate is NOT verified — accepts any.
-    /// Returns bytes of ClientFinished to send in Handshake CRYPTO frames.
+    /// Returns bytes to send in Handshake CRYPTO frames: `Finished` only, or
+    /// `Certificate` + `CertificateVerify` + `Finished` when `mutual` is non-null.
     pub fn processServerFlight(
         self: *ClientHandshake,
         hs_bytes: []const u8,
-        out_finished: []u8,
+        out: []u8,
+        mutual: ?ClientMutualTlsCredentials,
     ) !usize {
         // Walk through messages
         var p: usize = 0;
@@ -1371,10 +1486,28 @@ pub const ClientHandshake = struct {
 
         if (!found_finished) return error.NoServerFinished;
 
-        // Build client Finished
+        if (mutual) |m| {
+            var out_pos: usize = 0;
+            const cert_len = try buildCertificate(out[out_pos..], m.cert_der);
+            self.transcript.update(out[out_pos..][0..cert_len]);
+            out_pos += cert_len;
+
+            const cv_hash = peekHash(self.transcript);
+            const cv_len = try buildClientCertificateVerify(out[out_pos..], &cv_hash, m.private_key);
+            self.transcript.update(out[out_pos..][0..cv_len]);
+            out_pos += cv_len;
+
+            const fin_hash = peekHash(self.transcript);
+            const fin_len = buildFinished(out[out_pos..], self.secrets.client_handshake, &fin_hash);
+            self.transcript.update(out[out_pos..][0..fin_len]);
+            out_pos += fin_len;
+            self.handshake_done = true;
+            return out_pos;
+        }
+
         const client_fin_hash = peekHash(self.transcript);
-        const n = buildFinished(out_finished, self.secrets.client_handshake, &client_fin_hash);
-        self.transcript.update(out_finished[0..n]);
+        const n = buildFinished(out, self.secrets.client_handshake, &client_fin_hash);
+        self.transcript.update(out[0..n]);
         self.handshake_done = true;
         return n;
     }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -2430,10 +2430,10 @@ pub const Server = struct {
     }
 
     fn handleHandshakeCrypto(self: *Server, conn: *ConnState, data: []const u8, src: compat.Address) void {
-        if (data.len < 4 or data[0] != tls_hs.MSG_FINISHED) return;
+        if (data.len < 4) return;
 
-        conn.tls.processClientFinished(data) catch |err| {
-            dbg("io: client Finished verify failed: {}\n", .{err});
+        conn.tls.processClientHandshakeInbound(data) catch |err| {
+            dbg("io: client post-handshake TLS failed: {}\n", .{err});
             return;
         };
 
@@ -4423,6 +4423,9 @@ pub const ClientConfig = struct {
     raw_application_streams: bool = false,
     /// Maximum UDP payload (bytes) for path sizing (RFC 9000 §14.1). When null, uses ~Ethernet MTU.
     max_udp_payload: ?u16 = null,
+    /// Non-empty together with [`client_key_path`]: present this cert + key after the server flight (mutual TLS).
+    client_cert_path: []const u8 = "",
+    client_key_path: []const u8 = "",
 };
 
 /// TLS ALPN value for `ClientConfig`.
@@ -4482,6 +4485,13 @@ pub fn rawAppRecvBuffer(conn: *ConnState, stream_id: u64) ?[]const u8 {
         }
     }
     return null;
+}
+
+/// Client leaf certificate (DER) on a **server** `ConnState` after mutual TLS.
+pub fn serverConnPeerLeafCertificateDer(conn: *const ConnState) ?[]const u8 {
+    const n = conn.tls.peer_leaf_cert_der_len;
+    if (n == 0) return null;
+    return conn.tls.peer_leaf_cert_der[0..n];
 }
 
 // ── Stream download tracker ───────────────────────────────────────────────────
@@ -4567,6 +4577,14 @@ pub const Client = struct {
     client_hello_bytes: [2048]u8 = [_]u8{0} ** 2048,
     client_hello_len: usize = 0,
 
+    /// TLS payload after the server flight (Finished-only or Certificate+CertificateVerify+Finished), for retransmit.
+    client_hs_tail_buf: [tls_hs.max_peer_leaf_cert_bytes + 512]u8 = undefined,
+    client_hs_tail_len: usize = 0,
+    /// Loaded from [`ClientConfig.client_cert_path`] when mutual TLS is enabled.
+    client_cert_der: []u8 = &.{},
+    client_cert_owned: bool = false,
+    client_private_key: tls_vendor.config.PrivateKey = undefined,
+
     pub fn init(allocator: std.mem.Allocator, config: ClientConfig) !Client {
         const sock = try compat.socket(std.posix.AF.INET, std.posix.SOCK.DGRAM, 0);
         errdefer compat.close(sock);
@@ -4612,6 +4630,16 @@ pub const Client = struct {
             conn.qlog.connectionStarted("0.0.0.0", 0, dst_str, config.port, 0x00000001);
         }
 
+        var client_cert_der: []u8 = &.{};
+        var client_cert_owned: bool = false;
+        var client_private_key: tls_vendor.config.PrivateKey = undefined;
+        if (config.client_cert_path.len > 0 and config.client_key_path.len > 0) {
+            client_cert_der = try loadCertDer(allocator, config.client_cert_path);
+            errdefer allocator.free(client_cert_der);
+            client_private_key = try loadPrivateKey(allocator, config.client_key_path);
+            client_cert_owned = true;
+        }
+
         return .{
             .allocator = allocator,
             .config = config,
@@ -4620,6 +4648,9 @@ pub const Client = struct {
             .conn = conn,
             .active_urls = config.urls,
             .owns_socket = true,
+            .client_cert_der = client_cert_der,
+            .client_cert_owned = client_cert_owned,
+            .client_private_key = client_private_key,
         };
     }
 
@@ -4665,6 +4696,16 @@ pub const Client = struct {
             conn.qlog.connectionStarted("0.0.0.0", 0, dst_str, config.port, 0x00000001);
         }
 
+        var client_cert_der: []u8 = &.{};
+        var client_cert_owned: bool = false;
+        var client_private_key: tls_vendor.config.PrivateKey = undefined;
+        if (config.client_cert_path.len > 0 and config.client_key_path.len > 0) {
+            client_cert_der = try loadCertDer(allocator, config.client_cert_path);
+            errdefer allocator.free(client_cert_der);
+            client_private_key = try loadPrivateKey(allocator, config.client_key_path);
+            client_cert_owned = true;
+        }
+
         return .{
             .allocator = allocator,
             .config = config,
@@ -4673,10 +4714,16 @@ pub const Client = struct {
             .conn = conn,
             .active_urls = config.urls,
             .owns_socket = take_ownership,
+            .client_cert_der = client_cert_der,
+            .client_cert_owned = client_cert_owned,
+            .client_private_key = client_private_key,
         };
     }
 
     pub fn deinit(self: *Client) void {
+        if (self.client_cert_owned) {
+            self.allocator.free(self.client_cert_der);
+        }
         for (&self.raw_app_recv) |*slot| {
             slot.deinit(self.allocator);
         }
@@ -4708,15 +4755,9 @@ pub const Client = struct {
             self.sendClientHello(server_addr) catch {};
         }
         if (self.conn.has_hs_keys and self.conn.phase != .connected and
-            self.conn.finished_pkt_len > 0 and now - self.conn.finished_sent_ms >= 500)
+            self.client_hs_tail_len > 0 and now - self.conn.finished_sent_ms >= 500)
         {
-            _ = compat.sendto(
-                self.sock,
-                self.conn.finished_pkt[0..self.conn.finished_pkt_len],
-                0,
-                &server_addr.any,
-                server_addr.getOsSockLen(),
-            ) catch {};
+            self.flushClientHandshakeTailPacketsTo(server_addr);
             self.conn.finished_sent_ms = now;
         }
     }
@@ -4884,6 +4925,7 @@ pub const Client = struct {
         self.initial_pkt_len = 0;
         self.client_hello_bytes = [_]u8{0} ** 2048;
         self.client_hello_len = 0;
+        self.client_hs_tail_len = 0;
         // Clear 0-RTT state so the new connection starts fresh.
         self.early_km = null;
         self.zerortt_pn = 0;
@@ -4929,15 +4971,9 @@ pub const Client = struct {
                 last_initial_ms = now;
             }
             if (self.conn.has_hs_keys and self.conn.phase != .connected and
-                self.conn.finished_pkt_len > 0 and now - self.conn.finished_sent_ms >= 500)
+                self.client_hs_tail_len > 0 and now - self.conn.finished_sent_ms >= 500)
             {
-                _ = compat.sendto(
-                    self.sock,
-                    self.conn.finished_pkt[0..self.conn.finished_pkt_len],
-                    0,
-                    &server_addr.any,
-                    server_addr.getOsSockLen(),
-                ) catch {};
+                self.flushClientHandshakeTailPacketsTo(server_addr);
                 self.conn.finished_sent_ms = now;
             }
 
@@ -5509,8 +5545,12 @@ pub const Client = struct {
             const cdata = plaintext[fpos .. fpos + dlen];
 
             // Process server flight messages
-            var fin_buf: [128]u8 = undefined;
-            const fin_len = self.tls.processServerFlight(cdata, &fin_buf) catch |err| {
+            var flight_buf: [tls_hs.max_peer_leaf_cert_bytes + 512]u8 = undefined;
+            const mutual: ?tls_hs.ClientMutualTlsCredentials = if (self.client_cert_der.len > 0) .{
+                .cert_der = self.client_cert_der,
+                .private_key = &self.client_private_key,
+            } else null;
+            const tail_len = self.tls.processServerFlight(cdata, flight_buf[0..], mutual) catch |err| {
                 if (err != error.NoServerFinished) {
                     dbg("io: processServerFlight error: {}\n", .{err});
                 }
@@ -5520,38 +5560,60 @@ pub const Client = struct {
             // App secrets are now derived; update QUIC 1-RTT keys.
             self.conn.deriveAppKeys(&self.tls.secrets);
 
-            // Send client Finished
-            self.sendClientFinished(fin_buf[0..fin_len]);
+            self.sendClientHandshakeTail(flight_buf[0..tail_len]);
             break;
         }
     }
 
-    fn sendClientFinished(self: *Client, fin_bytes: []const u8) void {
+    fn flushClientHandshakeTailPacketsTo(self: *Client, dst: compat.Address) void {
+        if (!self.conn.has_hs_keys or self.client_hs_tail_len == 0) return;
+
+        const max_crypto_per_pkt = 1100;
+        const flight = self.client_hs_tail_buf[0..self.client_hs_tail_len];
+        var offset: usize = 0;
+        while (offset < flight.len) {
+            var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+            const chunk_len = @min(flight.len - offset, max_crypto_per_pkt);
+            const crypto_len = buildCryptoFrame(
+                &frame_buf,
+                @intCast(offset),
+                flight[offset .. offset + chunk_len],
+            ) catch return;
+
+            var pkt_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+            const pkt_len = buildHandshakePacket(
+                &pkt_buf,
+                self.conn.remote_cid,
+                self.conn.local_cid,
+                frame_buf[0..crypto_len],
+                self.conn.hs_pn,
+                &self.conn.hs_client_km,
+                self.conn.quicVersion(),
+            ) catch return;
+            self.conn.hs_pn += 1;
+
+            _ = compat.sendto(
+                self.sock,
+                pkt_buf[0..pkt_len],
+                0,
+                &dst.any,
+                dst.getOsSockLen(),
+            ) catch {};
+
+            offset += chunk_len;
+        }
+    }
+
+    fn sendClientHandshakeTail(self: *Client, hs_bytes: []const u8) void {
         if (!self.conn.has_hs_keys) return;
-
-        var frame_buf: [256]u8 = undefined;
-
-        const crypto_len = buildCryptoFrame(&frame_buf, 0, fin_bytes) catch return;
-        const pkt_len = buildHandshakePacket(
-            &self.conn.finished_pkt,
-            self.conn.remote_cid,
-            self.conn.local_cid,
-            frame_buf[0..crypto_len],
-            self.conn.hs_pn,
-            &self.conn.hs_client_km,
-            self.conn.quicVersion(),
-        ) catch return;
-        self.conn.hs_pn += 1;
-        self.conn.finished_pkt_len = pkt_len;
+        if (hs_bytes.len > self.client_hs_tail_buf.len) {
+            dbg("io: client handshake tail too large ({})\n", .{hs_bytes.len});
+            return;
+        }
+        @memcpy(self.client_hs_tail_buf[0..hs_bytes.len], hs_bytes);
+        self.client_hs_tail_len = hs_bytes.len;
+        self.flushClientHandshakeTailPacketsTo(self.conn.peer);
         self.conn.finished_sent_ms = compat.milliTimestamp();
-
-        _ = compat.sendto(
-            self.sock,
-            self.conn.finished_pkt[0..pkt_len],
-            0,
-            &self.conn.peer.any,
-            self.conn.peer.getOsSockLen(),
-        ) catch {};
     }
 
     fn process1RttPacket(self: *Client, buf: []const u8) void {


### PR DESCRIPTION
## Summary

Adds TLS 1.3 **mutual authentication** on the QUIC handshake path so embedders (e.g. libp2p) can present a client certificate and listeners can read the dialer leaf.

## Changes

- **Client:** `ClientConfig.client_cert_path` + `client_key_path` (both non-empty) load PEM and send **Certificate → CertificateVerify → Finished** after the server flight. Handshake tail is sent in chunked CRYPTO frames (~1100 bytes) with full-tail retransmit.
- **Server:** `ServerHandshake.processClientHandshakeInbound` accepts either the legacy **Finished-only** tail (existing behaviour) or the full mutual-TLS flight; verifies **CertificateVerify** (P-256 / P-384) and **Finished**.
- **API:** `transport.io.serverConnPeerLeafCertificateDer(conn)` returns the captured client leaf DER when mutual TLS was used.
- **Version:** `build.zig.zon` → **1.6.3**; `CHANGELOG.md` updated.

## Consumers

Downstream projects should pin zquic via **git URL + hash** (e.g. `zig fetch` after this lands), not a local path.

## Testing

`zig build test`