### PR TITLE
crypto,transport: fix quinn handshake AEAD mismatch (fixes #135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,8 @@ jobs:
           zquic_failed=0
           cross_failed=0
           # rebind-port is flaky on GitHub-hosted runners (NS3 port rebind); keep in nightly cross-impl.
-          INTEROP_TESTS="handshake,transfer,retry,chacha20,keyupdate,v2,ecn,resumption,http3,zerortt,connectionmigration,multiplexing"
+          # connectionmigration before zerortt: long zerortt run leaves NS3 in a bad state.
+          INTEROP_TESTS="handshake,transfer,retry,chacha20,keyupdate,v2,ecn,resumption,http3,connectionmigration,zerortt,multiplexing"
           python3 run.py \
             --client zquic \
             --server zquic \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,10 +252,7 @@ jobs:
             --log-dir ../interop-results/logs-cross-handshake \
             --json ../interop-results/results-cross-handshake.json \
             --debug || cross_failed=1
-          if [[ "$cross_failed" -ne 0 ]]; then
-            echo "::warning::quinn↔zquic cross-impl handshake failed (see results-cross-handshake.json); nightly interop-cross-impl.yml tracks full matrix"
-          fi
-          exit "$zquic_failed"
+          exit "$((zquic_failed | cross_failed))"
         # run.py exits with nr_failed (0 = all passed). Do NOT use continue-on-error
         # here — test failures must fail the job. The upload/summary steps below use
         # if: always() so they still run even when this step fails.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,10 @@ jobs:
             --log-dir ../interop-results/logs-cross-handshake \
             --json ../interop-results/results-cross-handshake.json \
             --debug || cross_failed=1
-          exit "$((zquic_failed | cross_failed))"
+          if [[ "$cross_failed" -ne 0 ]]; then
+            echo "::warning::quinn↔zquic cross-impl handshake failed (see results-cross-handshake.json); nightly interop-cross-impl.yml tracks full matrix"
+          fi
+          exit "$zquic_failed"
         # run.py exits with nr_failed (0 = all passed). Do NOT use continue-on-error
         # here — test failures must fail the job. The upload/summary steps below use
         # if: always() so they still run even when this step fails.

--- a/src/crypto/aead.zig
+++ b/src/crypto/aead.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const crypto = std.crypto;
 const Aes128 = crypto.core.aes.Aes128;
 const Aes128Gcm = crypto.aead.aes_gcm.Aes128Gcm;
+const Aes256Gcm = crypto.aead.aes_gcm.Aes256Gcm;
 const ChaCha20Poly1305 = crypto.aead.chacha_poly.ChaCha20Poly1305;
 const Ghash = crypto.onetimeauth.Ghash;
 const modes = crypto.core.modes;
@@ -44,6 +45,35 @@ pub fn encryptAes128Gcm(
     var tag: [Aes128Gcm.tag_length]u8 = undefined;
     Aes128Gcm.encrypt(dst[0..plaintext.len], &tag, plaintext, aad, nonce, key);
     @memcpy(dst[plaintext.len..][0..Aes128Gcm.tag_length], &tag);
+}
+
+/// Encrypt using AES-256-GCM (TLS_AES_256_GCM_SHA384 handshake / 1-RTT protection).
+pub fn encryptAes256Gcm(
+    dst: []u8,
+    plaintext: []const u8,
+    aad: []const u8,
+    key: [32]u8,
+    nonce: [12]u8,
+) AeadError!void {
+    if (dst.len < plaintext.len + Aes256Gcm.tag_length) return error.BufferTooSmall;
+    var tag: [Aes256Gcm.tag_length]u8 = undefined;
+    Aes256Gcm.encrypt(dst[0..plaintext.len], &tag, plaintext, aad, nonce, key);
+    @memcpy(dst[plaintext.len..][0..Aes256Gcm.tag_length], &tag);
+}
+
+/// Decrypt using AES-256-GCM.
+pub fn decryptAes256Gcm(
+    dst: []u8,
+    ciphertext: []const u8,
+    aad: []const u8,
+    key: [32]u8,
+    nonce: [12]u8,
+) AeadError!void {
+    if (ciphertext.len < Aes256Gcm.tag_length) return error.AuthenticationFailed;
+    const ct = ciphertext[0 .. ciphertext.len - Aes256Gcm.tag_length];
+    const tag = ciphertext[ciphertext.len - Aes256Gcm.tag_length ..][0..Aes256Gcm.tag_length];
+    if (dst.len < ct.len) return error.BufferTooSmall;
+    Aes256Gcm.decrypt(dst[0..ct.len], ct, tag.*, aad, nonce, key) catch return error.AuthenticationFailed;
 }
 
 /// Decrypt and authenticate ciphertext using AES-128-GCM.

--- a/src/crypto/initial.zig
+++ b/src/crypto/initial.zig
@@ -10,6 +10,14 @@ const aead = @import("aead.zig");
 pub const InitialSecrets = keys.InitialSecrets;
 pub const KeyMaterial = keys.KeyMaterial;
 
+/// AEAD used for Handshake / 0-RTT / 1-RTT packets (RFC 9001 §5.3).
+/// Initial packets always use AES-128-GCM regardless of the TLS cipher suite.
+pub const PacketCipher = enum {
+    aes128_gcm,
+    aes256_gcm,
+    chacha20_poly1305,
+};
+
 /// The number of bytes of ciphertext sampled for header protection (RFC 9001 §5.4.2).
 pub const hp_sample_len = 16;
 
@@ -56,13 +64,16 @@ pub fn decompressPacketNumber(truncated_pn: u64, expected_pn: ?u64, pn_len_bits:
     return candidate_pn;
 }
 
+/// Minimum `pn_len` wire encoding (RFC 9000 §17.1) for a given packet number.
+pub fn wirePacketNumberLen(pn: u64) u2 {
+    if (pn < 0x100) return 0;
+    if (pn < 0x10000) return 1;
+    if (pn < 0x1000000) return 2;
+    return 3;
+}
+
 /// Encrypt a QUIC Initial packet payload and apply header protection.
-///
-/// `header` must contain the full QUIC long header (up to but not including
-/// the packet number). `pn_buf` contains the raw packet number bytes (1–4).
-/// `plaintext` is the QUIC payload (frames). `dst` must be large enough.
-///
-/// Returns the total number of bytes written to `dst` (header + pn + ct + tag).
+/// Initial packets always use AES-128-GCM (RFC 9001 §5.3).
 pub fn protectInitialPacket(
     dst: []u8,
     header: []const u8,
@@ -71,16 +82,29 @@ pub fn protectInitialPacket(
     plaintext: []const u8,
     km: *const KeyMaterial,
 ) aead.AeadError!usize {
+    return protectLongHeaderPacket(dst, header, pn, pn_len, plaintext, km, .aes128_gcm);
+}
+
+/// Encrypt a long-header (Handshake / 0-RTT) packet and apply header protection.
+pub fn protectLongHeaderPacket(
+    dst: []u8,
+    header: []const u8,
+    pn: u64,
+    pn_len: u2,
+    plaintext: []const u8,
+    km: *const KeyMaterial,
+    cipher: PacketCipher,
+) aead.AeadError!usize {
     const actual_pn_len: usize = @as(usize, pn_len) + 1;
-    const ct_and_tag_len = plaintext.len + 16; // AES-128-GCM tag
+    const ct_and_tag_len = plaintext.len + 16;
 
     if (dst.len < header.len + actual_pn_len + ct_and_tag_len) return error.BufferTooSmall;
 
-    // Copy header
     @memcpy(dst[0..header.len], header);
+    dst[0] &= ~@as(u8, 0x03);
+    dst[0] |= @as(u8, pn_len);
     var pos = header.len;
 
-    // Write packet number (big-endian, truncated)
     var pn_buf: [4]u8 = undefined;
     var i: usize = 0;
     while (i < actual_pn_len) : (i += 1) {
@@ -89,16 +113,19 @@ pub fn protectInitialPacket(
     @memcpy(dst[pos .. pos + actual_pn_len], pn_buf[0..actual_pn_len]);
     pos += actual_pn_len;
 
-    // AAD = header || pn_bytes
-    const aad = dst[0..pos];
+    var aad_buf: [128]u8 = undefined;
+    if (pos > aad_buf.len) return error.BufferTooSmall;
+    @memcpy(aad_buf[0..pos], dst[0..pos]);
+    const aad = aad_buf[0..pos];
     const nonce = aead.buildNonce(km.iv, pn);
 
-    // Encrypt payload
-    try km.aes_ctx.encrypt(dst[pos .. pos + ct_and_tag_len], plaintext, aad, nonce);
+    switch (cipher) {
+        .aes128_gcm => try km.aes_ctx.encrypt(dst[pos .. pos + ct_and_tag_len], plaintext, aad, nonce),
+        .aes256_gcm => try aead.encryptAes256Gcm(dst[pos .. pos + ct_and_tag_len], plaintext, aad, km.key32, nonce),
+        .chacha20_poly1305 => try aead.encryptChaCha20Poly1305(dst[pos .. pos + ct_and_tag_len], plaintext, aad, km.key32, nonce),
+    }
     pos += ct_and_tag_len;
 
-    // Apply header protection using cached HP context
-    // Sample starts at pn_start + 4 (RFC 9001 §5.4.2)
     const pn_start = header.len;
     const sample_start = pn_start + hp_sample_offset;
     if (pos < sample_start + hp_sample_len) return error.BufferTooSmall;
@@ -106,12 +133,18 @@ pub fn protectInitialPacket(
     @memcpy(&sample, dst[sample_start .. sample_start + hp_sample_len]);
 
     const pn_bytes_slice = dst[pn_start .. pn_start + actual_pn_len];
-    // RFC 9001 §5.4.1: long headers mask bits 3-0 (0x0f), short headers mask bits 5-0 (0x1f).
     const first_byte_mask: u8 = if (header[0] & 0x80 != 0) 0x0f else 0x1f;
-    const mask = km.hp_ctx.hpMask(sample);
-    dst[0] ^= mask[0] & first_byte_mask;
-    for (pn_bytes_slice, 0..) |*b, mi| {
-        b.* ^= mask[1 + mi];
+    switch (cipher) {
+        .aes128_gcm, .aes256_gcm => {
+            const mask = km.hp_ctx.hpMask(sample);
+            dst[0] ^= mask[0] & first_byte_mask;
+            for (pn_bytes_slice, 0..) |*b, mi| {
+                b.* ^= mask[1 + mi];
+            }
+        },
+        .chacha20_poly1305 => {
+            aead.HeaderProtection.applyChaCha20(km.hp32, sample, &dst[0], pn_bytes_slice, first_byte_mask);
+        },
     }
 
     return pos;
@@ -146,6 +179,18 @@ pub fn unprotectInitialPacket(
     km: *const KeyMaterial,
     expected_recv_pn: ?u64,
 ) (aead.AeadError || error{BufferTooShort})!UnprotectResult {
+    return unprotectLongHeaderPacket(dst, buf, pn_start, payload_end, km, expected_recv_pn, .aes128_gcm);
+}
+
+pub fn unprotectLongHeaderPacket(
+    dst: []u8,
+    buf: []const u8,
+    pn_start: usize,
+    payload_end: usize,
+    km: *const KeyMaterial,
+    expected_recv_pn: ?u64,
+    cipher: PacketCipher,
+) (aead.AeadError || error{BufferTooShort})!UnprotectResult {
     if (buf.len < pn_start + hp_sample_offset + hp_sample_len) return error.BufferTooShort;
 
     // Sample for header protection removal
@@ -155,21 +200,44 @@ pub fn unprotectInitialPacket(
 
     // Compute HP mask and unmask first byte to discover PN length.
     const first_byte_mask: u8 = if (buf[0] & 0x80 != 0) 0x0f else 0x1f;
-    const mask = km.hp_ctx.hpMask(sample);
-    const unmasked_first = buf[0] ^ (mask[0] & first_byte_mask);
+    const unmasked_first: u8 = switch (cipher) {
+        .aes128_gcm, .aes256_gcm => blk: {
+            const mask = km.hp_ctx.hpMask(sample);
+            break :blk buf[0] ^ (mask[0] & first_byte_mask);
+        },
+        .chacha20_poly1305 => blk: {
+            const counter = std.mem.readInt(u32, sample[0..4], .little);
+            const cc_nonce = sample[4..16].*;
+            var full_mask: [64]u8 = undefined;
+            std.crypto.stream.chacha.ChaCha20IETF.xor(&full_mask, &(.{0} ** 64), counter, km.hp32, cc_nonce);
+            break :blk buf[0] ^ (full_mask[0] & first_byte_mask);
+        },
+    };
     const actual_pn_len: usize = (unmasked_first & 0x03) + 1;
 
-    // Copy only the header bytes needed for AAD (replaces the 1600-byte full-packet copy).
-    // 128 bytes covers the worst case: 1 + 4 + 1+20 + 1+20 + 8(token_len) + 53(token) + 8 + 4 = ~120.
     const aad_end = pn_start + actual_pn_len;
     var aad_buf: [128]u8 = undefined;
     if (aad_end > aad_buf.len or aad_end > buf.len) return error.BufferTooShort;
     @memcpy(aad_buf[0..aad_end], buf[0..aad_end]);
 
-    // Unmask first byte and PN bytes in the AAD copy.
-    aad_buf[0] ^= mask[0] & first_byte_mask;
-    for (aad_buf[pn_start..aad_end], 1..) |*b, mi| {
-        b.* ^= mask[mi];
+    switch (cipher) {
+        .aes128_gcm, .aes256_gcm => {
+            const mask = km.hp_ctx.hpMask(sample);
+            aad_buf[0] ^= mask[0] & first_byte_mask;
+            for (aad_buf[pn_start..aad_end], 1..) |*b, mi| {
+                b.* ^= mask[mi];
+            }
+        },
+        .chacha20_poly1305 => {
+            const counter = std.mem.readInt(u32, sample[0..4], .little);
+            const cc_nonce = sample[4..16].*;
+            var full_mask: [64]u8 = undefined;
+            std.crypto.stream.chacha.ChaCha20IETF.xor(&full_mask, &(.{0} ** 64), counter, km.hp32, cc_nonce);
+            aad_buf[0] ^= full_mask[0] & first_byte_mask;
+            for (aad_buf[pn_start..aad_end], 1..) |*b, mi| {
+                b.* ^= full_mask[mi];
+            }
+        },
     }
 
     // Decode the truncated wire PN, then reconstruct the full PN per RFC 9000
@@ -193,7 +261,11 @@ pub fn unprotectInitialPacket(
     const plaintext_len = ciphertext.len - 16;
     if (dst.len < plaintext_len) return error.BufferTooSmall;
 
-    try km.aes_ctx.decrypt(dst[0..plaintext_len], ciphertext, aad, nonce);
+    switch (cipher) {
+        .aes128_gcm => try km.aes_ctx.decrypt(dst[0..plaintext_len], ciphertext, aad, nonce),
+        .aes256_gcm => try aead.decryptAes256Gcm(dst[0..plaintext_len], ciphertext, aad, km.key32, nonce),
+        .chacha20_poly1305 => try aead.decryptChaCha20Poly1305(dst[0..plaintext_len], ciphertext, aad, km.key32, nonce),
+    }
     return .{ .pt_len = plaintext_len, .pn = pn };
 }
 
@@ -294,6 +366,29 @@ pub fn unprotectPacketChaCha20(
 
     try aead.decryptChaCha20Poly1305(dst[0..plaintext_len], ciphertext, aad_slice, km.key32, nonce);
     return plaintext_len;
+}
+
+test "initial: AES-256-GCM long-header round-trip" {
+    const testing = std.testing;
+    var km: KeyMaterial = .{ .secret = [_]u8{0x77} ** 32 };
+    km.expand();
+
+    const header = [_]u8{ 0xe0, 0x00, 0x00, 0x00, 0x01, 0x08, 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08, 0x00, 0x40, 0x10 };
+    const plaintext = "handshake flight payload";
+
+    var dst: [512]u8 = undefined;
+    const written = try protectLongHeaderPacket(&dst, &header, 0, 0, plaintext, &km, .aes256_gcm);
+    var decrypted: [128]u8 = undefined;
+    const dec = try unprotectLongHeaderPacket(
+        &decrypted,
+        dst[0..written],
+        header.len,
+        written,
+        &km,
+        null,
+        .aes256_gcm,
+    );
+    try testing.expectEqualSlices(u8, plaintext, decrypted[0..dec.pt_len]);
 }
 
 test "initial: encrypt/decrypt round-trip" {

--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -243,9 +243,11 @@ pub const CryptoStream = struct {
 // ---------------------------------------------------------------------------
 
 /// Maximum number of out-of-order segments held per encryption level.
-pub const REORDER_SLOTS: usize = 8;
-/// Maximum byte length of a single buffered CRYPTO fragment.
-pub const REORDER_SLOT_SIZE: usize = 1024;
+pub const REORDER_SLOTS: usize = 24;
+/// Maximum byte length of a single buffered CRYPTO/STREAM fragment.
+/// Must cover `path_mtu.appStreamChunkBytes` (~1350 B) or `insert` drops the
+/// segment and HTTP/0.9 downloads stall under NS3 loss (interop transfer).
+pub const REORDER_SLOT_SIZE: usize = 1450;
 
 const CryptoReorderSlot = struct {
     offset: u64 = 0,

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -230,19 +230,7 @@ pub fn parseClientHello(data: []const u8) ParseError!ClientHelloData {
     const cs_len = readU16(body[p..]);
     p += 2;
     if (body.len < p + cs_len) return error.TruncatedMessage;
-    var preferred: u16 = 0;
-    var i: usize = 0;
-    while (i + 1 < cs_len) : (i += 2) {
-        const cs = readU16(body[p + i ..]);
-        if (preferred == 0 and (cs == TLS_AES_128_GCM_SHA256 or
-            cs == TLS_AES_256_GCM_SHA384 or
-            cs == TLS_CHACHA20_POLY1305_SHA256))
-        {
-            preferred = cs;
-        }
-    }
-    if (preferred == 0) return error.UnsupportedCipherSuites;
-    result.cipher_suite = preferred;
+    result.cipher_suite = selectPreferredCipherSuite(body[p .. p + cs_len]) catch return error.UnsupportedCipherSuites;
     p += cs_len;
 
     // compression methods
@@ -323,6 +311,30 @@ pub fn parseClientHello(data: []const u8) ParseError!ClientHelloData {
 
     if (result.x25519_key == null) return error.NoKeyShare;
     return result;
+}
+
+/// Pick the best TLS 1.3 cipher from a ClientHello cipher_suites list (big-endian u16 values).
+/// Prefer AES-128-GCM for QUIC interop: many peers (e.g. quinn) list AES-256 first but
+/// expect the negotiated AEAD to match the suite (RFC 9001 §5.3).
+pub fn selectPreferredCipherSuite(cs_list: []const u8) !u16 {
+    var best: u16 = 0;
+    var best_rank: u8 = 0;
+    var i: usize = 0;
+    while (i + 1 < cs_list.len) : (i += 2) {
+        const cs = readU16(cs_list[i..]);
+        const rank: u8 = switch (cs) {
+            TLS_AES_128_GCM_SHA256 => 3,
+            TLS_CHACHA20_POLY1305_SHA256 => 2,
+            TLS_AES_256_GCM_SHA384 => 1,
+            else => 0,
+        };
+        if (rank > best_rank) {
+            best_rank = rank;
+            best = cs;
+        }
+    }
+    if (best_rank == 0) return error.UnsupportedCipherSuites;
+    return best;
 }
 
 // ── ServerHello builder ──────────────────────────────────────────────────────
@@ -1727,6 +1739,16 @@ test "handshake: client-server secrets are mirrored" {
     // At this point both sides should have matching handshake secrets
     try testing.expectEqualSlices(u8, &cli.secrets.client_handshake, &srv.secrets.client_handshake);
     try testing.expectEqualSlices(u8, &cli.secrets.server_handshake, &srv.secrets.server_handshake);
+}
+
+test "handshake: selectPreferredCipherSuite prefers AES-128 over AES-256" {
+    const testing = std.testing;
+    // quinn-style ordering: AES-256 first, then AES-128, then ChaCha20.
+    const suites = [_]u8{
+        0x13, 0x02, 0x13, 0x01, 0x13, 0x03,
+    };
+    const picked = try selectPreferredCipherSuite(&suites);
+    try testing.expectEqual(TLS_AES_128_GCM_SHA256, picked);
 }
 
 test "handshake: QUIC key derivation" {

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -6345,7 +6345,7 @@ pub const Client = struct {
                         dbg("io: client writeAll failed stream_id={}: {}\n", .{ sf.stream_id, err });
                         return;
                     };
-                    self.http09AdvanceContiguous(&s.recv_contiguous, sf.offset, sf.data.len);
+                    http09AdvanceContiguous(&s.recv_contiguous, sf.offset, sf.data.len);
                     if (sf.fin) {
                         s.fin_end_offset = sf.offset + @as(u64, @intCast(sf.data.len));
                         dbg("io: stream {} saw FIN (contiguous={} fin_end={})\n", .{

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1791,8 +1791,11 @@ pub const Server = struct {
                 // Retransmitted Initial: re-send the server flight so the client
                 // can make progress even if our first response was lost.
                 if (existing.phase == .waiting_finished or existing.phase == .connected) {
-                    existing.hs_pn = 0;
-                    self.sendCoalescedServerFlight(existing, src);
+                    // Separate Initial + Handshake datagrams (not coalesced): quinn
+                    // rustls rejects a second EncryptedExtensions if the Handshake
+                    // flight is replayed inside a coalesced datagram (#132 / #135).
+                    self.sendInitialServerHello(existing, src);
+                    self.sendHandshakeServerFlight(existing, src);
                 }
                 return;
             }
@@ -2237,7 +2240,11 @@ pub const Server = struct {
             writeKeylog(kpath, conn.tls.ch.random, &conn.tls.secrets);
         }
 
-        self.sendCoalescedServerFlight(conn, src);
+        // Send Initial (ServerHello) and Handshake (EE + cert + Finished) in
+        // separate UDP datagrams.  Coalescing is valid (RFC 9000 §12.2) but
+        // quinn/rustls rejects the coalesced Handshake portion (#132).
+        self.sendInitialServerHello(conn, src);
+        self.sendHandshakeServerFlight(conn, src);
 
         conn.phase = .waiting_finished;
     }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1791,11 +1791,12 @@ pub const Server = struct {
                 // Retransmitted Initial: re-send the server flight so the client
                 // can make progress even if our first response was lost.
                 if (existing.phase == .waiting_finished or existing.phase == .connected) {
-                    // Separate Initial + Handshake datagrams (not coalesced): quinn
-                    // rustls rejects a second EncryptedExtensions if the Handshake
-                    // flight is replayed inside a coalesced datagram (#132 / #135).
+                    // Retransmitted Initial after we already sent the Handshake flight:
+                    // replay only ServerHello in an Initial packet.  Re-sending the
+                    // Handshake CRYPTO stream from offset 0 duplicates
+                    // EncryptedExtensions and quinn/rustls reports
+                    // UnsolicitedEncryptedExtension (interop cross-handshake CI).
                     self.sendInitialServerHello(existing, src);
-                    self.sendHandshakeServerFlight(existing, src);
                 }
                 return;
             }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -3400,7 +3400,7 @@ pub const Server = struct {
         };
         const old_offset = slot.stream_offset;
         slot.stream_offset += @intCast(n);
-        var frame_buf: [2048]u8 = undefined;
+        var frame_buf: [path_mtu_mod.max_app_stream_chunk_cap + 64]u8 = undefined;
         const frame_len = sf_out.serialize(&frame_buf) catch |err| {
             dbg("io: http09 stream_id={} serialize error at offset {}: {}\n", .{ slot.stream_id, old_offset, err });
             if (conn.http09_active_count > 0) conn.http09_active_count -= 1;
@@ -4634,6 +4634,11 @@ const StreamDownload = struct {
     stream_id: u64,
     file: compat.fs.File,
     active: bool,
+    /// Highest contiguous byte offset received from stream offset 0 (HTTP/0.9).
+    recv_contiguous: u64 = 0,
+    /// Set when a STREAM frame with FIN is seen; download completes once
+    /// `recv_contiguous` reaches this offset (handles FIN-before-gap reordering).
+    fin_end_offset: ?u64 = null,
     /// HTTP/3 only: have we already seen and skipped the HEADERS frame?
     h3_headers_received: bool = false,
     /// Small buffer for incomplete HTTP/3 frame headers that span two STREAM frames.
@@ -6258,6 +6263,23 @@ pub const Client = struct {
         rawAppStreamReceiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
     }
 
+    fn http09AdvanceContiguous(recv_contiguous: *u64, frame_offset: u64, data_len: usize) void {
+        if (frame_offset == recv_contiguous.*) {
+            recv_contiguous.* += @as(u64, @intCast(data_len));
+        }
+    }
+
+    fn http09TryCompleteDownload(self: *Client, s: *StreamDownload) void {
+        const fin_end = s.fin_end_offset orelse return;
+        if (!s.active or s.recv_contiguous < fin_end) return;
+        s.file.close();
+        s.active = false;
+        self.streams_done += 1;
+        dbg("io: stream {} download complete (contiguous={} fin_end={} total: {}/{})\n", .{
+            s.stream_id, s.recv_contiguous, fin_end, self.streams_done, self.active_urls.len,
+        });
+    }
+
     fn handleStreamResponse(self: *Client, sf: *const stream_frame_mod.StreamFrame) void {
         dbg("io: client handleStreamResponse stream_id={} data_len={} fin={}\n", .{ sf.stream_id, sf.data.len, sf.fin });
 
@@ -6323,12 +6345,14 @@ pub const Client = struct {
                         dbg("io: client writeAll failed stream_id={}: {}\n", .{ sf.stream_id, err });
                         return;
                     };
+                    self.http09AdvanceContiguous(&s.recv_contiguous, sf.offset, sf.data.len);
                     if (sf.fin) {
-                        s.file.close();
-                        s.active = false;
-                        self.streams_done += 1;
-                        dbg("io: stream {} download complete (total: {}/{})\n", .{ sf.stream_id, self.streams_done, self.active_urls.len });
+                        s.fin_end_offset = sf.offset + @as(u64, @intCast(sf.data.len));
+                        dbg("io: stream {} saw FIN (contiguous={} fin_end={})\n", .{
+                            sf.stream_id, s.recv_contiguous, s.fin_end_offset.?,
+                        });
                     }
+                    self.http09TryCompleteDownload(s);
                 }
                 return;
             }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -6819,58 +6819,45 @@ pub const Client = struct {
                     break :blk url;
                 };
 
-                // For 0-RTT-registered streams, the slot already exists.  If a
-                // response has already arrived (recv_high_water > 0) the GET
-                // was delivered and we skip entirely.  Otherwise the 0-RTT
-                // packet was likely dropped (NS3 25-packet queue) — re-send
-                // the GET as 1-RTT without re-registering the slot.
-                var skip_register = false;
+                // Skip streams already sent as 0-RTT (registered by send0RttRequests).
+                // Re-sending them as 1-RTT would inflate 1-RTT bytes past the
+                // 0-RTT byte total and fail the interop zerortt check.  If a
+                // 0-RTT GET was actually lost the peer's PTO/k_packet_threshold
+                // loss detector will trigger STREAM retransmission on the
+                // already-registered slot.
                 if (global_i < self.zerortt_count) {
-                    var any_progress = false;
-                    for (&self.streams) |*s| {
-                        if (s.active and s.stream_id == stream_id) {
-                            if (s.recv_high_water > 0) any_progress = true;
-                            break;
-                        }
-                    }
-                    if (any_progress) {
-                        dbg("io: stream {} ({s}) already received 0-RTT data, skipping\n", .{ stream_id, path });
-                        continue;
-                    }
-                    dbg("io: stream {} ({s}) 0-RTT GET likely dropped, re-sending as 1-RTT\n", .{ stream_id, path });
-                    skip_register = true;
+                    dbg("io: stream {} ({s}) already sent as 0-RTT, skipping\n", .{ stream_id, path });
+                    continue;
                 }
 
                 dbg("io: downloadUrl[{}] path={s} stream_id={}\n", .{ global_i, path, stream_id });
 
-                if (!skip_register) {
-                    // Open output file
-                    var dl_path_buf: [512]u8 = undefined;
-                    const dl_path = http09_client.downloadPath(self.config.output_dir, path, &dl_path_buf) catch continue;
-                    const out_file = compat.fs.createFileAbsolute(dl_path, .{}) catch {
-                        dbg("io: cannot create {s}\n", .{dl_path});
-                        continue;
-                    };
+                // Open output file
+                var dl_path_buf: [512]u8 = undefined;
+                const dl_path = http09_client.downloadPath(self.config.output_dir, path, &dl_path_buf) catch continue;
+                const out_file = compat.fs.createFileAbsolute(dl_path, .{}) catch {
+                    dbg("io: cannot create {s}\n", .{dl_path});
+                    continue;
+                };
 
-                    // Register stream download in an available slot
-                    var registered = false;
-                    for (&self.streams) |*s| {
-                        if (!s.active) {
-                            s.* = .{ .stream_id = stream_id, .file = out_file, .active = true };
-                            if (!self.config.http3) {
-                                s.recv_reorder = try self.allocator.create(quic_tls_mod.CryptoReorderBuf);
-                                s.recv_reorder.?.* = .{};
-                            }
-                            dbg("io: registered stream {} for download\n", .{stream_id});
-                            registered = true;
-                            break;
+                // Register stream download in an available slot
+                var registered = false;
+                for (&self.streams) |*s| {
+                    if (!s.active) {
+                        s.* = .{ .stream_id = stream_id, .file = out_file, .active = true };
+                        if (!self.config.http3) {
+                            s.recv_reorder = try self.allocator.create(quic_tls_mod.CryptoReorderBuf);
+                            s.recv_reorder.?.* = .{};
                         }
+                        dbg("io: registered stream {} for download\n", .{stream_id});
+                        registered = true;
+                        break;
                     }
-                    if (!registered) {
-                        out_file.close();
-                        dbg("io: streams array full\n", .{});
-                        continue;
-                    }
+                }
+                if (!registered) {
+                    out_file.close();
+                    dbg("io: streams array full\n", .{});
+                    continue;
                 }
 
                 // Build the request payload and QUIC STREAM frame.

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1788,13 +1788,13 @@ pub const Server = struct {
             if (self.findConn(ip.dcid)) |c| break :blk c;
 
             if (self.findConnByPeer(src)) |existing| {
-                // Retransmitted Initial after the server flight was already sent.
-                // Quinn/rustls feed duplicate Initial/Handshake CRYPTO bytes into TLS
-                // and report UnsolicitedEncryptedExtension; zquic clients dedupe by
-                // offset, so silence is safe once we are past the first flight.
+                // Retransmitted Initial: replay the server flight so the client can
+                // make progress when our first response was lost (NS3 drops).
                 if (existing.phase == .waiting_finished or existing.phase == .connected) {
-                    return;
+                    self.sendInitialServerHello(existing, src);
+                    self.sendHandshakeServerFlight(existing, src);
                 }
+                return;
             }
 
             // Truly new connection
@@ -4635,8 +4635,9 @@ const StreamDownload = struct {
     recv_contiguous: u64 = 0,
     /// Highest `offset + data.len` seen (includes out-of-order segments).
     recv_high_water: u64 = 0,
-    /// Out-of-order STREAM payloads waiting to extend `recv_contiguous`.
-    recv_reorder: quic_tls_mod.CryptoReorderBuf = .{},
+    /// HTTP/0.9 only: out-of-order STREAM payloads (heap-allocated; not embedded in
+    /// the struct — 2000× CryptoReorderBuf would overflow the stack in Client.init).
+    recv_reorder: ?*quic_tls_mod.CryptoReorderBuf = null,
     /// Set when a STREAM frame with FIN is seen; download completes once
     /// `recv_contiguous` reaches this offset (handles FIN-before-gap reordering).
     fin_end_offset: ?u64 = null,
@@ -4876,6 +4877,12 @@ pub const Client = struct {
     pub fn deinit(self: *Client) void {
         if (self.client_cert_owned) {
             self.allocator.free(self.client_cert_der);
+        }
+        for (&self.streams) |*s| {
+            if (s.recv_reorder) |r| {
+                self.allocator.destroy(r);
+                s.recv_reorder = null;
+            }
         }
         for (&self.raw_app_recv) |*slot| {
             slot.deinit(self.allocator);
@@ -6269,7 +6276,7 @@ pub const Client = struct {
         rawAppStreamReceiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
     }
 
-    fn http09DeliverStreamBytes(s: *StreamDownload, offset: u64, data: []const u8) void {
+    fn http09DeliverStreamBytes(s: *StreamDownload, reorder: *quic_tls_mod.CryptoReorderBuf, offset: u64, data: []const u8) void {
         const end = offset + @as(u64, @intCast(data.len));
         if (end > s.recv_high_water) s.recv_high_water = end;
 
@@ -6279,7 +6286,7 @@ pub const Client = struct {
             s.recv_contiguous = end;
             var drain_buf: [quic_tls_mod.REORDER_SLOT_SIZE]u8 = undefined;
             while (true) {
-                const n = s.recv_reorder.take(s.recv_contiguous, &drain_buf);
+                const n = reorder.take(s.recv_contiguous, &drain_buf);
                 if (n == 0) break;
                 s.file.seekTo(s.recv_contiguous) catch return;
                 s.file.writeAll(drain_buf[0..n]) catch return;
@@ -6287,7 +6294,14 @@ pub const Client = struct {
                 if (s.recv_contiguous > s.recv_high_water) s.recv_high_water = s.recv_contiguous;
             }
         } else if (offset > s.recv_contiguous) {
-            s.recv_reorder.insert(offset, data);
+            reorder.insert(offset, data);
+        }
+    }
+
+    fn http09FreeStreamReorder(self: *Client, s: *StreamDownload) void {
+        if (s.recv_reorder) |r| {
+            self.allocator.destroy(r);
+            s.recv_reorder = null;
         }
     }
 
@@ -6296,6 +6310,7 @@ pub const Client = struct {
         if (!s.active or s.recv_contiguous < fin_end) return;
         s.file.close();
         s.active = false;
+        self.http09FreeStreamReorder(s);
         self.streams_done += 1;
         dbg("io: stream {} download complete (contiguous={} fin_end={} total: {}/{})\n", .{
             s.stream_id, s.recv_contiguous, fin_end, self.streams_done, self.active_urls.len,
@@ -6356,7 +6371,8 @@ pub const Client = struct {
                     self.handleH3StreamData(s, sf);
                 } else {
                     dbg("io: found matching stream {}, writing {} bytes\n", .{ sf.stream_id, sf.data.len });
-                    http09DeliverStreamBytes(s, sf.offset, sf.data);
+                    const reorder = s.recv_reorder orelse return;
+                    http09DeliverStreamBytes(s, reorder, sf.offset, sf.data);
                     if (sf.fin) {
                         const fin_end = sf.offset + @as(u64, @intCast(sf.data.len));
                         s.fin_end_offset = @max(fin_end, s.recv_high_water);
@@ -6719,6 +6735,10 @@ pub const Client = struct {
                 for (&self.streams) |*s| {
                     if (!s.active) {
                         s.* = .{ .stream_id = stream_id, .file = out_file, .active = true };
+                        if (!self.config.http3) {
+                            s.recv_reorder = try self.allocator.create(quic_tls_mod.CryptoReorderBuf);
+                            s.recv_reorder.?.* = .{};
+                        }
                         dbg("io: registered stream {} for download\n", .{stream_id});
                         registered = true;
                         break;
@@ -6871,6 +6891,7 @@ pub const Client = struct {
             if (s.active) {
                 s.file.close();
                 s.active = false;
+                self.http09FreeStreamReorder(s);
             }
         }
     }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -5265,11 +5265,6 @@ pub const Client = struct {
             // the existing processAppFrames handler responds with PATH_RESPONSE,
             // the server validates and updates conn.peer, and subsequent STREAM
             // responses are delivered to the new address (RFC 9000 §9).
-            if (self.conn.phase == .connected and self.config.migrate and !self.migrate_done) {
-                self.migrate_done = true;
-                self.rebindMigrateSocket(server_addr);
-            }
-
             // On connection established, send requests
             if (self.conn.phase == .connected and !self.requested) {
                 // Drain any 0-RTT GETs that did not fit in the first two NS3-safe batches.
@@ -5280,6 +5275,14 @@ pub const Client = struct {
                     try self.downloadUrls(server_addr);
                 }
                 self.requested = true;
+            }
+
+            // Migrate only after the download has started (RFC 9000 §9; interop
+            // connectionmigration).  Doing this before `downloadUrls` races the
+            // first GET with path validation on a fresh socket.
+            if (self.conn.phase == .connected and self.config.migrate and self.requested and !self.migrate_done) {
+                self.migrate_done = true;
+                self.rebindMigrateSocket(server_addr);
             }
 
             // Wait until all streams complete

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1788,17 +1788,13 @@ pub const Server = struct {
             if (self.findConn(ip.dcid)) |c| break :blk c;
 
             if (self.findConnByPeer(src)) |existing| {
-                // Retransmitted Initial: re-send the server flight so the client
-                // can make progress even if our first response was lost.
+                // Retransmitted Initial after the server flight was already sent.
+                // Quinn/rustls feed duplicate Initial/Handshake CRYPTO bytes into TLS
+                // and report UnsolicitedEncryptedExtension; zquic clients dedupe by
+                // offset, so silence is safe once we are past the first flight.
                 if (existing.phase == .waiting_finished or existing.phase == .connected) {
-                    // Retransmitted Initial after we already sent the Handshake flight:
-                    // replay only ServerHello in an Initial packet.  Re-sending the
-                    // Handshake CRYPTO stream from offset 0 duplicates
-                    // EncryptedExtensions and quinn/rustls reports
-                    // UnsolicitedEncryptedExtension (interop cross-handshake CI).
-                    self.sendInitialServerHello(existing, src);
+                    return;
                 }
-                return;
             }
 
             // Truly new connection
@@ -4637,6 +4633,10 @@ const StreamDownload = struct {
     active: bool,
     /// Highest contiguous byte offset received from stream offset 0 (HTTP/0.9).
     recv_contiguous: u64 = 0,
+    /// Highest `offset + data.len` seen (includes out-of-order segments).
+    recv_high_water: u64 = 0,
+    /// Out-of-order STREAM payloads waiting to extend `recv_contiguous`.
+    recv_reorder: quic_tls_mod.CryptoReorderBuf = .{},
     /// Set when a STREAM frame with FIN is seen; download completes once
     /// `recv_contiguous` reaches this offset (handles FIN-before-gap reordering).
     fin_end_offset: ?u64 = null,
@@ -5214,6 +5214,11 @@ pub const Client = struct {
         if (self.conn.phase != .connected) {
             dbg("io: client handshake timed out\n", .{});
             return error.HandshakeTimeout;
+        }
+
+        if (self.streams_done < self.active_urls.len) {
+            dbg("io: client downloads incomplete streams_done={}/{}\n", .{ self.streams_done, self.active_urls.len });
+            return error.DownloadIncomplete;
         }
 
         dbg("io: client done - phase={any} streams_done={}/{}\n", .{ self.conn.phase, self.streams_done, self.active_urls.len });
@@ -6264,9 +6269,25 @@ pub const Client = struct {
         rawAppStreamReceiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
     }
 
-    fn http09AdvanceContiguous(recv_contiguous: *u64, frame_offset: u64, data_len: usize) void {
-        if (frame_offset == recv_contiguous.*) {
-            recv_contiguous.* += @as(u64, @intCast(data_len));
+    fn http09DeliverStreamBytes(s: *StreamDownload, offset: u64, data: []const u8) void {
+        const end = offset + @as(u64, @intCast(data.len));
+        if (end > s.recv_high_water) s.recv_high_water = end;
+
+        if (offset == s.recv_contiguous) {
+            s.file.seekTo(offset) catch return;
+            s.file.writeAll(data) catch return;
+            s.recv_contiguous = end;
+            var drain_buf: [quic_tls_mod.REORDER_SLOT_SIZE]u8 = undefined;
+            while (true) {
+                const n = s.recv_reorder.take(s.recv_contiguous, &drain_buf);
+                if (n == 0) break;
+                s.file.seekTo(s.recv_contiguous) catch return;
+                s.file.writeAll(drain_buf[0..n]) catch return;
+                s.recv_contiguous += @as(u64, @intCast(n));
+                if (s.recv_contiguous > s.recv_high_water) s.recv_high_water = s.recv_contiguous;
+            }
+        } else if (offset > s.recv_contiguous) {
+            s.recv_reorder.insert(offset, data);
         }
     }
 
@@ -6335,22 +6356,12 @@ pub const Client = struct {
                     self.handleH3StreamData(s, sf);
                 } else {
                     dbg("io: found matching stream {}, writing {} bytes\n", .{ sf.stream_id, sf.data.len });
-                    // Write at the exact stream offset so retransmitted or
-                    // out-of-order STREAM frames (possible after a NAT rebind
-                    // triggers server-side retransmit) land at the right place.
-                    s.file.seekTo(sf.offset) catch |err| {
-                        dbg("io: client seekTo failed stream_id={}: {}\n", .{ sf.stream_id, err });
-                        return;
-                    };
-                    s.file.writeAll(sf.data) catch |err| {
-                        dbg("io: client writeAll failed stream_id={}: {}\n", .{ sf.stream_id, err });
-                        return;
-                    };
-                    http09AdvanceContiguous(&s.recv_contiguous, sf.offset, sf.data.len);
+                    http09DeliverStreamBytes(s, sf.offset, sf.data);
                     if (sf.fin) {
-                        s.fin_end_offset = sf.offset + @as(u64, @intCast(sf.data.len));
-                        dbg("io: stream {} saw FIN (contiguous={} fin_end={})\n", .{
-                            sf.stream_id, s.recv_contiguous, s.fin_end_offset.?,
+                        const fin_end = sf.offset + @as(u64, @intCast(sf.data.len));
+                        s.fin_end_offset = @max(fin_end, s.recv_high_water);
+                        dbg("io: stream {} saw FIN (contiguous={} fin_end={} high_water={})\n", .{
+                            sf.stream_id, s.recv_contiguous, s.fin_end_offset.?, s.recv_high_water,
                         });
                     }
                     self.http09TryCompleteDownload(s);
@@ -6777,7 +6788,7 @@ pub const Client = struct {
             // Wait for all downloads in this batch to complete.
             const batch_target = batch_end;
             dbg("io: downloadUrls waiting for batch target={} (deadline=60s)\n", .{batch_target});
-            const dl_deadline = compat.milliTimestamp() + 60_000;
+            const dl_deadline = compat.milliTimestamp() + 120_000;
             var dl_iter: u32 = 0;
             while (true) {
                 dl_iter += 1;

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -5506,9 +5506,9 @@ pub const Client = struct {
             var registered = false;
             for (&self.streams) |*s| {
                 if (!s.active) {
+                    s.* = .{ .stream_id = stream_id, .file = out_file, .active = true };
                     s.recv_reorder = try self.allocator.create(quic_tls_mod.CryptoReorderBuf);
                     s.recv_reorder.?.* = .{};
-                    s.* = .{ .stream_id = stream_id, .file = out_file, .active = true };
                     registered = true;
                     break;
                 }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -5166,9 +5166,10 @@ pub const Client = struct {
 
         // Event loop: receive and process packets
         var recv_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        // Scale budget for parallel 0-RTT downloads (interop zerortt sends ~30 GETs).
-        const url_budget_ms: i64 = @intCast(@min(self.active_urls.len * 5_000, 240_000));
-        var deadline = compat.milliTimestamp() + @max(120_000, url_budget_ms);
+        // 120 s overall budget keeps us well below the interop runner's 180 s
+        // docker abort, so a stall surfaces as `error.DownloadIncomplete`
+        // instead of a silent SIGKILL.
+        var deadline = compat.milliTimestamp() + 120_000;
 
         while (compat.milliTimestamp() < deadline) {
             const now = compat.milliTimestamp();
@@ -5265,6 +5266,15 @@ pub const Client = struct {
             // the existing processAppFrames handler responds with PATH_RESPONSE,
             // the server validates and updates conn.peer, and subsequent STREAM
             // responses are delivered to the new address (RFC 9000 §9).
+            // Connection migration (RFC 9000 §9): rebind to a new ephemeral
+            // port as soon as the handshake completes so subsequent GETs go
+            // out on the new path. The interop runner verifies via pcap that
+            // the server observed >1 source ports.
+            if (self.conn.phase == .connected and self.config.migrate and !self.migrate_done) {
+                self.migrate_done = true;
+                self.rebindMigrateSocket(server_addr);
+            }
+
             // On connection established, send requests
             if (self.conn.phase == .connected and !self.requested) {
                 // Drain any 0-RTT GETs that did not fit in the first two NS3-safe batches.
@@ -5275,14 +5285,6 @@ pub const Client = struct {
                     try self.downloadUrls(server_addr);
                 }
                 self.requested = true;
-            }
-
-            // Migrate only after the download has started (RFC 9000 §9; interop
-            // connectionmigration).  Doing this before `downloadUrls` races the
-            // first GET with path validation on a fresh socket.
-            if (self.conn.phase == .connected and self.config.migrate and self.requested and !self.migrate_done) {
-                self.migrate_done = true;
-                self.rebindMigrateSocket(server_addr);
             }
 
             // Wait until all streams complete
@@ -6817,43 +6819,58 @@ pub const Client = struct {
                     break :blk url;
                 };
 
-                // Skip streams already sent as 0-RTT (registered by send0RttRequests).
-                // Those streams are already tracked in self.streams; re-registering them
-                // would create duplicate slots.  The responses will arrive independently
-                // (either during the handshake phase or via server FIN retransmits).
+                // For 0-RTT-registered streams, the slot already exists.  If a
+                // response has already arrived (recv_high_water > 0) the GET
+                // was delivered and we skip entirely.  Otherwise the 0-RTT
+                // packet was likely dropped (NS3 25-packet queue) — re-send
+                // the GET as 1-RTT without re-registering the slot.
+                var skip_register = false;
                 if (global_i < self.zerortt_count) {
-                    dbg("io: stream {} ({s}) already sent as 0-RTT, skipping\n", .{ stream_id, path });
-                    continue;
+                    var any_progress = false;
+                    for (&self.streams) |*s| {
+                        if (s.active and s.stream_id == stream_id) {
+                            if (s.recv_high_water > 0) any_progress = true;
+                            break;
+                        }
+                    }
+                    if (any_progress) {
+                        dbg("io: stream {} ({s}) already received 0-RTT data, skipping\n", .{ stream_id, path });
+                        continue;
+                    }
+                    dbg("io: stream {} ({s}) 0-RTT GET likely dropped, re-sending as 1-RTT\n", .{ stream_id, path });
+                    skip_register = true;
                 }
 
                 dbg("io: downloadUrl[{}] path={s} stream_id={}\n", .{ global_i, path, stream_id });
 
-                // Open output file
-                var dl_path_buf: [512]u8 = undefined;
-                const dl_path = http09_client.downloadPath(self.config.output_dir, path, &dl_path_buf) catch continue;
-                const out_file = compat.fs.createFileAbsolute(dl_path, .{}) catch {
-                    dbg("io: cannot create {s}\n", .{dl_path});
-                    continue;
-                };
+                if (!skip_register) {
+                    // Open output file
+                    var dl_path_buf: [512]u8 = undefined;
+                    const dl_path = http09_client.downloadPath(self.config.output_dir, path, &dl_path_buf) catch continue;
+                    const out_file = compat.fs.createFileAbsolute(dl_path, .{}) catch {
+                        dbg("io: cannot create {s}\n", .{dl_path});
+                        continue;
+                    };
 
-                // Register stream download in an available slot
-                var registered = false;
-                for (&self.streams) |*s| {
-                    if (!s.active) {
-                        s.* = .{ .stream_id = stream_id, .file = out_file, .active = true };
-                        if (!self.config.http3) {
-                            s.recv_reorder = try self.allocator.create(quic_tls_mod.CryptoReorderBuf);
-                            s.recv_reorder.?.* = .{};
+                    // Register stream download in an available slot
+                    var registered = false;
+                    for (&self.streams) |*s| {
+                        if (!s.active) {
+                            s.* = .{ .stream_id = stream_id, .file = out_file, .active = true };
+                            if (!self.config.http3) {
+                                s.recv_reorder = try self.allocator.create(quic_tls_mod.CryptoReorderBuf);
+                                s.recv_reorder.?.* = .{};
+                            }
+                            dbg("io: registered stream {} for download\n", .{stream_id});
+                            registered = true;
+                            break;
                         }
-                        dbg("io: registered stream {} for download\n", .{stream_id});
-                        registered = true;
-                        break;
                     }
-                }
-                if (!registered) {
-                    out_file.close();
-                    dbg("io: streams array full\n", .{});
-                    continue;
+                    if (!registered) {
+                        out_file.close();
+                        dbg("io: streams array full\n", .{});
+                        continue;
+                    }
                 }
 
                 // Build the request payload and QUIC STREAM frame.

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -9,8 +9,8 @@
 //!
 //! Encryption levels:
 //!   Initial    – AES-128-GCM with DCID-derived Initial secrets
-//!   Handshake  – AES-128-GCM with keys derived from TLS handshake_secret
-//!   1-RTT      – AES-128-GCM with keys derived from TLS application_secret
+//!   Handshake  – AEAD from negotiated TLS cipher (AES-128/256-GCM or ChaCha20)
+//!   1-RTT      – same AEAD as Handshake
 
 const std = @import("std");
 const compat = @import("../compat.zig");
@@ -52,6 +52,16 @@ const ConnectionId = types.ConnectionId;
 const KeyMaterial = keys_mod.KeyMaterial;
 const InitialSecrets = keys_mod.InitialSecrets;
 const QuicKeyMaterial = tls_hs.QuicKeyMaterial;
+const PacketCipher = initial_mod.PacketCipher;
+
+fn packetCipherFromTls(cipher_suite: u16) PacketCipher {
+    return switch (cipher_suite) {
+        tls_hs.TLS_AES_128_GCM_SHA256 => .aes128_gcm,
+        tls_hs.TLS_AES_256_GCM_SHA384 => .aes256_gcm,
+        tls_hs.TLS_CHACHA20_POLY1305_SHA256 => .chacha20_poly1305,
+        else => .aes128_gcm,
+    };
+}
 const ServerHandshake = tls_hs.ServerHandshake;
 const ClientHandshake = tls_hs.ClientHandshake;
 
@@ -333,6 +343,7 @@ pub fn buildHandshakePacket(
     pn: u64,
     km: *const KeyMaterial,
     version: u32,
+    cipher: PacketCipher,
 ) !usize {
     var hdr_buf: [128]u8 = undefined;
     var hp: usize = 0;
@@ -354,7 +365,7 @@ pub fn buildHandshakePacket(
     hp += len_enc2.len;
 
     // We reuse the Initial protect logic since the AEAD structure is identical.
-    return initial_mod.protectInitialPacket(out, hdr_buf[0..hp], pn, 0, payload, km);
+    return initial_mod.protectLongHeaderPacket(out, hdr_buf[0..hp], pn, 0, payload, km, cipher);
 }
 
 /// Build a 0-RTT (Long Header, Type=0-RTT) packet.
@@ -367,6 +378,7 @@ pub fn build0RttPacket(
     pn: u64,
     km: *const KeyMaterial,
     version: u32,
+    cipher: PacketCipher,
 ) !usize {
     var hdr_buf: [128]u8 = undefined;
     var hp: usize = 0;
@@ -385,7 +397,7 @@ pub fn build0RttPacket(
     const length: u64 = 1 + payload.len + 16;
     const len_enc = try varint.encode(hdr_buf[hp..], length);
     hp += len_enc.len;
-    return initial_mod.protectInitialPacket(out, hdr_buf[0..hp], pn, 0, payload, km);
+    return initial_mod.protectLongHeaderPacket(out, hdr_buf[0..hp], pn, 0, payload, km, cipher);
 }
 
 /// Build a 1-RTT (Short Header) packet.
@@ -555,8 +567,9 @@ pub fn decryptLongPacket(
     payload_end: usize,
     km: *const KeyMaterial,
     expected_recv_pn: ?u64,
+    cipher: PacketCipher,
 ) !initial_mod.UnprotectResult {
-    return initial_mod.unprotectInitialPacket(dst, buf, pn_start, payload_end, km, expected_recv_pn);
+    return initial_mod.unprotectLongHeaderPacket(dst, buf, pn_start, payload_end, km, expected_recv_pn, cipher);
 }
 
 // ── PEM loading helpers ───────────────────────────────────────────────────────
@@ -1095,6 +1108,8 @@ pub const ConnState = struct {
     early_km: KeyMaterial = undefined,
     has_early_keys: bool = false,
 
+    // AEAD for Handshake / 0-RTT / 1-RTT (Initial always AES-128-GCM).
+    packet_cipher: PacketCipher = .aes128_gcm,
     // Cipher suite in use for 1-RTT packets (true = ChaCha20-Poly1305).
     use_chacha20: bool = false,
 
@@ -1149,15 +1164,18 @@ pub const ConnState = struct {
     /// Derive Handshake QUIC keys from TLS handshake traffic secrets.
     /// Call this after processServerHello (client) or processClientHello (server).
     pub fn deriveHandshakeKeys(self: *ConnState, secrets: *const tls_hs.TrafficSecrets) void {
-        const hs_client_qkm = tls_hs.deriveQuicKeys(secrets.client_handshake);
-        const hs_server_qkm = tls_hs.deriveQuicKeys(secrets.server_handshake);
-
-        self.hs_client_km = .{ .key = hs_client_qkm.key, .key32 = hs_client_qkm.key32, .iv = hs_client_qkm.iv, .hp = hs_client_qkm.hp, .hp32 = hs_client_qkm.hp32, .secret = secrets.client_handshake };
-        self.hs_client_km.initCachedContexts();
-        self.hs_server_km = .{ .key = hs_server_qkm.key, .key32 = hs_server_qkm.key32, .iv = hs_server_qkm.iv, .hp = hs_server_qkm.hp, .hp32 = hs_server_qkm.hp32, .secret = secrets.server_handshake };
-        self.hs_server_km.initCachedContexts();
+        self.hs_client_km = .{ .secret = secrets.client_handshake };
+        self.hs_server_km = .{ .secret = secrets.server_handshake };
+        if (self.use_v2) {
+            self.hs_client_km.expandV2();
+            self.hs_server_km.expandV2();
+        } else {
+            self.hs_client_km.expand();
+            self.hs_server_km.expand();
+        }
 
         self.has_hs_keys = true;
+        self.qlog.keyUpdated("handshake", "tls");
     }
 
     /// Derive 1-RTT QUIC keys from TLS application traffic secrets.
@@ -1773,8 +1791,8 @@ pub const Server = struct {
                 // Retransmitted Initial: re-send the server flight so the client
                 // can make progress even if our first response was lost.
                 if (existing.phase == .waiting_finished or existing.phase == .connected) {
-                    self.sendInitialServerHello(existing, src);
-                    self.sendHandshakeServerFlight(existing, src);
+                    existing.hs_pn = 0;
+                    self.sendCoalescedServerFlight(existing, src);
                 }
                 return;
             }
@@ -1903,6 +1921,7 @@ pub const Server = struct {
             payload_end,
             &conn.early_km,
             conn.zerortt_recv_pn,
+            conn.packet_cipher,
         ) catch |err| {
             dbg("io: 0-RTT decrypt failed: {}\n", .{err});
             return;
@@ -2119,12 +2138,9 @@ pub const Server = struct {
         conn.sh_len = sh_len;
 
         // Handshake secrets are available; derive QUIC handshake keys.
+        conn.packet_cipher = packetCipherFromTls(conn.tls.ch.cipher_suite);
+        conn.use_chacha20 = conn.packet_cipher == .chacha20_poly1305;
         conn.deriveHandshakeKeys(&conn.tls.secrets);
-
-        // Set cipher based on what was negotiated with the client.
-        if (conn.tls.ch.cipher_suite == tls_hs.TLS_CHACHA20_POLY1305_SHA256) {
-            conn.use_chacha20 = true;
-        }
 
         // Build and send server flight
         self.buildAndSendServerFlight(conn, src);
@@ -2217,12 +2233,11 @@ pub const Server = struct {
         // App secrets are now derived inside buildServerFlight; derive QUIC keys.
         conn.deriveAppKeys(&conn.tls.secrets);
 
-        // Send Initial (ServerHello) and Handshake (EE + cert + Finished) in
-        // separate UDP datagrams.  Coalescing (RFC 9000 §12.2) is valid but
-        // quinn rejects the coalesced Handshake portion (#132); separate sends
-        // match what quinn-interop and other stacks expect in practice.
-        self.sendInitialServerHello(conn, src);
-        self.sendHandshakeServerFlight(conn, src);
+        if (self.config.keylog_path) |kpath| {
+            writeKeylog(kpath, conn.tls.ch.random, &conn.tls.secrets);
+        }
+
+        self.sendCoalescedServerFlight(conn, src);
 
         conn.phase = .waiting_finished;
     }
@@ -2263,9 +2278,11 @@ pub const Server = struct {
                 dbg("io: amplification limit reached, deferring Initial ServerHello\n", .{});
                 return;
             }
+            const init_pn_sent = conn.init_pn;
             conn.init_pn += 1;
             conn.anti_amp_bytes_sent += pkt_len;
             coalesced_len = pkt_len;
+            conn.qlog.packetSent(.initial, init_pn_sent, pkt_len);
         }
 
         // ── Append Handshake packet(s) into the same datagram ───────────────
@@ -2285,20 +2302,23 @@ pub const Server = struct {
 
                 // Try to fit this Handshake packet into the coalesced datagram.
                 const remaining = coalesced_buf[coalesced_len..];
+                const hs_pn_sent = conn.hs_pn;
                 const pkt_len = buildHandshakePacket(
                     remaining,
                     conn.remote_cid,
                     conn.local_cid,
                     frames_buf[0..crypto_len],
-                    conn.hs_pn,
+                    hs_pn_sent,
                     &conn.hs_server_km,
                     conn.quicVersion(),
+                    conn.packet_cipher,
                 ) catch break; // not enough room — send what we have, rest goes separately
 
                 if (!conn.address_validated and conn.anti_amp_bytes_sent + pkt_len > conn.anti_amp_bytes_recv * 3) {
                     dbg("io: amplification limit reached, deferring Handshake flight\n", .{});
                     break;
                 }
+                conn.qlog.packetSent(.handshake, hs_pn_sent, pkt_len);
                 conn.hs_pn += 1;
                 conn.anti_amp_bytes_sent += pkt_len;
                 coalesced_len += pkt_len;
@@ -2359,8 +2379,10 @@ pub const Server = struct {
             return;
         }
 
+        const init_pn_sent = conn.init_pn;
         conn.init_pn += 1;
         conn.anti_amp_bytes_sent += pkt_len;
+        conn.qlog.packetSent(.initial, init_pn_sent, pkt_len);
 
         _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch |err| {
             dbg("io: sendto Initial failed: {}\n", .{err});
@@ -2394,14 +2416,16 @@ pub const Server = struct {
             ) catch return;
             fp += crypto_len;
 
+            const hs_pn_sent = conn.hs_pn;
             const pkt_len = buildHandshakePacket(
                 &send_buf,
                 conn.remote_cid,
                 conn.local_cid,
                 frames_buf[0..fp],
-                conn.hs_pn,
+                hs_pn_sent,
                 &conn.hs_server_km,
                 conn.quicVersion(),
+                conn.packet_cipher,
             ) catch return;
 
             if (!conn.address_validated and conn.anti_amp_bytes_sent + pkt_len > conn.anti_amp_bytes_recv * 3) {
@@ -2411,6 +2435,7 @@ pub const Server = struct {
 
             conn.hs_pn += 1;
             conn.anti_amp_bytes_sent += pkt_len;
+            conn.qlog.packetSent(.handshake, hs_pn_sent, pkt_len);
 
             _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch |err| {
                 dbg("io: sendto Handshake failed: {}\n", .{err});
@@ -2464,6 +2489,7 @@ pub const Server = struct {
             payload_end,
             &conn.hs_client_km,
             conn.hs_recv_pn,
+            conn.packet_cipher,
         ) catch return;
         const pt_len = dec.pt_len;
         if (conn.hs_recv_pn == null or dec.pn > conn.hs_recv_pn.?)
@@ -2556,16 +2582,19 @@ pub const Server = struct {
         var frames_buf: [64]u8 = undefined;
         const ack_len = buildAckFrame(&frames_buf, pn, 0) catch return;
 
+        const hs_pn_sent = conn.hs_pn;
         const pkt_len = buildHandshakePacket(
             &send_buf,
             conn.remote_cid,
             conn.local_cid,
             frames_buf[0..ack_len],
-            conn.hs_pn,
+            hs_pn_sent,
             &conn.hs_server_km,
             conn.quicVersion(),
+            conn.packet_cipher,
         ) catch return;
         conn.hs_pn += 1;
+        conn.qlog.packetSent(.handshake, hs_pn_sent, pkt_len);
 
         _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch {};
     }
@@ -5407,6 +5436,7 @@ pub const Client = struct {
                 self.zerortt_pn,
                 &km,
                 self.conn.quicVersion(),
+                packetCipherFromTls(self.tls.cipher_suite),
             ) catch continue;
             self.zerortt_pn += 1;
             _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &server.any, server.getOsSockLen()) catch {};
@@ -5605,11 +5635,9 @@ pub const Client = struct {
                     return;
                 };
                 // Now we have handshake secrets — derive QUIC keys
+                self.conn.packet_cipher = packetCipherFromTls(self.tls.cipher_suite);
+                self.conn.use_chacha20 = self.conn.packet_cipher == .chacha20_poly1305;
                 self.conn.deriveHandshakeKeys(&self.tls.secrets);
-                // Set cipher based on what the server negotiated.
-                if (self.tls.cipher_suite == tls_hs.TLS_CHACHA20_POLY1305_SHA256) {
-                    self.conn.use_chacha20 = true;
-                }
             }
             pos += dlen;
         }
@@ -5638,6 +5666,7 @@ pub const Client = struct {
             payload_end,
             &self.conn.hs_server_km,
             self.conn.hs_recv_pn,
+            self.conn.packet_cipher,
         ) catch return;
         const pt_len = dec.pt_len;
         if (self.conn.hs_recv_pn == null or dec.pn > self.conn.hs_recv_pn.?)
@@ -5704,16 +5733,19 @@ pub const Client = struct {
             ) catch return;
 
             var pkt_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+            const hs_pn_sent = self.conn.hs_pn;
             const pkt_len = buildHandshakePacket(
                 &pkt_buf,
                 self.conn.remote_cid,
                 self.conn.local_cid,
                 frame_buf[0..crypto_len],
-                self.conn.hs_pn,
+                hs_pn_sent,
                 &self.conn.hs_client_km,
                 self.conn.quicVersion(),
+                self.conn.packet_cipher,
             ) catch return;
             self.conn.hs_pn += 1;
+            self.conn.qlog.packetSent(.handshake, hs_pn_sent, pkt_len);
 
             _ = compat.sendto(
                 self.sock,


### PR DESCRIPTION
## Summary

Fixes [issue #135](https://github.com/ch4r10t33r/zquic/issues/135): quinn could decrypt zquic's Initial ServerHello but rejected the server Handshake flight with an AEAD tag error.

**Root cause:** quinn's ClientHello lists `TLS_AES_256_GCM_SHA384` first; zquic negotiated it but still encrypted Handshake/0-RTT/1-RTT packets with AES-128-GCM only. Initial packets always use AES-128 per RFC 9001, which is why ServerHello decrypted while the Handshake packet did not.

**Changes:**
- Prefer AES-128-GCM when the client offers multiple TLS 1.3 suites (quinn-style ordering).
- Add cipher-aware long-header protect/unprotect (AES-128, AES-256, ChaCha20) for Handshake / 0-RTT / 1-RTT.
- Derive handshake keys via `KeyMaterial.expand()` / `expandV2()` for QUIC v2 label compatibility.
- Restore coalesced Initial+Handshake server flight (RFC 9000 §12.2).
- Emit qlog `packet_sent` + handshake `key_updated`; write NSS keylog before sending the flight.
- Reset `hs_pn` on full-flight retransmit; fail PR CI on `quinn→zquic` handshake smoke.

## Test plan

- [x] `zig build test --summary all` (165/165 pass locally)
- [ ] CI interop: `zquic↔zquic` matrix green
- [ ] CI interop: `quinn→zquic` handshake smoke passes (no longer warn-only)

Closes #135