### PR TITLE
crypto/session,io: 0-RTT AEAD send-side audit (refs #138)

### DIFF
--- a/src/crypto/session.zig
+++ b/src/crypto/session.zig
@@ -66,6 +66,13 @@ pub const SessionTicket = struct {
     max_early_data_size: u32,
     /// Timestamp (ms since epoch) when the ticket was received.
     received_at_ms: u64,
+    /// TLS 1.3 cipher suite under which this ticket was issued (RFC 8446
+    /// §4.6.1 / §4.2.11.1).  A PSK is bound to a single cipher suite —
+    /// resumption attempts that select a different cipher suite MUST be
+    /// rejected, and 0-RTT keys MUST be derived with the same hash + AEAD.
+    /// Defaults to TLS_AES_128_GCM_SHA256 (0x1301) for backward compatibility
+    /// with tickets serialised before this field existed.
+    cipher_suite: u16 = 0x1301,
 
     /// Returns true if this ticket is still within its lifetime.
     pub fn isValid(self: *const SessionTicket, now_ms: u64) bool {
@@ -96,9 +103,10 @@ pub const SessionTicket = struct {
     ///   [resumption_secret_len]u8
     ///   u32 max_early_data_size
     ///   u64 received_at_ms
+    ///   u16 cipher_suite          (added; older deserialise() defaults to AES-128-GCM-SHA256)
     pub fn serialise(self: *const SessionTicket, buf: []u8) error{BufferTooSmall}!usize {
         const needed = 4 + 1 + self.nonce_len + 2 + self.ticket_len +
-            1 + self.resumption_secret_len + 4 + 8;
+            1 + self.resumption_secret_len + 4 + 8 + 2;
         if (buf.len < needed) return error.BufferTooSmall;
         var pos: usize = 0;
         std.mem.writeInt(u32, buf[pos..][0..4], self.lifetime_s, .big);
@@ -119,10 +127,15 @@ pub const SessionTicket = struct {
         pos += 4;
         std.mem.writeInt(u64, buf[pos..][0..8], self.received_at_ms, .big);
         pos += 8;
+        std.mem.writeInt(u16, buf[pos..][0..2], self.cipher_suite, .big);
+        pos += 2;
         return pos;
     }
 
     /// Deserialise from the wire format produced by `serialise`.
+    /// Tickets serialised before the `cipher_suite` field was added omit the
+    /// trailing two bytes; they default to TLS_AES_128_GCM_SHA256 (the only
+    /// cipher whose 0-RTT keys this implementation currently derives).
     pub fn deserialise(buf: []const u8) error{ BufferTooShort, DataTooLong }!SessionTicket {
         if (buf.len < 4 + 1 + 2 + 1 + 4 + 8) return error.BufferTooShort;
         var pos: usize = 0;
@@ -155,6 +168,14 @@ pub const SessionTicket = struct {
         const max_early = std.mem.readInt(u32, buf[pos..][0..4], .big);
         pos += 4;
         const received_at = std.mem.readInt(u64, buf[pos..][0..8], .big);
+        pos += 8;
+        // Optional cipher_suite tail.  Pre-field tickets terminate here and
+        // default to AES-128-GCM-SHA256 (the only suite whose 0-RTT keys we
+        // can derive today).
+        const cs: u16 = if (pos + 2 <= buf.len)
+            std.mem.readInt(u16, buf[pos..][0..2], .big)
+        else
+            0x1301; // TLS_AES_128_GCM_SHA256
         return SessionTicket{
             .lifetime_s = lifetime_s,
             .nonce = nonce,
@@ -165,6 +186,7 @@ pub const SessionTicket = struct {
             .resumption_secret_len = rsl,
             .max_early_data_size = max_early,
             .received_at_ms = received_at,
+            .cipher_suite = cs,
         };
     }
 };
@@ -210,6 +232,17 @@ pub const TicketStore = struct {
 // ---------------------------------------------------------------------------
 
 /// 0-RTT key material derived from a PSK.
+///
+/// **Only TLS_AES_128_GCM_SHA256 is supported today.** The field sizes are
+/// fixed to AES-128 dimensions (16-byte key, 16-byte HP key, 12-byte IV) and
+/// the derivation uses SHA-256.  Per RFC 9001 §5.6 / RFC 8446 §4.6.1 a PSK
+/// is bound to a single cipher suite, and the early traffic secret MUST be
+/// derived with that cipher suite's hash.  To support AES-256-GCM-SHA384 or
+/// ChaCha20-Poly1305-SHA256 0-RTT we would need:
+///   - 32-byte `key` / `hp` slots (a tagged union, or a parallel struct);
+///   - SHA-384 HKDF for AES-256 (and SHA-384-sized zeros in `Extract`).
+/// Callers must verify the ticket's `cipher_suite` is 0x1301 before invoking
+/// `deriveEarlyKeysFromSecret`.
 pub const EarlyDataKeys = struct {
     /// Write key (client → server for 0-RTT).
     key: [16]u8,
@@ -234,6 +267,12 @@ pub fn deriveEarlyTrafficSecret(psk: [32]u8, ch_hash: [32]u8) [32]u8 {
 }
 
 /// Derive QUIC 0-RTT keys from the client_early_traffic_secret.
+///
+/// **AES-128-GCM-SHA256 only.** See `EarlyDataKeys` for the rationale and
+/// what would need to change to support AES-256 or ChaCha20.  Callers MUST
+/// have verified the ticket's negotiated cipher suite is 0x1301 before
+/// reaching this function; mis-derived keys are silently wrong on the wire
+/// and the peer will reject them with an AEAD tag failure.
 pub fn deriveEarlyKeysFromSecret(early_traffic_secret: [32]u8) EarlyDataKeys {
     var key: [16]u8 = undefined;
     var iv: [12]u8 = undefined;
@@ -337,6 +376,7 @@ test "session: ticket serialise/deserialise round-trip" {
         .resumption_secret_len = 32,
         .max_early_data_size = 16384,
         .received_at_ms = 1_700_000_000_000,
+        .cipher_suite = 0x1303, // TLS_CHACHA20_POLY1305_SHA256
     };
 
     var buf: [2048]u8 = undefined;
@@ -350,6 +390,35 @@ test "session: ticket serialise/deserialise round-trip" {
     try testing.expectEqualSlices(u8, ticket.ticket[0..ticket.ticket_len], restored.ticket[0..restored.ticket_len]);
     try testing.expectEqual(ticket.max_early_data_size, restored.max_early_data_size);
     try testing.expectEqual(ticket.received_at_ms, restored.received_at_ms);
+    try testing.expectEqual(ticket.cipher_suite, restored.cipher_suite);
+}
+
+test "session: deserialise of pre-cipher_suite ticket defaults to AES-128-GCM" {
+    const testing = std.testing;
+    // Build a ticket serialisation that omits the trailing cipher_suite
+    // field, mirroring the on-disk format from before the field was added.
+    var buf: [256]u8 = undefined;
+    var pos: usize = 0;
+    std.mem.writeInt(u32, buf[pos..][0..4], 3600, .big);
+    pos += 4;
+    buf[pos] = 0; // nonce_len
+    pos += 1;
+    std.mem.writeInt(u16, buf[pos..][0..2], 4, .big); // ticket_len
+    pos += 2;
+    @memcpy(buf[pos .. pos + 4], "tckt");
+    pos += 4;
+    buf[pos] = 0; // resumption_secret_len
+    pos += 1;
+    std.mem.writeInt(u32, buf[pos..][0..4], 16384, .big); // max_early_data_size
+    pos += 4;
+    std.mem.writeInt(u64, buf[pos..][0..8], 1_700_000_000_000, .big); // received_at
+    pos += 8;
+    // NB: no cipher_suite tail.
+
+    const restored = try SessionTicket.deserialise(buf[0..pos]);
+    try testing.expectEqual(@as(u16, 0x1301), restored.cipher_suite);
+    try testing.expectEqual(@as(usize, 4), restored.ticket_len);
+    try testing.expectEqualSlices(u8, "tckt", restored.ticket[0..restored.ticket_len]);
 }
 
 test "session: ticket validity" {

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -5223,6 +5223,13 @@ pub const Client = struct {
     migrate_done: bool = false,
     /// 0-RTT early data keys (null until a PSK+early_data ClientHello is built).
     early_km: ?KeyMaterial = null,
+    /// Cipher suite negotiated for 0-RTT packet protection (RFC 8446 §4.6.1).
+    /// Captured from the resumption ticket when early keys are derived so the
+    /// 0-RTT send path uses the correct AEAD even though `self.tls.cipher_suite`
+    /// still holds its pre-ServerHello default at the time 0-RTT goes out.
+    /// Defaults to TLS_AES_128_GCM_SHA256 (the only suite our 0-RTT key
+    /// derivation supports today).
+    early_cipher_suite: u16 = 0x1301,
     /// Packet number space for 0-RTT packets (separate from 1-RTT PN space).
     zerortt_pn: u64 = 0,
 
@@ -5818,6 +5825,7 @@ pub const Client = struct {
         self.client_hs_tail_len = 0;
         // Clear 0-RTT state so the new connection starts fresh.
         self.early_km = null;
+        self.early_cipher_suite = tls_hs.TLS_AES_128_GCM_SHA256;
         self.zerortt_pn = 0;
     }
 
@@ -6015,8 +6023,21 @@ pub const Client = struct {
             // Choose ClientHello variant based on flags.
             const now_ms: u64 = @intCast(compat.milliTimestamp());
             const len = if (self.config.early_data) ed_blk: {
-                // 0-RTT: PSK + early_data extension
-                if (self.ticket_store.get(now_ms)) |ticket| {
+                // 0-RTT: PSK + early_data extension.
+                //
+                // PSK-cipher binding (RFC 8446 §4.6.1): a PSK is bound to a
+                // single cipher suite; resumption that selects a different
+                // cipher MUST be rejected.  Our 0-RTT key derivation today
+                // only supports TLS_AES_128_GCM_SHA256 (16-byte key, SHA-256
+                // HKDF — see `session.EarlyDataKeys`).  Tickets issued under
+                // any other suite cannot be used as 0-RTT; fall through to
+                // 1-RTT resumption instead of silently sending packets the
+                // server can't decrypt.
+                if (self.ticket_store.get(now_ms)) |ticket| ed_inner: {
+                    if (ticket.cipher_suite != tls_hs.TLS_AES_128_GCM_SHA256) {
+                        dbg("io: 0-RTT skipped — ticket cipher 0x{x:0>4} not supported (only AES-128-GCM-SHA256 today)\n", .{ticket.cipher_suite});
+                        break :ed_inner;
+                    }
                     var psk_bytes: [32]u8 = .{0} ** 32;
                     @memcpy(&psk_bytes, ticket.resumption_secret[0..@min(ticket.resumption_secret_len, 32)]);
                     const psk_info = tls_hs.PskInfo{
@@ -6024,7 +6045,7 @@ pub const Client = struct {
                         .obfuscated_age = ticket.ageMs(now_ms),
                         .psk = psk_bytes,
                     };
-                    dbg("io: client building ClientHello with PSK + early_data (ticket_len={})\n", .{ticket.ticket_len});
+                    dbg("io: client building ClientHello with PSK + early_data (ticket_len={} cipher=0x{x:0>4})\n", .{ ticket.ticket_len, ticket.cipher_suite });
                     const result = try self.tls.buildClientHelloMsgWithPskAndEarlyData(
                         &self.client_hello_bytes,
                         quic_tp,
@@ -6047,15 +6068,19 @@ pub const Client = struct {
                     };
                     ekm.initCachedContexts();
                     self.early_km = ekm;
+                    // Remember the ticket's cipher so the 0-RTT send path
+                    // protects each packet under the correct AEAD instead of
+                    // whatever cipher `self.tls.cipher_suite` happens to
+                    // default to before ServerHello arrives.
+                    self.early_cipher_suite = ticket.cipher_suite;
                     dbg("io: client derived 0-RTT early keys\n", .{});
                     break :ed_blk result.n;
-                } else {
-                    dbg("io: early_data enabled but no valid ticket — full handshake\n", .{});
-                    break :ed_blk if (self.config.chacha20)
-                        try self.tls.buildClientHelloMsgChaCha20(&self.client_hello_bytes, quic_tp, alpn, self.config.host)
-                    else
-                        try self.tls.buildClientHelloMsg(&self.client_hello_bytes, quic_tp, alpn, self.config.host);
                 }
+                dbg("io: early_data enabled but no valid 0-RTT ticket — full handshake\n", .{});
+                break :ed_blk if (self.config.chacha20)
+                    try self.tls.buildClientHelloMsgChaCha20(&self.client_hello_bytes, quic_tp, alpn, self.config.host)
+                else
+                    try self.tls.buildClientHelloMsg(&self.client_hello_bytes, quic_tp, alpn, self.config.host);
             } else if (self.config.resumption) psk_blk: {
                 // 1-RTT resumption: PSK only, no early_data extension
                 if (self.ticket_store.get(now_ms)) |ticket| {
@@ -6213,7 +6238,7 @@ pub const Client = struct {
                 self.zerortt_pn,
                 &km,
                 self.conn.quicVersion(),
-                packetCipherFromTls(self.tls.cipher_suite),
+                packetCipherFromTls(self.early_cipher_suite),
             ) catch continue;
             self.zerortt_pn += 1;
             _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &server.any, server.getOsSockLen()) catch {};
@@ -7032,9 +7057,14 @@ pub const Client = struct {
             .resumption_secret_len = @intCast(rs_len),
             .max_early_data_size = 16384,
             .received_at_ms = @intCast(compat.milliTimestamp()),
+            // Bind the PSK to the cipher suite negotiated by the handshake
+            // that produced this ticket (RFC 8446 §4.6.1).  Resumption
+            // attempts under a different cipher MUST be rejected, and 0-RTT
+            // keys MUST be derived with this suite's hash + AEAD.
+            .cipher_suite = self.tls.cipher_suite,
         };
         self.ticket_store.store(ticket);
-        dbg("io: stored session ticket (lifetime={}s)\n", .{lifetime_s});
+        dbg("io: stored session ticket (lifetime={}s cipher=0x{x:0>4})\n", .{ lifetime_s, self.tls.cipher_suite });
     }
 
     /// Respond to a server-sent PATH_CHALLENGE with a matching PATH_RESPONSE.


### PR DESCRIPTION
## Summary

Second of the remaining #138 follow-ups (the first being RFC 9002
loss-detection completeness, merged as #154). PR #136 made the
Handshake encryption path cipher-aware; this PR audits the 0-RTT
send path and tightens it against silent AEAD mismatches.

## Findings

- \`SessionTicket\` did not record the cipher suite the ticket was
  issued under, so PSK ↔ AEAD binding (RFC 8446 §4.6.1) was lost
  once the ticket round-tripped through the store.
- \`EarlyDataKeys\` is hard-coded to AES-128-GCM-SHA256 dimensions
  (16-byte key, 16-byte HP key, SHA-256 HKDF). Tickets issued under
  any other suite still derived 16-byte keys with SHA-256 and the
  client would silently send 0-RTT under the wrong AEAD.
- The 0-RTT send path threaded \`self.tls.cipher_suite\` into
  \`build0RttPacket\` — but at the moment 0-RTT goes out (before
  ServerHello arrives) that field still holds its pre-handshake
  default of TLS_AES_128_GCM_SHA256. It coincidentally matched
  today because of the hard-coded key derivation; it was wrong on
  the contract level.

## Changes

- \`SessionTicket\` gains a \`cipher_suite: u16\` field, serialised as
  a backward-compatible trailing u16. \`deserialise\` of pre-field
  blobs defaults to TLS_AES_128_GCM_SHA256.
- Client populates \`cipher_suite\` from \`self.tls.cipher_suite\` when
  storing a received NewSessionTicket.
- 0-RTT send path refuses early data when the ticket cipher is not
  TLS_AES_128_GCM_SHA256 (the only suite our early-key derivation
  supports today) and falls through to 1-RTT resumption with a
  clear log line.
- \`Client\` gains \`early_cipher_suite\`, captured from the ticket at
  key-derivation time and threaded into the
  \`packetCipherFromTls(...)\` call inside \`send0RttRequests\`.
- \`EarlyDataKeys\` and \`deriveEarlyKeysFromSecret\` carry explicit
  AES-128-only docs naming what would need to change for AES-256
  or ChaCha20 support (RFC 9001 §5.6).

## Test plan

- [x] \`zig fmt --check .\` clean
- [x] \`zig build test --summary all\` → **189/189 pass** (+1 new:
  pre-field ticket deserialise defaults to AES-128).
- [x] \`zig build\` and \`zig build examples\` succeed.
- [ ] Interop runs to follow once merged.

## Out of scope / explicit follow-ups

Wider 0-RTT cipher support (AES-256-GCM-SHA384, ChaCha20-Poly1305)
would need a tagged \`EarlyDataKeys\` union with 32-byte key slots
and SHA-384 HKDF for the AES-256 case. Called out in the new docs
on \`EarlyDataKeys\` / \`deriveEarlyKeysFromSecret\`.

Refs #138.