### PR TITLE
crypto/quic_tls,io: emit max_udp_payload_size + disable_active_migration (refs #138)

### DIFF
--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -127,6 +127,20 @@ pub const TransportParamsOpts = struct {
     /// willing to store for the peer. RFC 9000 §18.2 default is 2; we
     /// advertise a larger pool so the peer can rotate freely.
     active_connection_id_limit: u64 = 4,
+    /// `max_udp_payload_size` (0x03): largest UDP payload we are willing to
+    /// receive on this connection. Bounded by [1200, 65527] per RFC 9000
+    /// §18.2; values outside that range MUST be treated as TRANSPORT_PARAMETER_ERROR
+    /// by a compliant peer. Default 0 = omit (peer assumes the §18.2 default
+    /// of 65527). Callers should pass the connection's configured
+    /// `max_udp_payload` so the peer doesn't send packets we can't reassemble
+    /// on links with a smaller MTU.
+    max_udp_payload_size: u64 = 0,
+    /// `disable_active_migration` (0x0c): length-0 flag. When true we tell
+    /// the peer not to use addresses other than the one used during the
+    /// handshake. zquic supports active migration (gated on the `--migrate`
+    /// example flag), so the default is false — embedders that know they
+    /// won't migrate can opt in.
+    disable_active_migration: bool = false,
 };
 
 fn writeParamVarint(
@@ -188,6 +202,18 @@ pub fn buildTransportParams(out: []u8, opts: TransportParamsOpts) (varint.Encode
     // active_connection_id_limit (0x0e): we will accept this many distinct
     // CIDs from the peer; lets the peer rotate / migrate without exhausting.
     pos = try writeParamVarint(out, pos, 0x0e, opts.active_connection_id_limit);
+    // max_udp_payload_size (0x03): the largest UDP payload we are willing to
+    // receive on this connection (RFC 9000 §18.2). Only emitted when the
+    // caller passes a non-zero value; an absent param signals the §18.2
+    // default of 65527 to the peer.
+    if (opts.max_udp_payload_size != 0) {
+        pos = try writeParamVarint(out, pos, 0x03, opts.max_udp_payload_size);
+    }
+    // disable_active_migration (0x0c): length-0 flag indicating we will not
+    // initiate active migration. Only emitted when the caller opts in.
+    if (opts.disable_active_migration) {
+        pos = try writeParamBytes(out, pos, 0x0c, &[_]u8{});
+    }
 
     if (opts.original_destination_cid) |odcid| {
         pos = try writeParamBytes(out, pos, 0x00, odcid);
@@ -350,6 +376,53 @@ test "transport params: truncated value is rejected" {
     // id=0x04 (initial_max_data), len=4, but only 2 bytes of payload follow.
     const bytes = [_]u8{ 0x04, 0x04, 0x44, 0x80 };
     try testing.expectError(error.BufferTooShort, parseTransportParams(&bytes));
+}
+
+test "transport params: max_udp_payload_size emitted only when opted in" {
+    const testing = std.testing;
+    var buf: [256]u8 = undefined;
+    const cid = [_]u8{ 0xaa, 0xbb, 0xcc, 0xdd };
+
+    // Default opts → 0x03 absent → peer falls back to the §18.2 default 65527.
+    {
+        const n = try buildTransportParams(&buf, .{ .initial_source_cid = &cid });
+        const parsed = try parseTransportParams(buf[0..n]);
+        try testing.expectEqual(@as(u64, 65527), parsed.max_udp_payload_size);
+    }
+    // Opt in with our actual receive MTU; round-trip the exact value.
+    {
+        const n = try buildTransportParams(&buf, .{
+            .initial_source_cid = &cid,
+            .max_udp_payload_size = 1500,
+        });
+        const parsed = try parseTransportParams(buf[0..n]);
+        try testing.expectEqual(@as(u64, 1500), parsed.max_udp_payload_size);
+    }
+}
+
+test "transport params: disable_active_migration emitted only when opted in" {
+    const testing = std.testing;
+    var buf: [256]u8 = undefined;
+    const cid = [_]u8{ 0xaa, 0xbb, 0xcc, 0xdd };
+
+    // Default opts → 0x0c absent → peer reads false.
+    {
+        const n = try buildTransportParams(&buf, .{ .initial_source_cid = &cid });
+        const parsed = try parseTransportParams(buf[0..n]);
+        try testing.expectEqual(false, parsed.disable_active_migration);
+    }
+    // Opt in → 0x0c emitted as a length-0 flag → peer reads true.
+    {
+        const n = try buildTransportParams(&buf, .{
+            .initial_source_cid = &cid,
+            .disable_active_migration = true,
+        });
+        const parsed = try parseTransportParams(buf[0..n]);
+        try testing.expect(parsed.disable_active_migration);
+        // Bytes-on-wire check: the emitted frame is `0x0c 0x00` (id varint
+        // 0x0c, length varint 0). The buffer must contain that exact pair.
+        try testing.expect(std.mem.indexOf(u8, buf[0..n], &.{ 0x0c, 0x00 }) != null);
+    }
 }
 
 /// Tracks CRYPTO stream offsets per encryption level for reassembly.

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -2598,6 +2598,11 @@ pub const Server = struct {
             .initial_source_cid = conn.local_cid.slice(),
             .original_destination_cid = odcid,
             .stateless_reset_token = conn.stateless_reset_token,
+            // Advertise our actual receive-side UDP payload limit so the
+            // peer doesn't oversize datagrams (RFC 9000 §18.2). When the
+            // server doesn't actively migrate, the param is omitted (we
+            // still accept incoming migration if the peer initiates).
+            .max_udp_payload_size = conn.max_udp_payload,
         }) catch |err| {
             dbg("io: transport params encode failed: {}\n", .{err});
             return;
@@ -5938,7 +5943,11 @@ pub const Client = struct {
             // First send: build the ClientHello and save it for any future rebuild.
             const alpn = clientTlsAlpn(&self.config);
             var quic_tp_buf: [128]u8 = undefined;
-            const quic_tp = try buildEndpointTransportParams(&quic_tp_buf, self.conn.local_cid.slice());
+            const quic_tp = try buildEndpointTransportParams(
+                &quic_tp_buf,
+                self.conn.local_cid.slice(),
+                self.conn.max_udp_payload,
+            );
 
             // Choose ClientHello variant based on flags.
             const now_ms: u64 = @intCast(compat.milliTimestamp());
@@ -7694,9 +7703,14 @@ inline fn readU24(b: []const u8) u32 {
 fn buildEndpointTransportParams(
     buf: []u8,
     initial_source_cid: []const u8,
+    max_udp_payload_size: u64,
 ) (varint.EncodeError || varint.DecodeError)![]const u8 {
     const n = try quic_tls_mod.buildTransportParams(buf, .{
         .initial_source_cid = initial_source_cid,
+        // Advertise our actual receive-side UDP payload limit so the server
+        // doesn't oversize datagrams (RFC 9000 §18.2). Pass-through 0 means
+        // omit (peer assumes the §18.2 default of 65527).
+        .max_udp_payload_size = max_udp_payload_size,
     });
     return buf[0..n];
 }


### PR DESCRIPTION
## Summary

Two more §18.2 transport parameters we should be sending but weren't. The parse side already handled both (#150); this PR closes the symmetric emit side.

* **\`max_udp_payload_size\` (0x03)** — receive-side UDP payload limit. Per RFC 9000 §18.2 the peer assumes 65527 in our absence, which causes it to oversize datagrams on links with a smaller MTU. Both the server (in \`acceptHandshake\`) and the client (in \`sendClientHello\` via \`buildEndpointTransportParams\`) now pass \`conn.max_udp_payload\` so the peer sizes datagrams to our actual receive limit. Gated by a non-zero value so the legacy \`buildClientTransportParams\` test helper keeps the previous \"omit\" behaviour.

* **\`disable_active_migration\` (0x0c)** — length-0 flag. Threaded through \`TransportParamsOpts.disable_active_migration\` (default false) so embedders that know they will not migrate can opt in. zquic still supports active migration on demand, so we do not opt in by default; the wire-format hook is just there.

## What is *not* in this PR

- \`preferred_address\` (0x0d) — requires a real second address to publish; not on the libp2p hot path.
- \`max_datagram_frame_size\` (0x20) — RFC 9221 DATAGRAM frames, separate feature.

## Test plan

- [x] \`zig build test --summary all\` — 180 → 182 (two new round-trip tests covering opt-in / opt-out semantics for both params).
- [x] \`zig fmt --check .\`
- [x] \`zig build examples\`
- [ ] interop CI matrix (will run on push)

Refs #138.