### PR TITLE
feat(io,loss): retransmit raw-application STREAM frames on loss (server side)

### DIFF
--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -89,6 +89,21 @@ pub const SentPacket = struct {
     has_stream_data: bool = false,
     stream_id: u64 = 0,
     stream_offset: u64 = 0,
+    /// Heap-owned plaintext bytes for the raw-application STREAM frame, kept
+    /// so we can re-encrypt them under a fresh PN on loss.  `null` for the
+    /// HTTP/0.9 and HTTP/3 paths — those rewind their own per-slot state from
+    /// the underlying file on disk and don't need an in-memory copy.
+    ///
+    /// Ownership rules:
+    ///   - allocated by the producer (raw-app `sendRawStreamData`) via the
+    ///     same allocator passed to `LossDetector.deinit` / `onAck`;
+    ///   - freed by `onAck` when the carrying packet is acknowledged;
+    ///   - ownership transfers into `lost_buf` when the packet is declared
+    ///     lost — the caller MUST either re-attach the slice to a new
+    ///     `SentPacket` (via `onPacketSent`) or free it.
+    stream_data: ?[]u8 = null,
+    /// FIN flag accompanying `stream_data` (so retransmit preserves the bit).
+    stream_fin: bool = false,
 };
 
 /// Loss detection state for one packet number space.
