### PR TITLE
loss,io: RFC 9002 loss-detection completeness (refs #138)

### DIFF
--- a/src/loss/congestion.zig
+++ b/src/loss/congestion.zig
@@ -14,6 +14,8 @@ const std = @import("std");
 pub const mss: u64 = 1350;
 /// Maximum congestion window (bytes).
 const max_cwnd: u64 = 64 * 1024 * 1024; // 64 MB
+/// Minimum congestion window after persistent congestion (RFC 9002 §7.6.3).
+pub const minimum_window: u64 = 2 * mss;
 
 pub const CcState = enum {
     slow_start,
@@ -79,6 +81,26 @@ pub const NewReno = struct {
         self.state = .recovery;
     }
 
+    /// Called when persistent congestion is detected (RFC 9002 §7.6.3).
+    /// Collapses cwnd to the minimum window and re-enters slow start so the
+    /// sender does not continue to overload an apparently dead path.
+    /// Bytes-in-flight is left untouched — outstanding packets remain in
+    /// flight until they are acked, lost, or discarded.
+    pub fn onPersistentCongestion(self: *NewReno) void {
+        self.cwnd = minimum_window;
+        self.state = .slow_start;
+        self.bytes_acked_ca = 0;
+        self.end_of_recovery = null;
+    }
+
+    /// ECN-CE feedback or other peer-signalled congestion (RFC 9002 §B.4 /
+    /// RFC 9000 §13.4).  Equivalent to a packet-loss congestion event: halve
+    /// cwnd and enter recovery, gated by `end_of_recovery` so we don't react
+    /// twice within the same RTT.
+    pub fn onCongestionEvent(self: *NewReno, largest_acked_pn: u64) void {
+        self.onLoss(largest_acked_pn);
+    }
+
     /// Called when a packet is sent.
     pub fn onPacketSent(self: *NewReno, bytes: u64) void {
         self.bytes_in_flight +|= bytes;
@@ -117,6 +139,18 @@ pub const CongestionController = union(enum) {
     pub fn onLoss(self: *CongestionController, largest_lost_pn: u64) void {
         switch (self.*) {
             inline else => |*cc| cc.onLoss(largest_lost_pn),
+        }
+    }
+
+    pub fn onPersistentCongestion(self: *CongestionController) void {
+        switch (self.*) {
+            inline else => |*cc| cc.onPersistentCongestion(),
+        }
+    }
+
+    pub fn onCongestionEvent(self: *CongestionController, largest_acked_pn: u64) void {
+        switch (self.*) {
+            inline else => |*cc| cc.onCongestionEvent(largest_acked_pn),
         }
     }
 
@@ -205,6 +239,34 @@ test "new_reno: can_send check" {
     try testing.expect(cc.canSend(mss));
 }
 
+test "new_reno: persistent congestion collapses to minimum window" {
+    const testing = std.testing;
+    var cc = NewReno.init();
+    cc.cwnd = 100 * mss;
+    cc.state = .congestion_avoidance;
+    cc.bytes_acked_ca = 12345;
+
+    cc.onPersistentCongestion();
+    try testing.expectEqual(minimum_window, cc.cwnd);
+    try testing.expectEqual(CcState.slow_start, cc.state);
+    try testing.expectEqual(@as(u64, 0), cc.bytes_acked_ca);
+}
+
+test "new_reno: onCongestionEvent equivalent to onLoss" {
+    const testing = std.testing;
+    var a = NewReno.init();
+    var b = NewReno.init();
+    a.cwnd = 20 * mss;
+    b.cwnd = 20 * mss;
+    a.bytes_in_flight = 10 * mss;
+    b.bytes_in_flight = 10 * mss;
+    a.onLoss(42);
+    b.onCongestionEvent(42);
+    try testing.expectEqual(a.cwnd, b.cwnd);
+    try testing.expectEqual(a.ssthresh, b.ssthresh);
+    try testing.expectEqual(a.state, b.state);
+}
+
 test "congestion_controller: tagged union dispatches correctly" {
     const testing = std.testing;
 
@@ -224,4 +286,14 @@ test "congestion_controller: tagged union dispatches correctly" {
     cubic.onLoss(1);
     // After loss, CUBIC sets cwnd = cwnd × β (0.7).
     try testing.expect(cubic.canSend(mss));
+
+    // Persistent congestion collapses both variants to the minimum window.
+    // bytes_in_flight may still be non-zero from earlier; assert by reading
+    // the cwnd directly via sendCredit() bound.
+    nr.setBytesInFlight(0);
+    cubic.setBytesInFlight(0);
+    nr.onPersistentCongestion();
+    cubic.onPersistentCongestion();
+    try testing.expectEqual(minimum_window, nr.sendCredit());
+    try testing.expectEqual(minimum_window, cubic.sendCredit());
 }

--- a/src/loss/cubic.zig
+++ b/src/loss/cubic.zig
@@ -150,6 +150,26 @@ pub const Cubic = struct {
         self.bytes_acked_ca = 0;
     }
 
+    /// Called when persistent congestion is detected (RFC 9002 §7.6.3).
+    /// Collapse to the minimum window and re-enter slow start; clear the
+    /// CUBIC epoch so the next recovery starts fresh.
+    pub fn onPersistentCongestion(self: *Cubic) void {
+        self.cwnd = nr.minimum_window;
+        self.state = .slow_start;
+        self.epoch_start_ms = null;
+        self.bytes_acked_ca = 0;
+        self.end_of_recovery = null;
+        self.w_max = 0;
+        self.k_ms = 0;
+        self.tcp_cwnd = 0;
+    }
+
+    /// ECN-CE feedback or other peer-signalled congestion event.  Same
+    /// reaction as a packet-loss event — gated by `end_of_recovery`.
+    pub fn onCongestionEvent(self: *Cubic, largest_acked_pn: u64) void {
+        self.onLoss(largest_acked_pn);
+    }
+
     /// Called when a packet is sent.
     pub fn onPacketSent(self: *Cubic, bytes: u64) void {
         self.bytes_in_flight +|= bytes;

--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -22,6 +22,8 @@ const k_packet_threshold: u64 = 3;
 const k_max_ack_delay_ms: u64 = 25;
 /// Granularity timer resolution in ms
 const k_granularity_ms: u64 = 1;
+/// Persistent congestion duration multiplier (RFC 9002 §7.6.1)
+const k_persistent_congestion_threshold: u64 = 3;
 
 /// RTT estimator for a QUIC connection.
 pub const RttEstimator = struct {
@@ -72,6 +74,27 @@ pub const RttEstimator = struct {
         const with_delay: f64 = base_pto + @as(f64, @floatFromInt(max_ack_delay));
         const scaled = with_delay * std.math.pow(f64, 2.0, @floatFromInt(pto_count));
         return @intFromFloat(scaled);
+    }
+
+    /// Time-threshold loss delay in ms (RFC 9002 §6.1.2):
+    ///   loss_delay = kTimeThreshold * max(SRTT, latest_RTT), floored at kGranularity.
+    /// Before any RTT sample exists we fall back to the initial RTT so the
+    /// loss timer is still well-defined during the handshake.
+    pub fn loss_delay_ms(self: *const RttEstimator) u64 {
+        const srtt: u64 = if (self.first_rtt_sample) @intFromFloat(@max(self.srtt_ms, 0.0)) else initial_rtt_ms;
+        const base = @max(srtt, self.latest_rtt_ms);
+        const scaled = (base * k_time_threshold_num) / k_time_threshold_den;
+        return @max(scaled, k_granularity_ms);
+    }
+
+    /// Persistent-congestion duration in ms (RFC 9002 §7.6.1):
+    ///   pc_duration = (SRTT + 4*RTTVAR + max_ack_delay) * kPersistentCongestionThreshold.
+    /// Like `loss_delay_ms`, this falls back to the initial RTT before any sample.
+    pub fn persistent_congestion_duration_ms(self: *const RttEstimator, max_ack_delay: u64) u64 {
+        const srtt: f64 = if (self.first_rtt_sample) self.srtt_ms else @floatFromInt(initial_rtt_ms);
+        const rttvar: f64 = if (self.first_rtt_sample) self.rttvar_ms else @as(f64, @floatFromInt(initial_rtt_ms)) / 2.0;
+        const base: f64 = srtt + @max(4.0 * rttvar, @as(f64, @floatFromInt(k_granularity_ms))) + @as(f64, @floatFromInt(max_ack_delay));
+        return @intFromFloat(base * @as(f64, @floatFromInt(k_persistent_congestion_threshold)));
     }
 };
 
@@ -146,6 +169,16 @@ pub const LossDetector = struct {
         rtt_updated: bool,
         bytes_acked: u64,
         lost_bytes: u64,
+        /// True when the set of ack-eliciting packets declared lost by this
+        /// ACK spans a duration ≥ `persistent_congestion_duration_ms`
+        /// (RFC 9002 §7.6).  The caller should invoke
+        /// `CongestionController.onPersistentCongestion` in that case.
+        persistent_congestion: bool,
+        /// Largest packet number declared lost by this ACK, if any.  Exposed
+        /// so the caller can invoke `cc.onLoss(largest_lost_pn)` once per
+        /// ACK instead of once per lost packet — the recovery period bound
+        /// is what matters, not the individual PNs.
+        largest_lost_pn: ?u64,
     };
 
     /// Process an ACK frame. Returns packets declared lost.
@@ -205,6 +238,25 @@ pub const LossDetector = struct {
         var lost_count: usize = 0;
         var bytes_acked: u64 = 0;
         var lost_bytes: u64 = 0;
+        var largest_lost_pn: ?u64 = null;
+        // Track the earliest send_time of any ack-eliciting packet acked by
+        // this ACK.  Per RFC 9002 §7.6.2 the persistent congestion window
+        // must start at or before this time — otherwise we'd have direct
+        // evidence the path delivered something in the interval and the
+        // contiguity precondition is violated.
+        var earliest_acked_eliciting_send_time: ?u64 = null;
+        // Track the bounds of ack-eliciting packets declared lost so we can
+        // evaluate the persistent-congestion duration (RFC 9002 §7.6.1).
+        var earliest_lost_eliciting_send_time: ?u64 = null;
+        var latest_lost_eliciting_send_time: ?u64 = null;
+
+        // Compute the time-threshold loss bound once per ACK (RFC 9002
+        // §6.1.2).  A packet older than this is declared lost even if fewer
+        // than k_packet_threshold later PNs have been acked — this handles
+        // reordering windows beyond k_packet_threshold and tail drops where
+        // the gap from largest_acked back to the lost packet is large.
+        const loss_delay = rtt.loss_delay_ms();
+        const time_lost_before = now_ms -| loss_delay;
 
         var i: usize = 0;
         while (i < self.sent_count) {
@@ -213,7 +265,11 @@ pub const LossDetector = struct {
             // Packet is definitively acked: within [smallest_acked .. largest_acked].
             if (p.pn >= smallest_acked and p.pn <= largest_acked) {
                 bytes_acked += p.size;
-                // Free heap-owned retransmit buffer (raw-application path).
+                if (p.ack_eliciting) {
+                    if (earliest_acked_eliciting_send_time) |t| {
+                        if (p.send_time_ms < t) earliest_acked_eliciting_send_time = p.send_time_ms;
+                    } else earliest_acked_eliciting_send_time = p.send_time_ms;
+                }
                 if (self.sent[i].stream_data) |sd| {
                     allocator.free(sd);
                     self.sent[i].stream_data = null;
@@ -223,22 +279,33 @@ pub const LossDetector = struct {
                 continue;
             }
 
-            // Packet is below the acked range — apply k_packet_threshold loss
-            // detection only for true gaps (p.pn < smallest_acked).
-            // A packet is considered lost when k_packet_threshold or more
-            // later packets have been acknowledged (RFC 9002 §6.1.1).
-            if (p.pn < smallest_acked and largest_acked >= p.pn + k_packet_threshold) {
+            // Packet is below the acked range — apply RFC 9002 §6.1 loss
+            // detection for true gaps (p.pn < smallest_acked).  A packet is
+            // declared lost if EITHER:
+            //   - packet threshold: k_packet_threshold or more later PNs are
+            //     acked (RFC 9002 §6.1.1), OR
+            //   - time threshold:   it was sent before now - loss_delay
+            //     (RFC 9002 §6.1.2).
+            const packet_threshold_lost = (p.pn < smallest_acked and largest_acked >= p.pn + k_packet_threshold);
+            const time_threshold_lost = (p.pn < smallest_acked and p.send_time_ms <= time_lost_before);
+            if (packet_threshold_lost or time_threshold_lost) {
                 lost_bytes += p.size;
+                if (largest_lost_pn) |lpn| {
+                    if (p.pn > lpn) largest_lost_pn = p.pn;
+                } else largest_lost_pn = p.pn;
+                if (p.ack_eliciting) {
+                    if (earliest_lost_eliciting_send_time) |t| {
+                        if (p.send_time_ms < t) earliest_lost_eliciting_send_time = p.send_time_ms;
+                    } else earliest_lost_eliciting_send_time = p.send_time_ms;
+                    if (latest_lost_eliciting_send_time) |t| {
+                        if (p.send_time_ms > t) latest_lost_eliciting_send_time = p.send_time_ms;
+                    } else latest_lost_eliciting_send_time = p.send_time_ms;
+                }
                 if (lost_count < lost_buf.len) {
-                    lost_buf[lost_count] = p; // full descriptor for retransmission
-                    // Ownership of stream_data transfers from `self.sent[i]`
-                    // to `lost_buf[lost_count]`; clear the source so it isn't
-                    // freed when this slot is later overwritten.
+                    lost_buf[lost_count] = p;
                     self.sent[i].stream_data = null;
                     lost_count += 1;
                 } else {
-                    // No room to surface this loss — free the retransmit
-                    // buffer so it doesn't leak.
                     if (self.sent[i].stream_data) |sd| {
                         allocator.free(sd);
                         self.sent[i].stream_data = null;
@@ -252,11 +319,43 @@ pub const LossDetector = struct {
             i += 1;
         }
 
+        // Persistent congestion (RFC 9002 §7.6.1): the duration between the
+        // earliest and latest ack-eliciting packets declared lost spans the
+        // persistent_congestion threshold.  We only declare PC if no
+        // ack-eliciting packet was acked within that interval (otherwise the
+        // path clearly delivered something and is not in persistent
+        // congestion).  An RTT sample must exist — without one we cannot
+        // compute a meaningful threshold (RFC 9002 §7.6.2).
+        var pc = false;
+        if (rtt.first_rtt_sample) {
+            if (earliest_lost_eliciting_send_time) |t0| {
+                if (latest_lost_eliciting_send_time) |t1| {
+                    if (t1 > t0) {
+                        const span = t1 - t0;
+                        const pc_dur = rtt.persistent_congestion_duration_ms(k_max_ack_delay_ms);
+                        if (span >= pc_dur) {
+                            // Contiguity: no ack-eliciting packet acked by this
+                            // ACK fell inside (t0, t1).  If one did, this ACK
+                            // proves the path is delivering and PC does not
+                            // apply.
+                            const overlap = if (earliest_acked_eliciting_send_time) |ea|
+                                (ea > t0 and ea < t1)
+                            else
+                                false;
+                            if (!overlap) pc = true;
+                        }
+                    }
+                }
+            }
+        }
+
         return OnAckResult{
             .lost_count = lost_count,
             .rtt_updated = rtt_updated,
             .bytes_acked = bytes_acked,
             .lost_bytes = lost_bytes,
+            .persistent_congestion = pc,
+            .largest_lost_pn = largest_lost_pn,
         };
     }
 };
@@ -323,6 +422,99 @@ test "loss: rejects invalid first_ack_range > largest_acked" {
         error.FrameEncodingError,
         ld.onAck(5, 10, 0, 200, &rtt, &lost_buf, testing.allocator),
     );
+}
+
+test "loss: time-threshold declares old packet lost when gap < k_packet_threshold" {
+    const testing = std.testing;
+    var ld = LossDetector{};
+    var rtt = RttEstimator{};
+    // Establish an RTT sample so loss_delay is bounded and deterministic.
+    rtt.update(50, 0);
+    const loss_delay = rtt.loss_delay_ms();
+
+    // Send pn 0 at t=100 and pn 1 at t=200.  Only one later PN gets acked,
+    // so packet-threshold (kPacketThreshold=3) will NOT trip on pn 0.
+    _ = ld.onPacketSent(.{ .pn = 0, .send_time_ms = 100, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 1, .send_time_ms = 200, .size = 100, .ack_eliciting = true, .in_flight = true });
+
+    // Ack pn 1 at a time far enough past pn 0's send to trigger time-threshold.
+    const now = 200 + loss_delay + 1;
+    var lost_buf: [4]SentPacket = undefined;
+    const r = try ld.onAck(1, 0, 0, now, &rtt, &lost_buf, testing.allocator);
+    try testing.expectEqual(@as(usize, 1), r.lost_count);
+    try testing.expectEqual(@as(u64, 0), lost_buf[0].pn);
+    try testing.expect(r.largest_lost_pn != null);
+    try testing.expectEqual(@as(u64, 0), r.largest_lost_pn.?);
+}
+
+test "loss: persistent congestion across spread-out losses" {
+    const testing = std.testing;
+    var ld = LossDetector{};
+    var rtt = RttEstimator{};
+    // Pin a small SRTT so the PC threshold is small and easy to exceed.
+    rtt.update(10, 0);
+    const pc_dur = rtt.persistent_congestion_duration_ms(k_max_ack_delay_ms);
+
+    // Send 6 ack-eliciting packets spanning > pc_dur, then ack only pn 5.
+    // pns 0..2 are declared lost via packet-threshold; we space them so the
+    // span between earliest and latest ack-eliciting lost packet exceeds
+    // pc_dur.
+    const t0: u64 = 1_000;
+    const t_last = t0 + pc_dur + 50; // bound for the latest lost pn
+
+    _ = ld.onPacketSent(.{ .pn = 0, .send_time_ms = t0, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 1, .send_time_ms = t0 + (pc_dur / 2), .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 2, .send_time_ms = t_last, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 3, .send_time_ms = t_last + 10, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 4, .send_time_ms = t_last + 20, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 5, .send_time_ms = t_last + 30, .size = 100, .ack_eliciting = true, .in_flight = true });
+
+    // Ack only pn 5 so packet-threshold trips on 0, 1, 2.  Use a `now`
+    // large enough that time-threshold also fires on 3 and 4.
+    const now = t_last + 30 + rtt.loss_delay_ms() + 1;
+    var lost_buf: [16]SentPacket = undefined;
+    const r = try ld.onAck(5, 0, 0, now, &rtt, &lost_buf, testing.allocator);
+    try testing.expect(r.lost_count >= 3);
+    try testing.expect(r.persistent_congestion);
+}
+
+test "loss: no persistent congestion when ack proves path is delivering" {
+    const testing = std.testing;
+    var ld = LossDetector{};
+    var rtt = RttEstimator{};
+    rtt.update(10, 0);
+    const pc_dur = rtt.persistent_congestion_duration_ms(k_max_ack_delay_ms);
+
+    // pn 0 sent very early, then pn 1 sent inside the PC window and acked
+    // (proving delivery), then pn 2..5 surrounding so packet-threshold
+    // declares pn 0 lost.  Span of lost ack-eliciting packets is just pn 0
+    // alone, so PC must not fire — additionally the acked pn 1 falls within
+    // the loss window if there were a second lost packet, also blocking PC.
+    const t0: u64 = 1_000;
+
+    _ = ld.onPacketSent(.{ .pn = 0, .send_time_ms = t0, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 1, .send_time_ms = t0 + 5, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 2, .send_time_ms = t0 + pc_dur + 10, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 3, .send_time_ms = t0 + pc_dur + 11, .size = 100, .ack_eliciting = true, .in_flight = true });
+    _ = ld.onPacketSent(.{ .pn = 4, .send_time_ms = t0 + pc_dur + 12, .size = 100, .ack_eliciting = true, .in_flight = true });
+
+    // Ack pns 1..4 in one contiguous range.  pn 0 hits packet-threshold
+    // (largest_acked=4 ≥ 0+3) but pn 1 was acked inside the same ACK, so
+    // even if a second loss were present, PC would not apply.
+    var lost_buf: [8]SentPacket = undefined;
+    const r = try ld.onAck(4, 3, 0, t0 + pc_dur + 20, &rtt, &lost_buf, testing.allocator);
+    try testing.expect(r.lost_count >= 1);
+    try testing.expect(!r.persistent_congestion);
+}
+
+test "loss: persistent_congestion_duration falls back to initial RTT before first sample" {
+    const testing = std.testing;
+    const rtt = RttEstimator{};
+    // Before any sample, threshold should equal pc_threshold *
+    //   (initial_rtt + 4 * initial_rtt/2 + max_ack_delay)
+    //   = 3 * (333 + 666 + 25) = 3072.
+    const got = rtt.persistent_congestion_duration_ms(k_max_ack_delay_ms);
+    try testing.expectEqual(@as(u64, 3 * (333 + 666 + 25)), got);
 }
 
 test "loss: stream_data is freed on ack and transferred on loss" {

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -254,6 +254,37 @@ fn writeKeylog(path: []const u8, client_random: [32]u8, secrets: *const tls_hs.T
 /// Skip the body of an ACK frame (type 0x02 or 0x03), advancing `pos` past it.
 /// `is_ecn` should be true for type 0x03 (includes ECN counts).
 /// Returns the number of bytes consumed from `data` (which starts AFTER the type varint).
+/// Extract the trailing ECN counts (ect0, ect1, ecn-ce) from an ACK-ECN
+/// frame body.  `data` starts at the same offset as `skipAckBody`'s input
+/// (i.e. right after the type byte).  Returns `null` when the body is
+/// truncated; otherwise the three peer-reported counters.  We re-parse the
+/// body instead of refactoring the existing ACK fast path so the change
+/// stays focused on RFC 9002 §B.4 ECN feedback handling.
+fn parseAckEcnCounts(data: []const u8) ?struct { ect0: u64, ect1: u64, ce: u64 } {
+    var pos: usize = 0;
+    const lar = varint.decode(data[pos..]) catch return null;
+    pos += lar.len;
+    const del = varint.decode(data[pos..]) catch return null;
+    pos += del.len;
+    const cnt = varint.decode(data[pos..]) catch return null;
+    pos += cnt.len;
+    const fst = varint.decode(data[pos..]) catch return null;
+    pos += fst.len;
+    var ri: u64 = 0;
+    while (ri < cnt.value) : (ri += 1) {
+        const gp = varint.decode(data[pos..]) catch return null;
+        pos += gp.len;
+        const rl = varint.decode(data[pos..]) catch return null;
+        pos += rl.len;
+    }
+    const ect0 = varint.decode(data[pos..]) catch return null;
+    pos += ect0.len;
+    const ect1 = varint.decode(data[pos..]) catch return null;
+    pos += ect1.len;
+    const ce = varint.decode(data[pos..]) catch return null;
+    return .{ .ect0 = ect0.value, .ect1 = ect1.value, .ce = ce.value };
+}
+
 fn skipAckBody(data: []const u8, is_ecn: bool) usize {
     var pos: usize = 0;
     const lar = varint.decode(data[pos..]) catch return data.len;
@@ -1208,6 +1239,16 @@ pub const ConnState = struct {
     ecn_ect0_recv: u64 = 0,
     ecn_ect1_recv: u64 = 0,
     ecn_ce_recv: u64 = 0,
+
+    // Peer-reported ECN counters from ACK frames carrying ECN feedback
+    // (RFC 9002 §B.4 / RFC 9000 §13.4).  When `peer_ecn_ce` increases for a
+    // packet number space, the peer has reported a CE-marked packet — we
+    // treat this as a congestion signal.  Tracked only for the 1-RTT space;
+    // the Initial / Handshake spaces are short-lived enough that we do not
+    // currently react to ECN feedback there.
+    peer_ecn_ect0: u64 = 0,
+    peer_ecn_ect1: u64 = 0,
+    peer_ecn_ce: u64 = 0,
 
     // ── Congestion control + loss detection (RFC 9002) ────────────────────────
     // Congestion controller: NewReno (default) or CUBIC (configurable).
@@ -3389,6 +3430,28 @@ pub const Server = struct {
                 // lost packets are no longer "in flight").
                 if (ld_result.lost_bytes > 0) {
                     conn.cc.subBytesInFlight(ld_result.lost_bytes);
+                }
+                // ECN-CE feedback (RFC 9002 §B.4): an increase in the peer's
+                // reported CE counter is a congestion signal.  We only
+                // process ACK-ECN frames (type 0x03) and only react to a
+                // strictly-increasing CE count to avoid double-counting
+                // when ACKs are reordered or duplicated.
+                if (ft == 0x03) {
+                    if (parseAckEcnCounts(frames[pos..])) |ec| {
+                        if (ec.ce > conn.peer_ecn_ce) {
+                            conn.peer_ecn_ce = ec.ce;
+                            conn.cc.onCongestionEvent(largest_ack);
+                        }
+                        if (ec.ect0 > conn.peer_ecn_ect0) conn.peer_ecn_ect0 = ec.ect0;
+                        if (ec.ect1 > conn.peer_ecn_ect1) conn.peer_ecn_ect1 = ec.ect1;
+                    }
+                }
+                // Persistent congestion (RFC 9002 §7.6): collapse cwnd to the
+                // minimum window when the loss detector reports a long-enough
+                // unbroken span of lost ack-eliciting packets.
+                if (ld_result.persistent_congestion) {
+                    dbg("io: persistent congestion detected — resetting cwnd\n", .{});
+                    conn.cc.onPersistentCongestion();
                 }
                 // Signal loss events to CC and rewind any affected HTTP/0.9
                 // stream slots so lost data is retransmitted (RFC 9000 §3.3).
@@ -6627,6 +6690,22 @@ pub const Client = struct {
                 };
                 if (ld_result.bytes_acked > 0) self.conn.cc.onAck(ld_result.bytes_acked);
                 if (ld_result.lost_bytes > 0) self.conn.cc.subBytesInFlight(ld_result.lost_bytes);
+                // ECN-CE feedback (RFC 9002 §B.4): mirror of the server arm.
+                if (ft == 0x03) {
+                    if (parseAckEcnCounts(plaintext[pos..pt_len])) |ec| {
+                        if (ec.ce > self.conn.peer_ecn_ce) {
+                            self.conn.peer_ecn_ce = ec.ce;
+                            self.conn.cc.onCongestionEvent(largest_ack);
+                        }
+                        if (ec.ect0 > self.conn.peer_ecn_ect0) self.conn.peer_ecn_ect0 = ec.ect0;
+                        if (ec.ect1 > self.conn.peer_ecn_ect1) self.conn.peer_ecn_ect1 = ec.ect1;
+                    }
+                }
+                // Persistent congestion (RFC 9002 §7.6).
+                if (ld_result.persistent_congestion) {
+                    dbg("io: persistent congestion detected — resetting cwnd\n", .{});
+                    self.conn.cc.onPersistentCongestion();
+                }
                 // Retransmit any raw-app STREAM frames that the loss detector
                 // surfaced.  Symmetric to Server's onAck loss arm.
                 var li: usize = 0;


### PR DESCRIPTION
## Summary

Closes the remaining RFC 9002 gaps in the loss-detection and
congestion-control path. The packet-threshold loss detector landed in
earlier PRs; this completes the §6.1 / §7.6 / §B.4 trio.

- **Time-threshold loss** (§6.1.2): a packet is declared lost when its
  send time is older than `max(SRTT, latest_RTT) × 9/8` (floored at
  `kGranularity`), regardless of how many later PNs have been acked.
  Catches tail drops and reordering windows beyond `kPacketThreshold`.
- **Persistent congestion** (§7.6.1 / §7.6.3): when the span of
  ack-eliciting packets declared lost by a single ACK exceeds
  `(SRTT + 4·RTTVAR + max_ack_delay) × 3` — and no ack-eliciting
  packet acked by the same ACK falls inside that span — collapse cwnd
  to `kMinimumWindow = 2·MSS` and re-enter slow start. Both NewReno
  and CUBIC implement the reset.
- **ECN-CE feedback** (§B.4 / RFC 9000 §13.4): parse the trailing ECN
  counts on every ACK-ECN frame (type 0x03). When the peer's CE
  counter strictly increases, drive
  `CongestionController.onCongestionEvent(largest_acked)` — equivalent
  to `onLoss` for NewReno/CUBIC and gated by the same
  end-of-recovery guard so we react at most once per RTT.

## Files

- \`src/loss/recovery.zig\` — \`loss_delay_ms\`,
  \`persistent_congestion_duration_ms\`, time-threshold loss in
  \`LossDetector.onAck\`, PC detection, new \`OnAckResult\` fields
  (\`persistent_congestion\`, \`largest_lost_pn\`).
- \`src/loss/congestion.zig\`, \`src/loss/cubic.zig\` —
  \`onPersistentCongestion\` and \`onCongestionEvent\` on NewReno,
  CUBIC, and the tagged-union dispatcher.
- \`src/transport/io.zig\` — \`parseAckEcnCounts\` helper,
  \`peer_ecn_ect0/ect1/ce\` state on \`ConnState\`, ECN-CE and PC
  wiring on both the server-side and client-side ACK arms.

## Test plan

- [x] \`zig fmt --check .\` clean
- [x] \`zig build test --summary all\` → **188/188 pass** (was 182,
  +6 new tests: time-threshold loss, persistent congestion
  positive/negative, PC duration fallback, NewReno PC collapse,
  \`onCongestionEvent ≡ onLoss\`).
- [x] \`zig build\` and \`zig build examples\` succeed.
- [ ] Interop runs to follow once merged.

Refs #138.