### PR TITLE
fix(io): scale up local-bidi-stream credit (initial 1024, grow 50%/+1024)

### DIFF
--- a/src/compat.zig
+++ b/src/compat.zig
@@ -616,6 +616,20 @@ pub const fs = struct {
         return .{ .handle = fd };
     }
 
+    pub fn deleteFileAbsolute(path: []const u8) !void {
+        var path_buf: [4096]u8 = undefined;
+        const c_path = try nullTerminate(path, &path_buf);
+        const rc = system.unlink(c_path);
+        switch (checkRc(rc)) {
+            .SUCCESS => return,
+            .NOENT => return error.FileNotFound,
+            .ACCES => return error.AccessDenied,
+            .ISDIR => return error.IsDir,
+            .NAMETOOLONG => return error.NameTooLong,
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    }
+
     pub fn makeDirAbsolute(path: []const u8) !void {
         var path_buf: [4096]u8 = undefined;
         if (path.len >= path_buf.len) return error.NameTooLong;

--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -144,8 +144,8 @@ pub fn buildClientTransportParams(out: []u8) (varint.EncodeError || varint.Decod
     pos = try write_param(out, pos, 0x05, 16_777_216); // initial_max_stream_data_bidi_local (16 MiB)
     pos = try write_param(out, pos, 0x06, 16_777_216); // initial_max_stream_data_bidi_remote (16 MiB)
     pos = try write_param(out, pos, 0x07, 16_777_216); // initial_max_stream_data_uni (16 MiB)
-    pos = try write_param(out, pos, 0x08, 100); // initial_max_streams_bidi
-    pos = try write_param(out, pos, 0x09, 100); // initial_max_streams_uni
+    pos = try write_param(out, pos, 0x08, 1024); // initial_max_streams_bidi
+    pos = try write_param(out, pos, 0x09, 1024); // initial_max_streams_uni
     return pos;
 }
 

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -6898,7 +6898,7 @@ test "io PEM: parseCertDerFromPem round-trips file-based loadCertDer" {
         defer f.close();
         try f.writeAll(pem);
     }
-    defer _ = std.c.unlink(&path_buf);
+    defer compat.fs.deleteFileAbsolute(path) catch {};
 
     const from_file = try loadCertDer(a, path);
     defer a.free(from_file);
@@ -6931,7 +6931,7 @@ test "io PEM: parsePrivateKeyFromPem round-trips file-based loadPrivateKey" {
         defer f.close();
         try f.writeAll(key_pem);
     }
-    defer _ = std.c.unlink(&path_buf);
+    defer compat.fs.deleteFileAbsolute(path) catch {};
 
     const pk_file = try loadPrivateKey(a, path);
     try std.testing.expectEqual(pk_mem.signature_scheme, pk_file.signature_scheme);

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1000,18 +1000,18 @@ pub const ConnState = struct {
     path_challenge_data: ?[8]u8 = null,
 
     // ── Stream limit enforcement (RFC 9000 §4.6) ──────────────────────────────
-    // The server advertises initial_max_streams_bidi=100 and
-    // initial_max_streams_uni=100 in transport parameters.  Stream IDs that
+    // The server advertises initial_max_streams_bidi=1024 and
+    // initial_max_streams_uni=1024 in transport parameters.  Stream IDs that
     // exceed these limits trigger a STREAM_LIMIT_ERROR (0x4).
     // max_streams_*_recv is updated when we send MAX_STREAMS frames.
     // peer_*_stream_count tracks the highest stream number used so far.
     //
     // peer_max_*_streams: how many **locally initiated** streams of each type
     // the peer allows us to open (initial transport params + MAX_STREAMS frames).
-    max_streams_bidi_recv: u64 = 100,
-    max_streams_uni_recv: u64 = 100,
-    peer_max_bidi_streams: u64 = 100,
-    peer_max_uni_streams: u64 = 100,
+    max_streams_bidi_recv: u64 = 1024,
+    max_streams_uni_recv: u64 = 1024,
+    peer_max_bidi_streams: u64 = 1024,
+    peer_max_uni_streams: u64 = 1024,
     peer_bidi_stream_count: u64 = 0,
     peer_uni_stream_count: u64 = 0,
     /// Next locally opened uni stream ID (RFC 9000 §2.1). Initialized to 3 on the
@@ -3178,11 +3178,11 @@ pub const Server = struct {
                         }
                         if (stream_count > conn.peer_bidi_stream_count)
                             conn.peer_bidi_stream_count = stream_count;
-                        // Proactively raise the limit when 75% consumed — mirrors how
-                        // MAX_DATA is sent at 50% (RFC 9000 §4.2).  Prevents the
-                        // client from needing to send STREAMS_BLOCKED in the common
-                        // case of a burst of requests (e.g. multiplexing test).
-                        if (conn.peer_bidi_stream_count * 4 >= conn.max_streams_bidi_recv * 3)
+                        // Proactively raise the limit when 50% consumed (matches
+                        // MAX_DATA's 50% rule in RFC 9000 §4.2).  Earlier MAX_STREAMS
+                        // means the client never blocks on a burst of stream opens
+                        // (gossipsub per-message-stream pattern or batched req/resps).
+                        if (conn.peer_bidi_stream_count * 2 >= conn.max_streams_bidi_recv)
                             self.sendMaxStreams(conn, true, src);
                     } else {
                         // Unidirectional: enforce hard limit.
@@ -3193,8 +3193,8 @@ pub const Server = struct {
                         }
                         if (stream_count > conn.peer_uni_stream_count)
                             conn.peer_uni_stream_count = stream_count;
-                        // Proactively raise uni limit at 75% consumed.
-                        if (conn.peer_uni_stream_count * 4 >= conn.max_streams_uni_recv * 3)
+                        // Proactively raise uni limit at 50% consumed.
+                        if (conn.peer_uni_stream_count * 2 >= conn.max_streams_uni_recv)
                             self.sendMaxStreams(conn, false, src);
                     }
                 }
@@ -3593,11 +3593,13 @@ pub const Server = struct {
 
     /// Send a MAX_STREAMS frame granting the peer additional stream budget.
     fn sendMaxStreams(self: *Server, conn: *ConnState, bidi: bool, dst: compat.Address) void {
-        // Raise the limit by 100 streams each time we receive STREAMS_BLOCKED.
+        // Grow by 1024 streams per MAX_STREAMS — large enough that bursts of
+        // gossipsub publishes or req/resps on a fan-out mesh don't repeatedly
+        // race with the next credit grant.
         const new_limit: u64 = if (bidi)
-            conn.max_streams_bidi_recv + 100
+            conn.max_streams_bidi_recv + 1024
         else
-            conn.max_streams_uni_recv + 100;
+            conn.max_streams_uni_recv + 1024;
 
         if (bidi) {
             conn.max_streams_bidi_recv = new_limit;


### PR DESCRIPTION
## Summary

- Bump initial_max_streams_bidi / initial_max_streams_uni from 100 → 1024 in the transport-params advertisement and the corresponding ConnState defaults.
- Lower the server's proactive sendMaxStreams trigger from 75% to 50% so the next MAX_STREAMS frame leaves the wire earlier in the window.
- Grow MAX_STREAMS by 1024 (was 100) per send so subsequent bursts keep finding headroom.

## Why

Found while debugging zeam-on-zeam local-devnet (zeam runs zig-libp2p on top of zquic). libp2p's per-message-stream pattern for gossipsub publish opens a fresh QUIC bidi stream per RPC; combined with status RPC + blocks_by_root/range, a small mesh exhausts the 100-stream window before the first MAX_STREAMS round trip completes. The libp2p layer surfaces this as `StreamLimitExceeded` and stalls all subsequent publish/RPC paths.

The 50%-trigger / 1024-grow combination keeps the credit comfortably ahead of demand for any realistic gossipsub/req-resp workload without changing protocol semantics.

## Test plan

- [x] `zig build test` — all 162 existing tests pass.
- [ ] Verify on local-devnet that zeam containers no longer hit StreamLimitExceeded and that gossipsub propagation continues past slot ~80.