@@ -100,12 +115,28 @@ pub const LossDetector = struct {
     largest_acked: u64 = 0,
     loss_time_ms: ?u64 = null,
 
+    /// Free any heap-owned retransmit buffers attached to in-flight packets.
+    /// Caller passes the same allocator used when populating `stream_data`.
+    pub fn deinit(self: *LossDetector, allocator: std.mem.Allocator) void {
+        for (self.sent[0..self.sent_count]) |*p| {
+            if (p.stream_data) |sd| allocator.free(sd);
+            p.stream_data = null;
+        }
+        self.sent_count = 0;
+    }
+
     /// Record a newly sent packet.
-    pub fn onPacketSent(self: *LossDetector, pkt: SentPacket) void {
+    ///
+    /// If `pkt.stream_data` is non-null and we cannot record the packet
+    /// (buffer full), the caller is responsible for freeing the slice —
+    /// otherwise it would leak.  Returns true when the packet was stored.
+    pub fn onPacketSent(self: *LossDetector, pkt: SentPacket) bool {
         if (self.sent_count < max_tracked) {
             self.sent[self.sent_count] = pkt;
             self.sent_count += 1;
+            return true;
         }
+        return false;
     }
 
     pub const OnAckError = error{FrameEncodingError};
@@ -137,8 +168,14 @@ pub const LossDetector = struct {
         /// Caller-provided buffer.  On return the first `lost_count` entries
         /// hold the full SentPacket descriptors for packets declared lost.
         /// Callers that stored stream metadata in `has_stream_data` can use
-        /// this to rewind and retransmit the affected data.
+        /// this to rewind and retransmit the affected data.  For lost
+        /// packets whose `stream_data` is non-null, ownership of that slice
+        /// transfers to the caller (see `SentPacket.stream_data` docs).
         lost_buf: []SentPacket,
+        /// Allocator used to free `stream_data` for packets acked by this
+        /// range.  Pass the same allocator that the producer used when
+        /// attaching the data via `onPacketSent`.
+        allocator: std.mem.Allocator,
     ) OnAckError!OnAckResult {
         // Validate: first_ack_range must not exceed largest_acked (RFC 9000 §19.3).
         // A saturating subtract would mask this protocol violation as a silent
@@ -176,6 +213,11 @@ pub const LossDetector = struct {
             // Packet is definitively acked: within [smallest_acked .. largest_acked].
             if (p.pn >= smallest_acked and p.pn <= largest_acked) {
                 bytes_acked += p.size;
+                // Free heap-owned retransmit buffer (raw-application path).
+                if (self.sent[i].stream_data) |sd| {
+                    allocator.free(sd);
+                    self.sent[i].stream_data = null;
+                }
                 self.sent[i] = self.sent[self.sent_count - 1];
                 self.sent_count -= 1;
                 continue;
@@ -189,7 +231,18 @@ pub const LossDetector = struct {
                 lost_bytes += p.size;
                 if (lost_count < lost_buf.len) {
                     lost_buf[lost_count] = p; // full descriptor for retransmission
+                    // Ownership of stream_data transfers from `self.sent[i]`
+                    // to `lost_buf[lost_count]`; clear the source so it isn't
+                    // freed when this slot is later overwritten.
+                    self.sent[i].stream_data = null;
                     lost_count += 1;
+                } else {
+                    // No room to surface this loss — free the retransmit
+                    // buffer so it doesn't leak.
+                    if (self.sent[i].stream_data) |sd| {
+                        allocator.free(sd);
+                        self.sent[i].stream_data = null;
+                    }
                 }
                 self.sent[i] = self.sent[self.sent_count - 1];
                 self.sent_count -= 1;
@@ -243,7 +296,7 @@ test "loss: packet threshold detection" {
     // Send packets 0..5
     var i: u64 = 0;
     while (i < 6) : (i += 1) {
-        ld.onPacketSent(.{
+        _ = ld.onPacketSent(.{
             .pn = i,
             .send_time_ms = 100 + i * 10,
             .size = 100,
@@ -256,7 +309,7 @@ test "loss: packet threshold detection" {
     // Packets 0, 1, 2 are in a gap and should be detected as lost via
     // k_packet_threshold (5 >= 0+3, 1+3, 2+3).
     var lost_buf: [8]SentPacket = undefined;
-    const result = try ld.onAck(5, 0, 0, 200, &rtt, &lost_buf);
+    const result = try ld.onAck(5, 0, 0, 200, &rtt, &lost_buf, testing.allocator);
     try testing.expect(result.lost_count >= 2);
 }
 
@@ -268,6 +321,74 @@ test "loss: rejects invalid first_ack_range > largest_acked" {
     // largest_acked=5, first_ack_range=10 → would underflow.
     try testing.expectError(
         error.FrameEncodingError,
-        ld.onAck(5, 10, 0, 200, &rtt, &lost_buf),
+        ld.onAck(5, 10, 0, 200, &rtt, &lost_buf, testing.allocator),
     );
+}
+
+test "loss: stream_data is freed on ack and transferred on loss" {
+    const testing = std.testing;
+    const a = testing.allocator;
+    var ld = LossDetector{};
+    defer ld.deinit(a);
+    var rtt = RttEstimator{};
+
+    // Pkt 0: will be acked → expect stream_data freed by onAck.
+    const buf0 = try a.dupe(u8, "ack-me");
+    _ = ld.onPacketSent(.{
+        .pn = 0,
+        .send_time_ms = 100,
+        .size = 100,
+        .ack_eliciting = true,
+        .in_flight = true,
+        .has_stream_data = true,
+        .stream_id = 42,
+        .stream_offset = 0,
+        .stream_data = buf0,
+    });
+
+    // Pkts 1..5 keep the gap visible so pkt 1 hits the packet-threshold loss path.
+    var i: u64 = 1;
+    while (i < 6) : (i += 1) {
+        _ = ld.onPacketSent(.{
+            .pn = i,
+            .send_time_ms = 110 + i * 10,
+            .size = 100,
+            .ack_eliciting = true,
+            .in_flight = true,
+        });
+    }
+
+    // Pkt 1: will be lost (k_packet_threshold trips when pn 5 is acked).
+    // Caller owns stream_data after it lands in lost_buf; we free it below.
+    const buf1 = try a.dupe(u8, "retransmit-me");
+    // Find pkt 1 and attach buf to it so we can verify ownership transfer.
+    for (ld.sent[0..ld.sent_count]) |*p| {
+        if (p.pn == 1) {
+            p.has_stream_data = true;
+            p.stream_id = 7;
+            p.stream_offset = 9;
+            p.stream_data = buf1;
+            break;
+        }
+    }
+
+    var lost_buf: [8]SentPacket = undefined;
+    // Ack pn 0 (frees buf0 internally), then ack pn 5 separately so pn 1
+    // is declared lost via k_packet_threshold.
+    const r0 = try ld.onAck(0, 0, 0, 200, &rtt, &lost_buf, a);
+    try testing.expectEqual(@as(usize, 0), r0.lost_count);
+
+    const r1 = try ld.onAck(5, 0, 0, 200, &rtt, &lost_buf, a);
+    try testing.expect(r1.lost_count >= 1);
+    // Find the lost descriptor that owns the heap slice.
+    var saw_transfer = false;
+    var li: usize = 0;
+    while (li < r1.lost_count) : (li += 1) {
+        if (lost_buf[li].pn == 1) {
+            try testing.expect(lost_buf[li].stream_data != null);
+            a.free(lost_buf[li].stream_data.?);
+            saw_transfer = true;
+        }
+    }
+    try testing.expect(saw_transfer);
 }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1472,7 +1472,27 @@ pub const Server = struct {
         data: []const u8,
         fin: bool,
     ) void {
-        if (conn.phase != .connected or !conn.has_app_keys) return;
+        self.sendRawStreamDataInner(conn, stream_id, offset, data, fin, null);
+    }
+
+    /// Internal: optionally adopt `owned_buf` (already heap-allocated by an
+    /// earlier `sendRawStreamData` call) as the retransmit buffer instead of
+    /// duping `data`.  Used by the loss-recovery branch in `onAck` so we move
+    /// the bytes from the lost SentPacket into the new SentPacket without
+    /// allocating a fresh copy.
+    fn sendRawStreamDataInner(
+        self: *Server,
+        conn: *ConnState,
+        stream_id: u64,
+        offset: u64,
+        data: []const u8,
+        fin: bool,
+        owned_buf: ?[]u8,
+    ) void {
+        if (conn.phase != .connected or !conn.has_app_keys) {
+            if (owned_buf) |b| self.allocator.free(b);
+            return;
+        }
         const sf = stream_frame_mod.StreamFrame{
             .stream_id = stream_id,
             .offset = offset,
@@ -1481,8 +1501,41 @@ pub const Server = struct {
             .has_length = true,
         };
         var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const flen = sf.serialize(&frame_buf) catch return;
+        const flen = sf.serialize(&frame_buf) catch {
+            if (owned_buf) |b| self.allocator.free(b);
+            return;
+        };
+        const pn_before = conn.app_pn;
         self.send1Rtt(conn, frame_buf[0..flen], conn.peer);
+        // If send1Rtt actually emitted a packet, app_pn advanced.  Attach the
+        // retransmit buffer to the LD entry it just appended so the loss
+        // detector can replay this STREAM frame under a fresh PN on loss.
+        // `send1Rtt` only fails silently for `draining` — in that case
+        // app_pn does not move and we free `owned_buf` to avoid leaking.
+        if (conn.app_pn == pn_before) {
+            if (owned_buf) |b| self.allocator.free(b);
+            return;
+        }
+        if (conn.ld.sent_count == 0) {
+            if (owned_buf) |b| self.allocator.free(b);
+            return;
+        }
+        const buf = owned_buf orelse blk: {
+            // First send: copy the embedder-supplied data onto the heap so we
+            // own it until the carrying packet is acked (the embedder's slice
+            // typically points into a transient frame buffer).
+            const dup = self.allocator.dupe(u8, data) catch return;
+            break :blk dup;
+        };
+        const last = &conn.ld.sent[conn.ld.sent_count - 1];
+        // Defence-in-depth: free any pre-existing data so we don't leak if
+        // some unrelated path already attached one.
+        if (last.stream_data) |old| self.allocator.free(old);
+        last.has_stream_data = true;
+        last.stream_id = stream_id;
+        last.stream_offset = offset;
+        last.stream_data = buf;
+        last.stream_fin = fin;
     }
 
     pub fn deinit(self: *Server) void {
@@ -3022,6 +3075,7 @@ pub const Server = struct {
                     @intCast(compat.milliTimestamp()),
                     &conn.rtt,
                     &lost_buf,
+                    self.allocator,
                 ) catch {
                     // Malformed ACK (e.g. first_ack_range > largest_acked) —
                     // RFC 9000 §11.3 FRAME_ENCODING_ERROR.  Skip rest of frames.
@@ -3122,6 +3176,17 @@ pub const Server = struct {
                                 }
                             }
                             break;
+                        }
+                        // raw_application_streams: zquic is the data source.
+                        // The lost packet carries a heap-owned plaintext copy
+                        // of the STREAM payload in `lp.stream_data`; re-send
+                        // it via `sendRawStreamDataInner` so the bytes get a
+                        // fresh PN and the new SentPacket adopts the buffer.
+                        if (lp.stream_data) |buf| {
+                            self.sendRawStreamDataInner(conn, lp.stream_id, lp.stream_offset, buf, lp.stream_fin, buf);
+                            // ownership of `buf` is transferred into the new
+                            // SentPacket (or freed inside *Inner on draining /
+                            // serialize failure); we must NOT touch it again.
                         }
                     }
                 }
@@ -3411,8 +3476,13 @@ pub const Server = struct {
         }
         // Congestion control: update bytes in flight.
         conn.cc.onPacketSent(@intCast(pkt_len));
-        // Loss detection: record this packet.
-        conn.ld.onPacketSent(.{
+        // Loss detection: record this packet.  Discard return value — this
+        // tracker can fill (max_tracked) under sustained loss; in that case
+        // the packet is dropped from the LD.  The raw-app retransmit path
+        // (`Server.sendRawStreamData` etc.) is responsible for freeing
+        // `stream_data` if it ever attaches a buffer to a SentPacket that
+        // does not get recorded.
+        _ = conn.ld.onPacketSent(.{
             .pn = conn.app_pn - 1,
             .send_time_ms = @intCast(compat.milliTimestamp()),
             .size = pkt_len,
@@ -4634,6 +4704,11 @@ fn freeConnStateRawAppBuffers(conn: *ConnState, allocator: std.mem.Allocator) vo
     for (&conn.raw_app_streams) |*slot| {
         slot.deinit(allocator);
     }
+    // Free any retransmit buffers attached to in-flight LD entries so the
+    // raw_application_streams send-side doesn't leak when a connection is
+    // reaped or migrated.  HTTP/0.9 / HTTP/3 stream_data is `null` so this
+    // is a no-op for those paths.
+    conn.ld.deinit(allocator);
 }
 
 /// Opening a stream beyond the peer's limit (RFC 9000 §4.6).


### PR DESCRIPTION
## Summary

Server-side raw-application STREAM frames now retransmit on loss. Closes the libp2p stall where the responder writes a multistream ack, the packet is lost, and the initiator's \`handshake_done\` transition never fires because zquic's PTO probes with PING but never re-sends the actual STREAM bytes.

The loss detector already had the scaffolding (\`has_stream_data\` / \`stream_id\` / \`stream_offset\` on \`SentPacket\`) but it was only populated and acted on by the HTTP/0.9 and HTTP/3 paths. Raw-application streams — the path libp2p uses — emitted ack-eliciting STREAM frames that were tracked as in-flight but never retransmitted.

## Changes

- \`SentPacket\` gains \`stream_data: ?[]u8\` and \`stream_fin: bool\`; owned by the producer, transferred into \`lost_buf\` on loss, freed in \`onAck\` for acked packets.
- \`LossDetector.onPacketSent\` now returns \`bool\` so callers attaching \`stream_data\` can detect the rare full-buffer drop and free their slice. All existing call sites just \`_ =\` it.
- \`LossDetector.onAck\` takes an allocator so it can free retransmit buffers of acked / unsurfaced-lost packets.
- \`LossDetector.deinit\` walks the in-flight set and frees pending buffers; called from \`freeConnStateRawAppBuffers\`.
- \`Server.sendRawStreamData\` dupes the embedder's data onto the heap and attaches it to the LD's last \`SentPacket\`. A new internal \`sendRawStreamDataInner\` adopts an already-owned buffer (used when retransmitting from \`lost_buf\` so we don't double-allocate).
- The loss recovery branch in the ACK handler now has a third arm (after HTTP/0.9 and HTTP/3) that re-emits raw-app STREAMs via \`sendRawStreamDataInner\`, transferring ownership of the heap slice into the newly emitted packet's LD entry.

## Why server-side only

\`Client.sendRawStreamData\` does not currently call \`conn.ld.onPacketSent\` at all and \`Client.process1RttPacket\` *skips* ACK frame bodies. Wiring client-side loss detection is a follow-up PR. For zeam ↔ zeam the immediate stall is on the server's multistream ack write, so a server-only fix is sufficient to unblock the responder-side path.

## Test plan

- [x] \`zig build test --summary all\` — 169/169 tests pass (1 new test \`loss: stream_data is freed on ack and transferred on loss\`).
- [ ] zquic↔zquic interop matrix stays green.
- [ ] Bump zeam → run brief devnet soak. Expected: \`process1RttPacket\` count on the receiver jumps significantly, status RPC completes, head_slot advances.

## Related

Tracked under #138 (gap analysis, P0 row). Stacks under PR #139 (sendmmsg rc handling).