### PR TITLE
fix(batch_io): handle sendmmsg short / failed returns

### DIFF
--- a/src/transport/batch_io.zig
+++ b/src/transport/batch_io.zig
@@ -112,8 +112,36 @@ fn flushLinux(sock: std.posix.socket_t, entries: []SendEntry) void {
             };
         }
 
+        // sendmmsg(2) returns the number of messages actually queued.  A
+        // previous version ignored the rc and assumed every message went
+        // out, which silently dropped the tail on any short send and
+        // dropped EVERYTHING on hard errors (EAGAIN, ENOBUFS, EBADF, …).
+        // That matches the empirical 24-in / 2-out asymmetry observed on
+        // loopback when zeam's server starts emitting STREAM-frame acks.
+        // RFC 9000 §13.2 makes server-side STREAM frames discardable on
+        // the wire but zquic's PTO does NOT re-arm for arbitrary
+        // ack-eliciting raw-app STREAMs, so a dropped batch never
+        // retransmits and the libp2p layer above stalls.
+        //
+        // Fix: check the rc.  On a short return, retry the tail
+        // synchronously via sendto.  On error (rc <= 0) fall back to
+        // sendto for the whole batch so the syscall path's error gets
+        // exercised per-packet (and an individual EAGAIN doesn't drop
+        // the rest of the connection's outbound traffic).
         const rc = linux.sendmmsg(@intCast(sock), msgs[0..batch.len].ptr, @intCast(batch.len), 0);
-        _ = rc; // ignore partial-send; packets are loss-tolerant
+        const rc_i: isize = @bitCast(rc);
+        if (rc_i <= 0) {
+            for (batch) |*e| {
+                _ = std.posix.sendto(sock, e.buf[0..e.len], 0, &e.addr.any, e.addr.getOsSockLen()) catch {};
+            }
+        } else {
+            const n: usize = @intCast(rc_i);
+            if (n < batch.len) {
+                for (batch[n..]) |*e| {
+                    _ = std.posix.sendto(sock, e.buf[0..e.len], 0, &e.addr.any, e.addr.getOsSockLen()) catch {};
+                }
+            }
+        }
         sent += batch.len;
     }
 }

--- a/src/transport/batch_io.zig
+++ b/src/transport/batch_io.zig
@@ -132,13 +132,13 @@ fn flushLinux(sock: std.posix.socket_t, entries: []SendEntry) void {
         const rc_i: isize = @bitCast(rc);
         if (rc_i <= 0) {
             for (batch) |*e| {
-                _ = std.posix.sendto(sock, e.buf[0..e.len], 0, &e.addr.any, e.addr.getOsSockLen()) catch {};
+                _ = compat.sendto(sock, e.buf[0..e.len], 0, &e.addr.any, e.addr.getOsSockLen()) catch {};
             }
         } else {
             const n: usize = @intCast(rc_i);
             if (n < batch.len) {
                 for (batch[n..]) |*e| {
-                    _ = std.posix.sendto(sock, e.buf[0..e.len], 0, &e.addr.any, e.addr.getOsSockLen()) catch {};
+                    _ = compat.sendto(sock, e.buf[0..e.len], 0, &e.addr.any, e.addr.getOsSockLen()) catch {};
                 }
             }
         }


### PR DESCRIPTION
## Summary

\`flushLinux\` previously discarded the \`sendmmsg(2)\` return value with \"ignore partial-send; packets are loss-tolerant\". This silently dropped the entire batch on any hard error (EAGAIN, ENOBUFS, EBADF, EINVAL, …) and dropped the tail on any short send.

## Why this hurts libp2p

In a zeam ↔ zeam loopback devnet the server enqueues 24 STREAM-frame multistream-acks (confirmed via diag warns: \`phase=connected\`, \`has_keys=true\`, \`send1Rtt-done\` all fire). But the peer's \`Client.process1RttPacket\` only fires ~2 times over 30 seconds. Zquic's PTO timer does NOT re-arm for arbitrary ack-eliciting raw-app STREAM frames, so a dropped batch never retransmits and every multistream-select / req-resp / gossipsub publish stalls because the initiator never receives the responder's ack bytes.

## Fix

- Capture \`sendmmsg\` rc.
- On \`rc <= 0\` fall back to per-packet \`sendto(2)\` for the whole batch — a single EAGAIN should not poison the rest of the connection's outbound traffic, and any real error is exercised per-packet with errors swallowed at the same granularity as the existing portable path (lines 74-76 of the existing code).
- On a short send (\`0 < rc < batch.len\`) retry the tail (\`batch[rc..]\`) via the same per-packet \`sendto\` fallback.

No behaviour change on the happy path: when \`sendmmsg\` returns \`batch.len\` we still advance \`sent\` by \`batch.len\` and skip the fallback entirely.

## Test plan

- [x] \`zig build test --summary all\` — 168/168 tests pass.
- [ ] Bump zeam to this branch, rebuild image, soak 60s on local devnet. Expected: \`process1RttPacket\` count jumps from ~2 to dozens, outbound req \`handshake_done\` transitions fire, status RPC completes (today: times out every 32s from slot 0).
- [ ] zquic↔zquic interop matrix stays green.

## Related

One entry on the broader gap list tracked in #138.