### PR TITLE
zquic: release v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v1.6.3] - 2026-05-08
+## [v1.6.3] - 2026-05-09
 
 ### Added
 
@@ -380,7 +380,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/ch4r10t33r/zquic/compare/v1.6.2...HEAD
+[Unreleased]: https://github.com/ch4r10t33r/zquic/compare/v1.6.3...HEAD
+[v1.6.3]: https://github.com/ch4r10t33r/zquic/compare/v1.6.2...v1.6.3
 [v1.6.2]: https://github.com/ch4r10t33r/zquic/compare/v1.6.1...v1.6.2
 [v1.6.1]: https://github.com/ch4r10t33r/zquic/compare/v1.6.0...v1.6.1
 [v1.6.0]: https://github.com/ch4r10t33r/zquic/compare/v1.5.0...v1.6.0


### PR DESCRIPTION
Release tag for v1.6.3.  Feature work already landed in PR #124 (mutual TLS client flight on QUIC); this PR finalises the release metadata.

## Added (rolled forward from #124)

- **Mutual TLS 1.3 on QUIC (client certificate flight).** When `ClientConfig.client_cert_path` and `client_key_path` are both non-empty, the client sends `Certificate` + `CertificateVerify` + `Finished` after the server flight.  The server verifies the client `CertificateVerify`; legacy Finished-only clients remain supported.
- **`transport.io.serverConnPeerLeafCertificateDer`** — read the captured client leaf DER from a server `ConnState` after handshake completion when mutual TLS was used.

## Changed

- **`ServerHandshake.processClientHandshakeInbound`** replaces Finished-only handling in the QUIC server CRYPTO path (`handleHandshakeCrypto`).
- **Client handshake tail retransmit** may send multiple Handshake packets (chunked CRYPTO) when the mutual TLS payload exceeds one datagram.

## This PR
- CHANGELOG link refs updated for v1.6.3.
- Date corrected to 2026-05-09.

## Verification

- 166/166 unit tests pass.
- `zig fmt` clean.
- Tag `v1.6.3` will fire the release workflow once merged → Linux statically-linked binaries published.