### PR TITLE
tls,io: parse and apply peer transport parameters (refs #138)

### DIFF
--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -188,6 +188,150 @@ pub fn buildClientTransportParams(out: []u8) (varint.EncodeError || varint.Decod
     return buildTransportParams(out, .{ .initial_source_cid = &placeholder_cid });
 }
 
+/// Subset of RFC 9000 §18.2 transport parameters relevant for runtime behavior.
+///
+/// Only the fields whose absence would cause us to violate the peer's limits
+/// or compute a wrong PTO are surfaced here. Connection-id parameters
+/// (`original_destination`, `initial_source`, `retry_source`) are validated
+/// elsewhere as part of the handshake check; we do not retain them here.
+pub const PeerTransportParams = struct {
+    /// 0x04 — peer's connection-level receive window. Caps the cumulative
+    /// stream-data bytes we may have in flight to the peer (RFC 9000 §4.1).
+    /// Default 0 (per spec) — peer must advertise a non-zero value before
+    /// we may send any STREAM data.
+    initial_max_data: u64 = 0,
+    /// 0x05 — peer's per-stream receive window for streams the peer opens
+    /// and we send on (locally-initiated bidi from peer's perspective →
+    /// remotely-initiated bidi from ours).
+    initial_max_stream_data_bidi_local: u64 = 0,
+    /// 0x06 — peer's per-stream receive window for streams we initiate
+    /// (remotely-initiated bidi from peer's perspective → locally-initiated
+    /// bidi from ours).
+    initial_max_stream_data_bidi_remote: u64 = 0,
+    /// 0x07 — peer's per-stream receive window for unidirectional streams
+    /// we initiate.
+    initial_max_stream_data_uni: u64 = 0,
+    /// 0x08 — max bidirectional streams the peer permits us to open.
+    initial_max_streams_bidi: u64 = 0,
+    /// 0x09 — max unidirectional streams the peer permits us to open.
+    initial_max_streams_uni: u64 = 0,
+    /// 0x01 — peer's idle timeout in milliseconds. The connection's effective
+    /// idle timeout is `min(local, peer)` per RFC 9000 §10.1.
+    max_idle_timeout_ms: u64 = 0,
+    /// 0x0a — exponent for ACK-Delay encoding in the peer's ACK frames
+    /// (RFC 9000 §13.2.5). Defaults to 3 if absent.
+    ack_delay_exponent: u8 = 3,
+    /// 0x0b — peer's max_ack_delay in milliseconds. Used by our PTO
+    /// calculation (RFC 9002 §6.2.1). Defaults to 25 ms if absent.
+    max_ack_delay_ms: u64 = 25,
+    /// 0x0c — peer requested no active migration. Empty (length-0) value.
+    disable_active_migration: bool = false,
+    /// 0x0e — number of distinct CIDs the peer is willing to store for us.
+    /// Defaults to 2 if absent.
+    active_connection_id_limit: u64 = 2,
+    /// 0x03 — peer's max receive UDP payload size. Defaults to 65527 if absent.
+    max_udp_payload_size: u64 = 65527,
+};
+
+/// Parse the encoded `quic_transport_parameters` TLS extension body
+/// (RFC 9000 §18). Unknown ids are skipped per §18.1. Reserved transport
+/// parameters (id mod 31 == 27) are accepted and ignored.
+pub fn parseTransportParams(bytes: []const u8) varint.DecodeError!PeerTransportParams {
+    var out: PeerTransportParams = .{};
+    var pos: usize = 0;
+    while (pos < bytes.len) {
+        const id_r = try varint.decode(bytes[pos..]);
+        pos += id_r.len;
+        if (pos >= bytes.len) return error.BufferTooShort;
+        const len_r = try varint.decode(bytes[pos..]);
+        pos += len_r.len;
+        const value_len = try varint.lenToUsize(len_r.value);
+        if (pos + value_len > bytes.len) return error.BufferTooShort;
+        const value = bytes[pos .. pos + value_len];
+        pos += value_len;
+
+        switch (id_r.value) {
+            0x01 => out.max_idle_timeout_ms = readVarintField(value) catch continue,
+            0x03 => out.max_udp_payload_size = readVarintField(value) catch continue,
+            0x04 => out.initial_max_data = readVarintField(value) catch continue,
+            0x05 => out.initial_max_stream_data_bidi_local = readVarintField(value) catch continue,
+            0x06 => out.initial_max_stream_data_bidi_remote = readVarintField(value) catch continue,
+            0x07 => out.initial_max_stream_data_uni = readVarintField(value) catch continue,
+            0x08 => out.initial_max_streams_bidi = readVarintField(value) catch continue,
+            0x09 => out.initial_max_streams_uni = readVarintField(value) catch continue,
+            0x0a => {
+                const v = readVarintField(value) catch continue;
+                if (v <= 20) out.ack_delay_exponent = @intCast(v);
+            },
+            0x0b => out.max_ack_delay_ms = readVarintField(value) catch continue,
+            0x0c => out.disable_active_migration = (value_len == 0),
+            0x0e => out.active_connection_id_limit = readVarintField(value) catch continue,
+            else => {}, // unknown / reserved / connection-id params are not surfaced here
+        }
+    }
+    return out;
+}
+
+/// Decode a single varint that occupies `value` exactly.
+/// Returns an error if the buffer is empty or has trailing bytes.
+fn readVarintField(value: []const u8) varint.DecodeError!u64 {
+    if (value.len == 0) return error.BufferTooShort;
+    const r = try varint.decode(value);
+    if (r.len != value.len) return error.NonMinimalEncoding;
+    return r.value;
+}
+
+test "transport params: round-trip varint fields" {
+    const testing = std.testing;
+    var buf: [256]u8 = undefined;
+    const cid = [_]u8{ 0xaa, 0xbb, 0xcc, 0xdd };
+    const n = try buildTransportParams(&buf, .{ .initial_source_cid = &cid });
+    const parsed = try parseTransportParams(buf[0..n]);
+    try testing.expectEqual(@as(u64, 30_000), parsed.max_idle_timeout_ms);
+    try testing.expectEqual(@as(u64, 67_108_864), parsed.initial_max_data);
+    try testing.expectEqual(@as(u64, 16_777_216), parsed.initial_max_stream_data_bidi_local);
+    try testing.expectEqual(@as(u64, 16_777_216), parsed.initial_max_stream_data_bidi_remote);
+    try testing.expectEqual(@as(u64, 16_777_216), parsed.initial_max_stream_data_uni);
+    try testing.expectEqual(@as(u64, 1000), parsed.initial_max_streams_bidi);
+    try testing.expectEqual(@as(u64, 1000), parsed.initial_max_streams_uni);
+    // Defaults for params we don't currently emit.
+    try testing.expectEqual(@as(u8, 3), parsed.ack_delay_exponent);
+    try testing.expectEqual(@as(u64, 25), parsed.max_ack_delay_ms);
+    try testing.expectEqual(false, parsed.disable_active_migration);
+    try testing.expectEqual(@as(u64, 2), parsed.active_connection_id_limit);
+}
+
+test "transport params: unknown ids are skipped" {
+    const testing = std.testing;
+    // id=0x21 (unknown, 1-byte varint), len=2, value=2 opaque bytes.
+    // Followed by id=0x04 (initial_max_data), len=2, value=0x44 0x80 (varint = 0x0480 = 1152).
+    const bytes = [_]u8{ 0x21, 0x02, 0xaa, 0xbb, 0x04, 0x02, 0x44, 0x80 };
+    const parsed = try parseTransportParams(&bytes);
+    try testing.expectEqual(@as(u64, 0x0480), parsed.initial_max_data);
+}
+
+test "transport params: disable_active_migration is a length-0 flag" {
+    const testing = std.testing;
+    const bytes = [_]u8{ 0x0c, 0x00 };
+    const parsed = try parseTransportParams(&bytes);
+    try testing.expect(parsed.disable_active_migration);
+}
+
+test "transport params: ack_delay_exponent above 20 is clamped to default" {
+    const testing = std.testing;
+    // id=0x0a, len=1, value=21 (illegal — RFC 9000 §18.2 bounds it to 20).
+    const bytes = [_]u8{ 0x0a, 0x01, 0x15 };
+    const parsed = try parseTransportParams(&bytes);
+    try testing.expectEqual(@as(u8, 3), parsed.ack_delay_exponent);
+}
+
+test "transport params: truncated value is rejected" {
+    const testing = std.testing;
+    // id=0x04 (initial_max_data), len=4, but only 2 bytes of payload follow.
+    const bytes = [_]u8{ 0x04, 0x04, 0x44, 0x80 };
+    try testing.expectError(error.BufferTooShort, parseTransportParams(&bytes));
+}
+
 /// Tracks CRYPTO stream offsets per encryption level for reassembly.
 pub const CryptoStream = struct {
     /// Bytes received so far (next expected offset)

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -421,6 +421,36 @@ pub fn buildServerHello(
     return pos;
 }
 
+/// Locate the `quic_transport_parameters` TLS extension body inside a complete
+/// `EncryptedExtensions` handshake message (including its 4-byte handshake
+/// header). Returns null on any malformation rather than erroring — the caller
+/// treats absence as "fall back to RFC defaults".
+pub fn extractQuicTpFromEncryptedExtensions(msg: []const u8) ?[]const u8 {
+    // Handshake message header: msg_type(1) + length(3).
+    if (msg.len < 4) return null;
+    if (msg[0] != MSG_ENCRYPTED_EXTENSIONS) return null;
+    const body_len = readU24(msg[1..]);
+    if (4 + body_len > msg.len) return null;
+    const body = msg[4 .. 4 + body_len];
+    // EncryptedExtensions body: extensions<6..2^16-1> (2-byte length prefix).
+    if (body.len < 2) return null;
+    const ext_total = (@as(usize, body[0]) << 8) | body[1];
+    if (2 + ext_total > body.len) return null;
+    var p: usize = 2;
+    const end = 2 + ext_total;
+    while (p + 4 <= end) {
+        const ext_type = (@as(u16, body[p]) << 8) | body[p + 1];
+        const ext_len = (@as(usize, body[p + 2]) << 8) | body[p + 3];
+        p += 4;
+        if (p + ext_len > end) return null;
+        if (ext_type == EXT_QUIC_TRANSPORT_PARAMS) {
+            return body[p .. p + ext_len];
+        }
+        p += ext_len;
+    }
+    return null;
+}
+
 // ── EncryptedExtensions builder ───────────────────────────────────────────────
 
 /// Build a TLS 1.3 EncryptedExtensions message (raw, no record header).
@@ -1146,6 +1176,11 @@ pub const ServerHandshake = struct {
     /// Client leaf (DER) when the client sends a `Certificate` message (mutual TLS).
     peer_leaf_cert_der: [max_peer_leaf_cert_bytes]u8 = undefined,
     peer_leaf_cert_der_len: u16 = 0,
+    /// Encoded QUIC transport parameters extension body from the client's
+    /// ClientHello message (RFC 9001 §8.2). Populated in `processClientHello`.
+    /// See `ClientHandshake.peer_qtp` for the size rationale.
+    peer_qtp: [512]u8 = undefined,
+    peer_qtp_len: u16 = 0,
 
     pub fn init() ServerHandshake {
         return .{
@@ -1173,6 +1208,15 @@ pub const ServerHandshake = struct {
         out_initial: []u8,
     ) !usize {
         self.ch = try parseClientHello(ch_bytes);
+
+        // Capture the peer's QUIC transport parameters before `ch_bytes`
+        // ownership escapes us (see ClientHandshake.peer_qtp for rationale).
+        if (self.ch.quic_transport_params) |qtp| {
+            if (qtp.len <= self.peer_qtp.len and qtp.offset + qtp.len <= ch_bytes.len) {
+                @memcpy(self.peer_qtp[0..qtp.len], ch_bytes[qtp.offset .. qtp.offset + qtp.len]);
+                self.peer_qtp_len = @intCast(qtp.len);
+            }
+        }
 
         // Add ClientHello to transcript
         self.transcript.update(ch_bytes);
@@ -1367,6 +1411,13 @@ pub const ClientHandshake = struct {
     /// Server leaf certificate (DER) from the first `Certificate` message in the server flight.
     peer_leaf_cert_der: [max_peer_leaf_cert_bytes]u8 = undefined,
     peer_leaf_cert_der_len: u16 = 0,
+    /// Encoded QUIC transport parameters extension body from the server's
+    /// EncryptedExtensions message (RFC 9001 §8.2). Captured in
+    /// `processServerFlight`. `peer_qtp_len == 0` means absent or oversize
+    /// (peers exceeding 512 bytes are silently dropped — the spec ceiling
+    /// is 65535, but no real-world deployment exceeds a few hundred).
+    peer_qtp: [512]u8 = undefined,
+    peer_qtp_len: u16 = 0,
 
     pub fn init() ClientHandshake {
         return .{
@@ -1534,6 +1585,17 @@ pub const ClientHandshake = struct {
             switch (msg_type) {
                 MSG_ENCRYPTED_EXTENSIONS, MSG_CERTIFICATE_VERIFY, MSG_CERTIFICATE_REQUEST => {
                     if (msg_type == MSG_CERTIFICATE_REQUEST) saw_certificate_request = true;
+                    if (msg_type == MSG_ENCRYPTED_EXTENSIONS) {
+                        // Best-effort: extract the peer's QUIC transport parameters
+                        // extension. Failures are silent — `peer_qtp_len == 0` then
+                        // signals the caller to fall back to RFC defaults.
+                        if (extractQuicTpFromEncryptedExtensions(msg)) |qtp| {
+                            if (qtp.len <= self.peer_qtp.len) {
+                                @memcpy(self.peer_qtp[0..qtp.len], qtp);
+                                self.peer_qtp_len = @intCast(qtp.len);
+                            }
+                        }
+                    }
                     self.transcript.update(msg);
                 },
                 MSG_CERTIFICATE => {

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1097,15 +1097,28 @@ pub const ConnState = struct {
     address_validated: bool = false,
 
     // ── Connection-level flow control (RFC 9000 §4) ───────────────────────────
-    // Both sides advertise initial_max_data = 64 MiB in transport parameters.
-    // fc_send_max tracks how many cumulative bytes we may send (peer's window);
-    // it is raised by MAX_DATA frames from the peer.
+    // fc_send_max is the peer's connection-level receive window. The default
+    // here is the speculative ceiling we use until the handshake completes;
+    // `applyPeerTransportParams` overwrites it with the peer's advertised
+    // `initial_max_data` (RFC 9000 §18.2). The peer raises it later via
+    // MAX_DATA frames.
     // fc_bytes_sent / fc_bytes_recv track cumulative stream-data bytes sent and
     // received; used to check credit and decide when to advertise more window.
     fc_send_max: u64 = 64 * 1024 * 1024,
     fc_recv_max: u64 = 64 * 1024 * 1024,
     fc_bytes_sent: u64 = 0,
     fc_bytes_recv: u64 = 0,
+
+    // ── Per-stream initial limits the peer advertised (RFC 9000 §18.2) ────────
+    // Currently captured but not yet enforced on the send path; per-stream
+    // gating is queued as a follow-up to this PR (see issue #138 §"Flow
+    // control"). Stored zero-initialised — `applyPeerTransportParams` updates
+    // them on handshake completion.
+    peer_initial_max_stream_data_bidi_local: u64 = 0,
+    peer_initial_max_stream_data_bidi_remote: u64 = 0,
+    peer_initial_max_stream_data_uni: u64 = 0,
+    peer_max_streams_bidi: u64 = 0,
+    peer_max_streams_uni: u64 = 0,
 
     // ── Graceful teardown ─────────────────────────────────────────────────────
     // draining is set when CONNECTION_CLOSE is sent or received; once set, all
@@ -1219,6 +1232,32 @@ pub const ConnState = struct {
 
         self.has_app_keys = true;
         self.qlog.keyUpdated("1rtt", "tls");
+    }
+
+    /// Apply transport parameters received from the peer (RFC 9000 §18).
+    /// Seeds connection-level send credit and tracks per-stream limits so
+    /// outgoing STREAM frames stay within the peer's flow-control window.
+    /// Idempotent: a no-op when `qtp` is empty (peer omitted the extension).
+    ///
+    /// This is intentionally a small subset of §18.2. Idle-timeout, RTT
+    /// (`max_ack_delay`, `ack_delay_exponent`), and CID-pool sizing are
+    /// applied in follow-ups so each gap from issue #138 lands as its own
+    /// reviewable diff.
+    pub fn applyPeerTransportParams(self: *ConnState, qtp: []const u8) void {
+        if (qtp.len == 0) return;
+        const parsed = quic_tls_mod.parseTransportParams(qtp) catch |err| {
+            dbg("io: peer transport-params parse error: {} ({} bytes)\n", .{ err, qtp.len });
+            return;
+        };
+        if (parsed.initial_max_data > 0) {
+            self.fc_send_max = parsed.initial_max_data;
+            dbg("io: applied peer initial_max_data={}\n", .{parsed.initial_max_data});
+        }
+        self.peer_initial_max_stream_data_bidi_local = parsed.initial_max_stream_data_bidi_local;
+        self.peer_initial_max_stream_data_bidi_remote = parsed.initial_max_stream_data_bidi_remote;
+        self.peer_initial_max_stream_data_uni = parsed.initial_max_stream_data_uni;
+        self.peer_max_streams_bidi = parsed.initial_max_streams_bidi;
+        self.peer_max_streams_uni = parsed.initial_max_streams_uni;
     }
 };
 
@@ -2242,6 +2281,12 @@ pub const Server = struct {
             return;
         };
         conn.sh_len = sh_len;
+
+        // Apply peer's transport parameters now that ClientHello has been parsed.
+        // Done before the server flight is sent so any size-driven adjustments
+        // (none today, but follow-ups will need it) are in effect on the first
+        // outgoing 1-RTT packet (RFC 9000 §7.4.1).
+        conn.applyPeerTransportParams(conn.tls.peer_qtp[0..conn.tls.peer_qtp_len]);
 
         // Handshake secrets are available; derive QUIC handshake keys.
         conn.packet_cipher = packetCipherFromTls(conn.tls.ch.cipher_suite);
@@ -6119,6 +6164,9 @@ pub const Client = struct {
                 fpos += dlen;
                 continue;
             };
+            // Apply server's transport parameters from EncryptedExtensions
+            // before any 1-RTT data is exchanged (RFC 9000 §7.4.1).
+            self.conn.applyPeerTransportParams(self.tls.peer_qtp[0..self.tls.peer_qtp_len]);
             // App secrets are now derived; update QUIC 1-RTT keys.
             self.conn.deriveAppKeys(&self.tls.secrets);
 


### PR DESCRIPTION
## Summary

First of the gaps tracked in #138. Until now zquic ignored every transport parameter the peer sent in its ClientHello / EncryptedExtensions — `fc_send_max` was hardcoded to 64 MiB on both sides, so against any peer that advertised a smaller `initial_max_data` (rustls / quinn defaults are far below this) we'd blast past the window and get killed with `FLOW_CONTROL_ERROR`.

This PR:

- Adds `parseTransportParams(bytes) -> PeerTransportParams` in `src/crypto/quic_tls.zig`, covering the RFC 9000 §18.2 ids that affect runtime behavior (skips the connection-id params — those are validated as part of the handshake check, not surfaced here).
- Captures the peer's encoded TP extension bytes on `ServerHandshake` / `ClientHandshake`. The server reads them out of `parseClientHello`'s recorded offset; the client gets a small `EncryptedExtensions` scanner (`extractQuicTpFromEncryptedExtensions`) so we don't need a full EE parser to fish out one extension.
- Adds `ConnState.applyPeerTransportParams` that overwrites `fc_send_max` with the peer's `initial_max_data` and stashes the per-stream limits for follow-up enforcement. Called immediately after the relevant TLS step on each side, before any 1-RTT packet leaves the wire (RFC 9000 §7.4.1).

## What is intentionally NOT in this PR

To keep the diff reviewable, the following gaps from #138 are queued as separate PRs:

- Per-stream send-side gating against `peer_initial_max_stream_data_*` (fields are captured here but not yet enforced on the send path).
- Idle-timeout intersection (use `min(local, peer.max_idle_timeout)`).
- RTT estimator plumbing for `max_ack_delay` / `ack_delay_exponent`.
- `active_connection_id_limit` honoring (CID pool sizing).
- Emitting the missing TPs on our own side (`ack_delay_exponent`, `max_ack_delay`, `active_connection_id_limit`, `stateless_reset_token`).

## Test plan

- [x] `zig build test` — 5 new parser tests cover round-trip via `buildTransportParams`, unknown-id skipping, the length-0 `disable_active_migration` flag, the §18.2 clamp on `ack_delay_exponent`, and truncation rejection.
- [x] `zig fmt --check .`
- [x] `zig build examples`
- [ ] interop CI (`quinn` matrix should now see our advertised limits respected; nothing should regress).

Refs #138.