### PR TITLE
feat(io,loss): retransmit raw-app STREAM frames on loss (client side)

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -5071,7 +5071,26 @@ pub const Client = struct {
         data: []const u8,
         fin: bool,
     ) void {
-        if (self.conn.phase != .connected or !self.conn.has_app_keys) return;
+        self.sendRawStreamDataInner(stream_id, offset, data, fin, null);
+    }
+
+    /// Internal: optionally adopt `owned_buf` (already heap-allocated by an
+    /// earlier `sendRawStreamData` call) as the retransmit buffer instead of
+    /// duping `data`.  Used by the loss-recovery branch in `process1RttPacket`
+    /// so we move the bytes from the lost SentPacket into the new SentPacket
+    /// without allocating a fresh copy.  Mirrors `Server.sendRawStreamDataInner`.
+    fn sendRawStreamDataInner(
+        self: *Client,
+        stream_id: u64,
+        offset: u64,
+        data: []const u8,
+        fin: bool,
+        owned_buf: ?[]u8,
+    ) void {
+        if (self.conn.phase != .connected or !self.conn.has_app_keys) {
+            if (owned_buf) |b| self.allocator.free(b);
+            return;
+        }
         const sf = stream_frame_mod.StreamFrame{
             .stream_id = stream_id,
             .offset = offset,
@@ -5080,7 +5099,10 @@ pub const Client = struct {
             .has_length = true,
         };
         var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const flen = sf.serialize(&frame_buf) catch return;
+        const flen = sf.serialize(&frame_buf) catch {
+            if (owned_buf) |b| self.allocator.free(b);
+            return;
+        };
         var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
         const pkt_len = build1RttPacketFull(
             &send_buf,
@@ -5090,9 +5112,37 @@ pub const Client = struct {
             &self.conn.app_client_km,
             self.conn.key_phase_bit,
             self.conn.use_chacha20,
-        ) catch return;
+        ) catch {
+            if (owned_buf) |b| self.allocator.free(b);
+            return;
+        };
+        const pn = self.conn.app_pn;
         self.conn.app_pn += 1;
         _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch {};
+
+        // Track for retransmit.  See Server.sendRawStreamDataInner for the
+        // ownership-transfer protocol; the Client mirrors it.
+        const buf = owned_buf orelse blk: {
+            const dup = self.allocator.dupe(u8, data) catch return;
+            break :blk dup;
+        };
+        const recorded = self.conn.ld.onPacketSent(.{
+            .pn = pn,
+            .send_time_ms = @intCast(compat.milliTimestamp()),
+            .size = pkt_len,
+            .ack_eliciting = true,
+            .in_flight = true,
+            .has_stream_data = true,
+            .stream_id = stream_id,
+            .stream_offset = offset,
+            .stream_data = buf,
+            .stream_fin = fin,
+        });
+        if (!recorded) {
+            // LD full — caller's data has already gone on the wire; we just
+            // can't retransmit it on loss.  Free the buffer to avoid the leak.
+            self.allocator.free(buf);
+        }
     }
 
     /// Opaque receive buffer for an inbound raw-application stream on a **client**.
@@ -6044,7 +6094,63 @@ pub const Client = struct {
             if (ft == 0x00) continue; // PADDING
             if (ft == 0x01) continue; // PING — no body
             if (ft == 0x02 or ft == 0x03) {
-                // ACK frame — parse and skip all variable-length fields.
+                // ACK frame (RFC 9000 §19.3).  Parse the first range and run
+                // it through the loss detector so server-sent ACKs can ack
+                // our outgoing 1-RTT packets and surface lost STREAM frames
+                // for the raw-application retransmit path below.
+                var ack_pos: usize = pos;
+                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
+                    continue;
+                };
+                ack_pos += lar_r.len;
+                const largest_ack = lar_r.value;
+
+                const del_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
+                    continue;
+                };
+                ack_pos += del_r.len;
+                const ack_delay = del_r.value;
+
+                const cnt_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
+                    continue;
+                };
+                ack_pos += cnt_r.len;
+
+                const fst_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
+                    continue;
+                };
+                const first_ack_range = fst_r.value;
+
+                var lost_buf: [32]recovery.SentPacket = undefined;
+                const ld_result = self.conn.ld.onAck(
+                    largest_ack,
+                    first_ack_range,
+                    ack_delay,
+                    @intCast(compat.milliTimestamp()),
+                    &self.conn.rtt,
+                    &lost_buf,
+                    self.allocator,
+                ) catch {
+                    pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
+                    continue;
+                };
+                if (ld_result.bytes_acked > 0) self.conn.cc.onAck(ld_result.bytes_acked);
+                if (ld_result.lost_bytes > 0) self.conn.cc.subBytesInFlight(ld_result.lost_bytes);
+                // Retransmit any raw-app STREAM frames that the loss detector
+                // surfaced.  Symmetric to Server's onAck loss arm.
+                var li: usize = 0;
+                while (li < ld_result.lost_count) : (li += 1) {
+                    const lp = lost_buf[li];
+                    self.conn.cc.onLoss(lp.pn);
+                    if (lp.stream_data) |sbuf| {
+                        self.sendRawStreamDataInner(lp.stream_id, lp.stream_offset, sbuf, lp.stream_fin, sbuf);
+                        // ownership transferred into the new SentPacket.
+                    }
+                }
                 pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
                 continue;
             }


### PR DESCRIPTION
## Summary

Mirror of #140 on the **Client** side. The server-side fix landed but the
client-side path was still fire-and-forget:

- `Client.sendRawStreamData` never called `onPacketSent`, so outgoing
  STREAM packets were not tracked.
- `Client.process1RttPacket` skipped every ACK body with `skipAckBody`,
  so the loss detector never saw a single server ack.

Result: zeam→peer libp2p frames (status RPC, gossipsub, mplex control)
were lost forever on any UDP drop.

## Changes

1. `Client.sendRawStreamData` is now a thin shim over `sendRawStreamDataInner(... owned_buf: ?[]u8)`, matching `Server.sendRawStreamDataInner`. The inner form duplicates the payload, records a `SentPacket` with `has_stream_data / stream_data / stream_fin`, and frees the dup on LD-full to plug a leak. Retransmits reuse the lost packet's own buffer.
2. `Client.process1RttPacket` ACK handler now parses largest_ack / ack_delay / range_count / first_ack_range, calls `self.conn.ld.onAck(...)`, drives CC (`onAck`, `subBytesInFlight`, `onLoss`), and re-sends any lost packet whose `stream_data != null` via `sendRawStreamDataInner`.

## Why this still matters even with #140 merged

#140 only retransmits server→client. Without this PR, anything the
**client** sends (libp2p REQ side, status request, mplex window-update,
gossipsub IHAVE/IWANT) still has zero loss recovery.

## Test plan

- [x] `zig build`
- [x] `zig build test` (recovery loss-vs-ack ownership test from #140 still green)
- [ ] Devnet: zeam↔zeam status-RPC-timeouts → expect drop below 16/min seen after #140