### PR TITLE
feat(io): enforce connection-level send credit on raw-app STREAM path (RFC 9000 §4.1 / §19.9)

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1493,6 +1493,27 @@ pub const Server = struct {
             if (owned_buf) |b| self.allocator.free(b);
             return;
         }
+        // Connection-level send-credit gate (RFC 9000 §4.1 / §19.9).  Without
+        // this, zquic can send STREAM payload past the peer's advertised
+        // MAX_DATA budget; the peer would then close with FLOW_CONTROL_ERROR
+        // (0x03).  Only the *original* byte range counts toward the
+        // cumulative limit; retransmits (owned_buf set) re-emit bytes
+        // already charged.
+        const is_fresh = owned_buf == null;
+        if (is_fresh) {
+            const projected: u64 = conn.fc_bytes_sent +| data.len;
+            if (projected > conn.fc_send_max) {
+                dbg("io: server send-credit gate stream_id={} bytes={} fc_bytes_sent={} fc_send_max={} — sending DATA_BLOCKED and dropping\n", .{
+                    stream_id, data.len, conn.fc_bytes_sent, conn.fc_send_max,
+                });
+                // Emit DATA_BLOCKED (0x14) so the peer knows to issue MAX_DATA.
+                var blk_buf: [16]u8 = undefined;
+                blk_buf[0] = 0x14;
+                const enc = varint.encode(blk_buf[1..], conn.fc_send_max) catch return;
+                self.send1Rtt(conn, blk_buf[0 .. 1 + enc.len], conn.peer);
+                return;
+            }
+        }
         const sf = stream_frame_mod.StreamFrame{
             .stream_id = stream_id,
             .offset = offset,
@@ -1536,6 +1557,9 @@ pub const Server = struct {
         last.stream_offset = offset;
         last.stream_data = buf;
         last.stream_fin = fin;
+        // Charge fresh-send bytes against the connection-level limit.
+        // Retransmits reuse already-charged bytes (RFC 9000 §4.1).
+        if (is_fresh) conn.fc_bytes_sent +|= data.len;
     }
 
     pub fn deinit(self: *Server) void {
@@ -5097,6 +5121,36 @@ pub const Client = struct {
             if (owned_buf) |b| self.allocator.free(b);
             return;
         }
+        // Connection-level send-credit gate (RFC 9000 §4.1 / §19.9).  Mirror
+        // of Server.sendRawStreamDataInner.  Retransmits (owned_buf set)
+        // bypass the gate because their byte range was already charged on
+        // the original send.
+        const is_fresh = owned_buf == null;
+        if (is_fresh) {
+            const projected: u64 = self.conn.fc_bytes_sent +| data.len;
+            if (projected > self.conn.fc_send_max) {
+                dbg("io: client send-credit gate stream_id={} bytes={} fc_bytes_sent={} fc_send_max={} — sending DATA_BLOCKED and dropping\n", .{
+                    stream_id, data.len, self.conn.fc_bytes_sent, self.conn.fc_send_max,
+                });
+                // Emit DATA_BLOCKED (0x14) inside a 1-RTT packet.
+                var blk_buf: [16]u8 = undefined;
+                blk_buf[0] = 0x14;
+                const enc = varint.encode(blk_buf[1..], self.conn.fc_send_max) catch return;
+                var send_blk: [MAX_DATAGRAM_SIZE]u8 = undefined;
+                const blk_pkt_len = build1RttPacketFull(
+                    &send_blk,
+                    self.conn.remote_cid,
+                    blk_buf[0 .. 1 + enc.len],
+                    self.conn.app_pn,
+                    &self.conn.app_client_km,
+                    self.conn.key_phase_bit,
+                    self.conn.use_chacha20,
+                ) catch return;
+                self.conn.app_pn += 1;
+                _ = compat.sendto(self.sock, send_blk[0..blk_pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch {};
+                return;
+            }
+        }
         const sf = stream_frame_mod.StreamFrame{
             .stream_id = stream_id,
             .offset = offset,
@@ -5125,6 +5179,8 @@ pub const Client = struct {
         const pn = self.conn.app_pn;
         self.conn.app_pn += 1;
         _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch {};
+        // Charge fresh-send bytes against the connection-level limit.
+        if (is_fresh) self.conn.fc_bytes_sent +|= data.len;
 
         // Track for retransmit.  See Server.sendRawStreamDataInner for the
         // ownership-transfer protocol; the Client mirrors it.


### PR DESCRIPTION
## Summary

zquic was tracking neither side of connection-level send-side flow control:
- \`fc_send_max\` was a hardcoded 64 MiB, only updated by incoming MAX_DATA (correct).
- \`fc_bytes_sent\` was declared but never assigned, stuck at 0 forever.
- the send path on raw-application streams never compared the two.

Net: the connection-level send limit was unenforced. zquic↔zquic works
because both sides default to 64 MiB and zeam's libp2p workload is
well under that; against any peer with smaller \`initial_max_data\`
(quinn, msquic) zquic could overrun and the peer would
FLOW_CONTROL_ERROR (0x03).

## Changes

Both \`Server.sendRawStreamDataInner\` and \`Client.sendRawStreamDataInner\`:

1. **Gate** fresh sends on \`fc_bytes_sent + data.len <= fc_send_max\`.
   On overage: emit DATA_BLOCKED (0x14) so the peer knows to issue
   MAX_DATA, drop the send, return. No queueing — the libp2p layer
   retransmits at application timescales.
2. **Charge** \`fc_bytes_sent\` by \`data.len\` after a successful *fresh*
   send. Retransmits (owned_buf provided by the loss-recovery branch)
   re-emit the same original byte range under a new PN and do not bump
   the counter (RFC 9000 §4.1).

## Out of scope (follow-ups)

- Other STREAM-bearing paths (HTTP/0.9, HTTP/3) still skip the gate.
- Per-stream send-credit (MAX_STREAM_DATA enforcement).
- Parsing the peer's \`initial_max_data\` transport parameter to seed
  \`fc_send_max\` — until that lands, \`fc_send_max\` is the right
  value only by coincidence with peers that match zquic's default.

## Test plan

- [x] \`zig build\` clean
- [x] \`zig build test\` green
- [ ] Devnet: zeam doesn't trip the gate (libp2p traffic well under
      64 MiB) but the accounting becomes correct.