### PR TITLE
fix(io): MAX_STREAM_DATA must not clobber connection-level send window (RFC 9000 §19.10)

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -3208,14 +3208,20 @@ pub const Server = struct {
                 continue;
             }
             if (ft == 0x11) {
-                // MAX_STREAM_DATA — peer raises send window on a specific stream.
-                // We track only connection-level credit; use the stream's max to
-                // advance our connection-level credit if it is the binding limit.
+                // MAX_STREAM_DATA (RFC 9000 §19.10) — peer raises send window on
+                // a *specific stream*.  This is a per-stream limit and MUST NOT
+                // be conflated with the connection-level limit (MAX_DATA / 0x10
+                // / conn.fc_send_max).  We currently do not enforce per-stream
+                // send credit (only connection-level), so the safest thing is
+                // to parse the frame for protocol-conformance (varint decode +
+                // skip), and NOT clobber conn.fc_send_max with the per-stream
+                // value.  TODO: track per-stream limits in a side table once
+                // raw-application streams enforce them on the send path.
                 const r = transport_frames.MaxStreamData.parse(frames[pos..]) catch return;
                 pos += r.consumed;
-                if (r.frame.maximum_stream_data > conn.fc_send_max) {
-                    conn.fc_send_max = r.frame.maximum_stream_data;
-                }
+                dbg("io: MAX_STREAM_DATA stream_id={} max={} (per-stream, not applied to conn fc_send_max)\n", .{
+                    r.frame.stream_id, r.frame.maximum_stream_data,
+                });
                 continue;
             }
             if (ft == 0x12 or ft == 0x13) {
@@ -6270,12 +6276,16 @@ pub const Client = struct {
                 continue;
             }
             if (ft == 0x11) {
-                // MAX_STREAM_DATA — server raises stream-level send window.
+                // MAX_STREAM_DATA (RFC 9000 §19.10) — per-stream limit; mirror
+                // of the server-side handler.  Must NOT update conn.fc_send_max
+                // (that is the connection-level MAX_DATA limit, frame 0x10).
+                // We currently don't enforce per-stream send credit; decode for
+                // protocol conformance and skip.
                 const r = transport_frames.MaxStreamData.parse(plaintext[pos..pt_len]) catch return;
                 pos += r.consumed;
-                if (r.frame.maximum_stream_data > self.conn.fc_send_max) {
-                    self.conn.fc_send_max = r.frame.maximum_stream_data;
-                }
+                dbg("io: client MAX_STREAM_DATA stream_id={} max={} (per-stream, not applied to conn fc_send_max)\n", .{
+                    r.frame.stream_id, r.frame.maximum_stream_data,
+                });
                 continue;
             }
             if (ft == 0x12 or ft == 0x13) {


### PR DESCRIPTION
## Summary

Both \`Server.processAppFrames\` and \`Client.process1RttPacket\` had a
MAX_STREAM_DATA (0x11) handler that, when the per-stream value exceeded
the connection-level send window, overwrote \`conn.fc_send_max\` with the
per-stream value. That's two RFC 9000 violations in one:

- **§19.10**: MAX_STREAM_DATA is a *per-stream* limit; raising the
  connection-level limit is what MAX_DATA (0x10) does.
- **§4.1 / §4.2**: the connection-level limit always bounds the
  per-stream limit, never vice versa.

## Why it didn't bite zquic↔zquic

Both sides advertise the same hardcoded 64 MiB \`initial_max_data\` and
neither sends a MAX_STREAM_DATA frame with a value above it, so the
buggy branch was never taken. Against quinn / msquic / quic-go — whose
defaults differ — zquic could raise its connection-level send window
above the peer's actual connection-level credit and overrun it. Peer
would close with FLOW_CONTROL_ERROR (0x03).

## Fix

Drop the assignment on both Server and Client. The frame is still
parsed for protocol conformance and the per-stream value is logged.

Per-stream send-credit tracking remains a TODO (zquic currently only
enforces connection-level on the send path; the per-stream gap hasn't
bitten zeam yet but will need work before cross-impl libp2p interop is
solid).

## Test plan

- [x] \`zig build\` clean
- [x] \`zig build test\` green
- [ ] No new test wired up; the fix removes a state-update, not an
      observable behavior on the zquic↔zquic path. A regression test
      would need a synthetic peer that ships MAX_STREAM_DATA > 64 MiB.