### PR TITLE
fix(io,crypto/quic_tls): cap initial_max_streams at 1000 (interop-runner sanity)

### DIFF
--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -144,8 +144,10 @@ pub fn buildClientTransportParams(out: []u8) (varint.EncodeError || varint.Decod
     pos = try write_param(out, pos, 0x05, 16_777_216); // initial_max_stream_data_bidi_local (16 MiB)
     pos = try write_param(out, pos, 0x06, 16_777_216); // initial_max_stream_data_bidi_remote (16 MiB)
     pos = try write_param(out, pos, 0x07, 16_777_216); // initial_max_stream_data_uni (16 MiB)
-    pos = try write_param(out, pos, 0x08, 1024); // initial_max_streams_bidi
-    pos = try write_param(out, pos, 0x09, 1024); // initial_max_streams_uni
+    // Stay at <=1000 so quic-interop-runner's multiplexing test (which fails
+    // any server advertising "stream limit > 1000") still passes.
+    pos = try write_param(out, pos, 0x08, 1000); // initial_max_streams_bidi
+    pos = try write_param(out, pos, 0x09, 1000); // initial_max_streams_uni
     return pos;
 }
 

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1000,18 +1000,20 @@ pub const ConnState = struct {
     path_challenge_data: ?[8]u8 = null,
 
     // ── Stream limit enforcement (RFC 9000 §4.6) ──────────────────────────────
-    // The server advertises initial_max_streams_bidi=1024 and
-    // initial_max_streams_uni=1024 in transport parameters.  Stream IDs that
-    // exceed these limits trigger a STREAM_LIMIT_ERROR (0x4).
+    // The server advertises initial_max_streams_bidi=1000 and
+    // initial_max_streams_uni=1000 in transport parameters.  The value is
+    // pinned to <=1000 so quic-interop-runner's multiplexing test (which
+    // asserts "stream limit > 1000" as a failure) still passes.  Stream IDs
+    // that exceed these limits trigger STREAM_LIMIT_ERROR (0x4).
     // max_streams_*_recv is updated when we send MAX_STREAMS frames.
     // peer_*_stream_count tracks the highest stream number used so far.
     //
     // peer_max_*_streams: how many **locally initiated** streams of each type
     // the peer allows us to open (initial transport params + MAX_STREAMS frames).
-    max_streams_bidi_recv: u64 = 1024,
-    max_streams_uni_recv: u64 = 1024,
-    peer_max_bidi_streams: u64 = 1024,
-    peer_max_uni_streams: u64 = 1024,
+    max_streams_bidi_recv: u64 = 1000,
+    max_streams_uni_recv: u64 = 1000,
+    peer_max_bidi_streams: u64 = 1000,
+    peer_max_uni_streams: u64 = 1000,
     peer_bidi_stream_count: u64 = 0,
     peer_uni_stream_count: u64 = 0,
     /// Next locally opened uni stream ID (RFC 9000 §2.1). Initialized to 3 on the
@@ -3593,13 +3595,14 @@ pub const Server = struct {
 
     /// Send a MAX_STREAMS frame granting the peer additional stream budget.
     fn sendMaxStreams(self: *Server, conn: *ConnState, bidi: bool, dst: compat.Address) void {
-        // Grow by 1024 streams per MAX_STREAMS — large enough that bursts of
+        // Grow by 1000 streams per MAX_STREAMS — large enough that bursts of
         // gossipsub publishes or req/resps on a fan-out mesh don't repeatedly
-        // race with the next credit grant.
+        // race with the next credit grant, and matches the initial value to
+        // keep behaviour predictable.
         const new_limit: u64 = if (bidi)
-            conn.max_streams_bidi_recv + 1024
+            conn.max_streams_bidi_recv + 1000
         else
-            conn.max_streams_uni_recv + 1024;
+            conn.max_streams_uni_recv + 1000;
 
         if (bidi) {
             conn.max_streams_bidi_recv = new_limit;


### PR DESCRIPTION
## Summary

PR #130 bumped initial_max_streams_bidi / initial_max_streams_uni to 1024 to absorb gossipsub burst opens.  quic-interop-runner's multiplexing test asserts \`Server set a stream limit > 1000\` as a failure case, so master's interop CI started reporting \`multiplexing(zquic→zquic)\` red as soon as #130 landed.

Pin both the initial transport-param value AND the per-MAX_STREAMS grow step to 1000.  Still 10× the pre-#130 headroom and still ahead of the libp2p burst-open workload that motivated #130; just below the runner's threshold.

## Test plan

- [x] \`zig build test\` — 162/162 tests pass.
- [ ] \`multiplexing(zquic→zquic)\` interop test passes in CI.