### PR TITLE
feat(io): enforce connection-level send credit on raw-app STREAM path (RFC 9000 §4.1 / §19.9)

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1493,6 +1493,33 @@ pub const Server = struct {
             if (owned_buf) |b| self.allocator.free(b);
             return;
         }
+        // Connection-level send-credit gate (RFC 9000 §4.1 / §19.9).  Sending
+        // STREAM payload past the peer's advertised MAX_DATA would let the
+        // peer kill the connection with FLOW_CONTROL_ERROR.  zquic↔zquic
+        // never trips this because both sides advertise 64 MiB and zeam's
+        // libp2p workload is tiny, but cross-impl peers (quinn, msquic)
+        // advertise much smaller initial_max_data defaults.
+        //
+        // When over budget: send a DATA_BLOCKED frame so the peer knows to
+        // grant more credit, drop this send, and free the retransmit buffer.
+        // We deliberately do not queue — the only path that calls us is the
+        // libp2p layer, which retransmits at the application timescale
+        // (gossipsub heartbeat, req-resp timeout).
+        const projected: u64 = conn.fc_bytes_sent +| data.len;
+        if (projected > conn.fc_send_max) {
+            dbg("io: send-credit gate stream_id={} bytes={} fc_bytes_sent={} fc_send_max={} — sending DATA_BLOCKED and dropping\n", .{
+                stream_id, data.len, conn.fc_bytes_sent, conn.fc_send_max,
+            });
+            var blk_buf: [16]u8 = undefined;
+            blk_buf[0] = 0x14; // DATA_BLOCKED
+            const enc = varint.encode(blk_buf[1..], conn.fc_send_max) catch {
+                if (owned_buf) |b| self.allocator.free(b);
+                return;
+            };
+            self.send1Rtt(conn, blk_buf[0 .. 1 + enc.len], conn.peer);
+            if (owned_buf) |b| self.allocator.free(b);
+            return;
+        }
         const sf = stream_frame_mod.StreamFrame{
             .stream_id = stream_id,
             .offset = offset,
@@ -1520,6 +1547,7 @@ pub const Server = struct {
             if (owned_buf) |b| self.allocator.free(b);
             return;
         }
+        const is_fresh_send = owned_buf == null;
         const buf = owned_buf orelse blk: {
             // First send: copy the embedder-supplied data onto the heap so we
             // own it until the carrying packet is acked (the embedder's slice
@@ -1536,6 +1564,10 @@ pub const Server = struct {
         last.stream_offset = offset;
         last.stream_data = buf;
         last.stream_fin = fin;
+        // Only fresh sends advance the connection-level send counter; a
+        // retransmit re-emits the same byte range under a new PN (RFC 9000
+        // §4.1: MAX_DATA counts cumulative *original* stream-data bytes).
+        if (is_fresh_send) conn.fc_bytes_sent +|= data.len;
     }
 
     pub fn deinit(self: *Server) void {
@@ -5097,6 +5129,34 @@ pub const Client = struct {
             if (owned_buf) |b| self.allocator.free(b);
             return;
         }
+        // Connection-level send-credit gate (RFC 9000 §4.1 / §19.9).  See
+        // Server.sendRawStreamDataInner for the rationale.  Mirror on the
+        // client side: peer's MAX_DATA bounds our cumulative stream-data
+        // bytes, including retransmits' original byte ranges (already
+        // counted on first send).
+        const projected: u64 = self.conn.fc_bytes_sent +| data.len;
+        if (owned_buf == null and projected > self.conn.fc_send_max) {
+            dbg("io: client send-credit gate stream_id={} bytes={} fc_bytes_sent={} fc_send_max={} — sending DATA_BLOCKED and dropping\n", .{
+                stream_id, data.len, self.conn.fc_bytes_sent, self.conn.fc_send_max,
+            });
+            // Emit DATA_BLOCKED so the peer knows to issue a MAX_DATA update.
+            var blk_buf: [16]u8 = undefined;
+            blk_buf[0] = 0x14;
+            const enc = varint.encode(blk_buf[1..], self.conn.fc_send_max) catch return;
+            var send_blk: [MAX_DATAGRAM_SIZE]u8 = undefined;
+            const blk_pkt_len = build1RttPacketFull(
+                &send_blk,
+                self.conn.remote_cid,
+                blk_buf[0 .. 1 + enc.len],
+                self.conn.app_pn,
+                &self.conn.app_client_km,
+                self.conn.key_phase_bit,
+                self.conn.use_chacha20,
+            ) catch return;
+            self.conn.app_pn += 1;
+            _ = compat.sendto(self.sock, send_blk[0..blk_pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch {};
+            return;
+        }
         const sf = stream_frame_mod.StreamFrame{
             .stream_id = stream_id,
             .offset = offset,
@@ -5125,6 +5185,8 @@ pub const Client = struct {
         const pn = self.conn.app_pn;
         self.conn.app_pn += 1;
         _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch {};
+        // Original byte range counted once, on the first send only.
+        if (owned_buf == null) self.conn.fc_bytes_sent +|= data.len;
 
         // Track for retransmit.  See Server.sendRawStreamDataInner for the
         // ownership-transfer protocol; the Client mirrors it.


### PR DESCRIPTION
## Summary

zquic was tracking neither side of connection-level send-side flow control:
- \`fc_send_max\` was a hardcoded 64 MiB, updated only by incoming MAX_DATA frames (correct).
- \`fc_bytes_sent\` was declared but never assigned, stuck at 0 forever.
- the send path on raw-application streams never compared the two.

Net effect: the connection-level send limit was unenforced. zquic↔zquic
worked because both sides default to 64 MiB; against any peer with a
smaller \`initial_max_data\` (quinn, msquic) zquic could overrun the
budget and the peer would FLOW_CONTROL_ERROR (0x03).

## Changes

Both \`Server.sendRawStreamDataInner\` and \`Client.sendRawStreamDataInner\`:

1. **Gate** before serialising the STREAM frame:
   \`fc_bytes_sent + data.len <= fc_send_max\`. If projected send exceeds
   credit, emit a DATA_BLOCKED (0x14) frame so the peer can issue
   MAX_DATA, drop the send, and free the retransmit buffer.
2. **Increment** \`fc_bytes_sent\` by \`data.len\` after a successful
   *fresh* send. Retransmits re-emit the same original byte range under
   a new PN and do NOT bump the counter (RFC 9000 §4.1: the limit
   counts cumulative *original* bytes).

No queueing: the libp2p layer retransmits at the application timescale
(gossipsub heartbeat, REQ-RESP timeout). Surfacing the block as a
dropped send is better than overrunning the peer's window.

## What this does NOT fix

- Other STREAM-bearing paths (HTTP/0.9, HTTP/3) still skip the gate.
  They are zquic-only (no cross-impl libp2p risk) and follow-up work.
- Per-stream send-credit enforcement (MAX_STREAM_DATA) — separate gap.
- Peer-transport-param parsing — \`fc_send_max\` is still seeded from
  zquic's own 64 MiB default. Until we parse peer's
  \`initial_max_data\` from EncryptedExtensions / ClientHello,
  \`fc_send_max\` is right only by coincidence with peers that match.

## Test plan

- [x] \`zig build\` clean
- [x] \`zig build test\` green (existing FC tests + recovery still pass)
- [ ] Devnet: zeam will not trip the gate (zeam libp2p traffic is
      well under 64 MiB), but the accounting becomes correct.