### PR TITLE
transport: fix quinn UnsolicitedEncryptedExtension on Initial retransmit

### DIFF
--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -1701,6 +1701,53 @@ test "handshake: key schedule" {
     try testing.expect(!std.mem.eql(u8, &client_hs, &client_ap));
 }
 
+test "handshake: EE ALPN only when client offered (rustls/quinn)" {
+    const testing = std.testing;
+    var ch: ClientHelloData = .{};
+    try testing.expect(eeAlpnMatchingClientOffer(&ch, ALPN_H3) == null);
+    try testing.expect(eeAlpnMatchingClientOffer(&ch, ALPN_H09) == null);
+    ch.alpn_h3 = true;
+    try testing.expectEqualSlices(u8, ALPN_H3, eeAlpnMatchingClientOffer(&ch, ALPN_H3).?);
+    ch.alpn_h3 = false;
+    ch.alpn_h09 = true;
+    try testing.expectEqualSlices(u8, ALPN_H09, eeAlpnMatchingClientOffer(&ch, ALPN_H09).?);
+}
+
+test "handshake: EE early_data only on accepted PSK (rustls decide_if_early_data_allowed)" {
+    const testing = std.testing;
+    var ch: ClientHelloData = .{ .has_early_data = true };
+    try testing.expect(!eeAcceptEarlyData(&ch, false));
+    try testing.expect(eeAcceptEarlyData(&ch, true));
+}
+
+test "handshake: EncryptedExtensions wire encoding omits unsolicited ALPN" {
+    const testing = std.testing;
+    var buf_alpn: [512]u8 = undefined;
+    var buf_no_alpn: [512]u8 = undefined;
+    const tp = [_]u8{ 0x05, 0x00, 0x00, 0x00, 0x00 }; // minimal QUIC TP blob
+    const with_alpn = try buildEncryptedExtensions(&buf_alpn, &tp, ALPN_H3, false);
+    const without_alpn = try buildEncryptedExtensions(&buf_no_alpn, &tp, null, false);
+    try testing.expect(eeExtensionsContainType(buf_alpn[0..with_alpn], EXT_ALPN));
+    try testing.expect(!eeExtensionsContainType(buf_no_alpn[0..without_alpn], EXT_ALPN));
+    try testing.expect(eeExtensionsContainType(buf_no_alpn[0..without_alpn], EXT_QUIC_TRANSPORT_PARAMS));
+}
+
+fn eeExtensionsContainType(ee_msg: []const u8, ext_type: u16) bool {
+    if (ee_msg.len < 8 or ee_msg[0] != MSG_ENCRYPTED_EXTENSIONS) return false;
+    const body_len = readU24(ee_msg[1..]);
+    const ext_list_len = readU16(ee_msg[4..]);
+    var p: usize = 6;
+    const ext_end = 4 + body_len;
+    const list_end = p + ext_list_len;
+    if (list_end > ext_end or list_end > ee_msg.len) return false;
+    while (p + 4 <= list_end) {
+        if (readU16(ee_msg[p..]) == ext_type) return true;
+        const elen = readU16(ee_msg[p + 2 ..]);
+        p += 4 + elen;
+    }
+    return false;
+}
+
 test "handshake: build and parse ServerHello" {
     const testing = std.testing;
     var buf: [512]u8 = undefined;

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -468,6 +468,20 @@ pub fn buildEncryptedExtensions(
     return pos;
 }
 
+/// ALPN for EncryptedExtensions only when the client offered it (rustls
+/// `server/hs.rs` `process_common` + client `validate_encrypted_extensions`).
+fn eeAlpnMatchingClientOffer(ch: *const ClientHelloData, preferred: ?[]const u8) ?[]const u8 {
+    const p = preferred orelse return null;
+    if (std.mem.eql(u8, p, ALPN_H3) and ch.alpn_h3) return p;
+    if (std.mem.eql(u8, p, ALPN_H09) and ch.alpn_h09) return p;
+    return null;
+}
+
+/// early_data in EE only on accepted PSK resumption (rustls `decide_if_early_data_allowed`).
+fn eeAcceptEarlyData(ch: *const ClientHelloData, accept_psk: bool) bool {
+    return ch.has_early_data and accept_psk;
+}
+
 // ── Certificate builder ───────────────────────────────────────────────────────
 
 /// Build a TLS 1.3 Certificate message with one DER certificate.
@@ -1207,8 +1221,10 @@ pub const ServerHandshake = struct {
     ) !usize {
         var pos: usize = 0;
 
-        // EncryptedExtensions (include early_data acceptance if client requested it)
-        const ee_len = try buildEncryptedExtensions(out[pos..], quic_tp, alpn, self.ch.has_early_data);
+        // EncryptedExtensions: mirror rustls/quinn — only extensions the client offered.
+        const ee_alpn = eeAlpnMatchingClientOffer(&self.ch, alpn);
+        const ee_early = eeAcceptEarlyData(&self.ch, self.accept_psk);
+        const ee_len = try buildEncryptedExtensions(out[pos..], quic_tp, ee_alpn, ee_early);
         self.transcript.update(out[pos .. pos + ee_len]);
         pos += ee_len;
 

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1797,6 +1797,8 @@ pub const Server = struct {
                 if (existing.phase == .waiting_finished or existing.phase == .connected) {
                     self.replayStoredServerFlight(existing, src);
                 }
+                // Quinn does not rebuild the TLS flight here; loss recovery re-sends the
+                // same CRYPTO bytes (connection/spaces.rs). We cache the first UDP payloads.
                 return;
             }
 
@@ -2235,7 +2237,7 @@ pub const Server = struct {
     }
 
     fn buildAndSendServerFlight(self: *Server, conn: *ConnState, src: compat.Address) void {
-        clearServerFlightResend(conn);
+        Server.clearServerFlightResend(conn);
 
         // Server transport parameters (RFC 9000 §7.4 / §18.2): quinn and other
         // stacks require initial_source_connection_id and original_destination_connection_id.

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -2235,7 +2235,7 @@ pub const Server = struct {
     }
 
     fn buildAndSendServerFlight(self: *Server, conn: *ConnState, src: compat.Address) void {
-        self.clearServerFlightResend(conn);
+        clearServerFlightResend(conn);
 
         // Server transport parameters (RFC 9000 §7.4 / §18.2): quinn and other
         // stacks require initial_source_connection_id and original_destination_connection_id.

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -852,6 +852,21 @@ fn checkFinalSize(tracker: *const [16]FinEntry, stream_id: u64, final_size: u64)
 }
 
 /// Per-connection crypto and TLS state.
+/// Max Handshake datagrams for an 8192-byte server flight (~8 at 1100 B/crypto).
+const max_server_flight_resend_datagrams: usize = 10;
+
+/// Cached UDP payload for server flight retransmit (same PN/ciphertext).
+const StoredDatagram = struct {
+    len: u16 = 0,
+    data: [MAX_DATAGRAM_SIZE]u8 = undefined,
+
+    fn store(self: *StoredDatagram, pkt: []const u8) void {
+        const n = @min(pkt.len, self.data.len);
+        @memcpy(self.data[0..n], pkt[0..n]);
+        self.len = @intCast(n);
+    }
+};
+
 pub const ConnState = struct {
     phase: ConnPhase = .initial,
 
@@ -990,6 +1005,13 @@ pub const ConnState = struct {
     finished_pkt: [MAX_DATAGRAM_SIZE]u8 = [_]u8{0} ** MAX_DATAGRAM_SIZE,
     finished_pkt_len: usize = 0,
     finished_sent_ms: i64 = 0,
+
+    // Server flight datagrams for Initial retransmit (quinn/rustls #132).
+    init_resend: StoredDatagram = .{},
+    init_resend_valid: bool = false,
+    hs_resend: [max_server_flight_resend_datagrams]StoredDatagram =
+        [_]StoredDatagram{.{}} ** max_server_flight_resend_datagrams,
+    hs_resend_count: u8 = 0,
 
     // 1-RTT key phase tracking for key updates (RFC 9001 §6).
     // Tracks the current key phase bit for outgoing short-header packets.
@@ -1770,11 +1792,10 @@ pub const Server = struct {
             if (self.findConn(ip.dcid)) |c| break :blk c;
 
             if (self.findConnByPeer(src)) |existing| {
-                // Retransmitted Initial: re-send the server flight so the client
-                // can make progress even if our first response was lost.
+                // Retransmitted Initial: replay exact UDP payloads. Rebuilding with
+                // new PNs re-injects TLS records and quinn reports UnsolicitedEncryptedExtension.
                 if (existing.phase == .waiting_finished or existing.phase == .connected) {
-                    self.sendInitialServerHello(existing, src);
-                    self.sendHandshakeServerFlight(existing, src);
+                    self.replayStoredServerFlight(existing, src);
                 }
                 return;
             }
@@ -2179,7 +2200,43 @@ pub const Server = struct {
         }
     }
 
+    fn clearServerFlightResend(conn: *ConnState) void {
+        conn.init_resend_valid = false;
+        conn.hs_resend_count = 0;
+    }
+
+    /// Resend cached Initial + Handshake datagrams without new packet numbers.
+    fn replayStoredServerFlight(self: *Server, conn: *ConnState, src: compat.Address) void {
+        if (conn.init_resend_valid and conn.init_resend.len > 0) {
+            _ = compat.sendto(
+                self.sock,
+                conn.init_resend.data[0..conn.init_resend.len],
+                0,
+                &src.any,
+                src.getOsSockLen(),
+            ) catch |err| {
+                dbg("io: retransmit Initial failed: {}\n", .{err});
+            };
+        }
+        var i: u8 = 0;
+        while (i < conn.hs_resend_count) : (i += 1) {
+            const slot = &conn.hs_resend[i];
+            if (slot.len == 0) continue;
+            _ = compat.sendto(
+                self.sock,
+                slot.data[0..slot.len],
+                0,
+                &src.any,
+                src.getOsSockLen(),
+            ) catch |err| {
+                dbg("io: retransmit Handshake failed: {}\n", .{err});
+            };
+        }
+    }
+
     fn buildAndSendServerFlight(self: *Server, conn: *ConnState, src: compat.Address) void {
+        self.clearServerFlightResend(conn);
+
         // Server transport parameters (RFC 9000 §7.4 / §18.2): quinn and other
         // stacks require initial_source_connection_id and original_destination_connection_id.
         const odcid: []const u8 = if (conn.retry_odcid_len > 0)
@@ -2362,6 +2419,9 @@ pub const Server = struct {
         conn.init_pn += 1;
         conn.anti_amp_bytes_sent += pkt_len;
 
+        conn.init_resend.store(send_buf[0..pkt_len]);
+        conn.init_resend_valid = true;
+
         _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch |err| {
             dbg("io: sendto Initial failed: {}\n", .{err});
         };
@@ -2411,6 +2471,11 @@ pub const Server = struct {
 
             conn.hs_pn += 1;
             conn.anti_amp_bytes_sent += pkt_len;
+
+            if (conn.hs_resend_count < max_server_flight_resend_datagrams) {
+                conn.hs_resend[conn.hs_resend_count].store(send_buf[0..pkt_len]);
+                conn.hs_resend_count += 1;
+            }
 
             _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &src.any, src.getOsSockLen()) catch |err| {
                 dbg("io: sendto Handshake failed: {}\n", .{err});


### PR DESCRIPTION
## Summary

When a quinn client retransmits its Initial (common under NS3 loss), zquic matched the connection by peer address and **rebuilt** the server flight with new Initial/Handshake packet numbers. Quinn/rustls had already processed `EncryptedExtensions` from the first flight; the rebuilt Handshake CRYPTO at offset 0 delivered duplicate TLS records → `peer misbehaved: UnsolicitedEncryptedExtension` ([#132](https://github.com/ch4r10t33r/zquic/issues/132)).

This PR caches the exact UDP payloads sent on the first server flight and **replays** them on Initial retransmit instead of calling `sendInitialServerHello` / `sendHandshakeServerFlight` again.

Separate from [#136](https://github.com/ch4r10t33r/zquic/pull/136) (handshake AEAD cipher negotiation / #135).

## Changes

- `ConnState`: `init_resend` + `hs_resend[]` slots populated in `sendInitialServerHello` / `sendHandshakeServerFlightFrom`
- `replayStoredServerFlight` used from `findConnByPeer` retransmit path
- Cleared when `buildAndSendServerFlight` runs

## Test plan

- [x] `zig build test --summary all` (163 tests)
- [ ] CI interop: quinn→zquic cross-handshake smoke (currently warning-only in `ci.yml`)