### PR TITLE
crypto/initial,transport/io: cipher-aware 1-RTT receive + AES-256 HP fix (refs #138)

### DIFF
--- a/src/crypto/initial.zig
+++ b/src/crypto/initial.zig
@@ -135,8 +135,25 @@ pub fn protectLongHeaderPacket(
     const pn_bytes_slice = dst[pn_start .. pn_start + actual_pn_len];
     const first_byte_mask: u8 = if (header[0] & 0x80 != 0) 0x0f else 0x1f;
     switch (cipher) {
-        .aes128_gcm, .aes256_gcm => {
+        // AES-128 HP: cached 16-byte AES context (built from `km.hp` at
+        // `initCachedContexts` time).
+        .aes128_gcm => {
             const mask = km.hp_ctx.hpMask(sample);
+            dst[0] ^= mask[0] & first_byte_mask;
+            for (pn_bytes_slice, 0..) |*b, mi| {
+                b.* ^= mask[1 + mi];
+            }
+        },
+        // AES-256 HP: RFC 9001 §5.4.3 — "Header protection has the same
+        // key length as the packet protection key."  Must use AES-256 over
+        // `km.hp32` (32 bytes), not the 16-byte cached AES-128 context.
+        // Prior to this fix, AES-256-negotiated connections silently
+        // applied HP under AES-128 with the truncated key — a wire-level
+        // bug that would fail to interop with any spec-compliant peer.
+        .aes256_gcm => {
+            const ctx = std.crypto.core.aes.Aes256.initEnc(km.hp32);
+            var mask: [16]u8 = undefined;
+            ctx.encrypt(&mask, &sample);
             dst[0] ^= mask[0] & first_byte_mask;
             for (pn_bytes_slice, 0..) |*b, mi| {
                 b.* ^= mask[1 + mi];
@@ -198,21 +215,31 @@ pub fn unprotectLongHeaderPacket(
     var sample: [hp_sample_len]u8 = undefined;
     @memcpy(&sample, buf[sample_start .. sample_start + hp_sample_len]);
 
-    // Compute HP mask and unmask first byte to discover PN length.
-    const first_byte_mask: u8 = if (buf[0] & 0x80 != 0) 0x0f else 0x1f;
-    const unmasked_first: u8 = switch (cipher) {
-        .aes128_gcm, .aes256_gcm => blk: {
-            const mask = km.hp_ctx.hpMask(sample);
-            break :blk buf[0] ^ (mask[0] & first_byte_mask);
+    // Compute the 16-byte HP mask once up front under the negotiated
+    // cipher (RFC 9001 §5.4).  Pre-fix, the AES-128 and AES-256 arms
+    // both used the 16-byte cached AES-128 context — see the matching
+    // §5.4.3 note in `protectLongHeaderPacket` for the wire-level bug.
+    const hp_mask: [16]u8 = switch (cipher) {
+        .aes128_gcm => km.hp_ctx.hpMask(sample),
+        .aes256_gcm => blk: {
+            const ctx = std.crypto.core.aes.Aes256.initEnc(km.hp32);
+            var m: [16]u8 = undefined;
+            ctx.encrypt(&m, &sample);
+            break :blk m;
         },
         .chacha20_poly1305 => blk: {
             const counter = std.mem.readInt(u32, sample[0..4], .little);
             const cc_nonce = sample[4..16].*;
             var full_mask: [64]u8 = undefined;
             std.crypto.stream.chacha.ChaCha20IETF.xor(&full_mask, &(.{0} ** 64), counter, km.hp32, cc_nonce);
-            break :blk buf[0] ^ (full_mask[0] & first_byte_mask);
+            var m: [16]u8 = undefined;
+            @memcpy(&m, full_mask[0..16]);
+            break :blk m;
         },
     };
+
+    const first_byte_mask: u8 = if (buf[0] & 0x80 != 0) 0x0f else 0x1f;
+    const unmasked_first: u8 = buf[0] ^ (hp_mask[0] & first_byte_mask);
     const actual_pn_len: usize = (unmasked_first & 0x03) + 1;
 
     const aad_end = pn_start + actual_pn_len;
@@ -220,24 +247,9 @@ pub fn unprotectLongHeaderPacket(
     if (aad_end > aad_buf.len or aad_end > buf.len) return error.BufferTooShort;
     @memcpy(aad_buf[0..aad_end], buf[0..aad_end]);
 
-    switch (cipher) {
-        .aes128_gcm, .aes256_gcm => {
-            const mask = km.hp_ctx.hpMask(sample);
-            aad_buf[0] ^= mask[0] & first_byte_mask;
-            for (aad_buf[pn_start..aad_end], 1..) |*b, mi| {
-                b.* ^= mask[mi];
-            }
-        },
-        .chacha20_poly1305 => {
-            const counter = std.mem.readInt(u32, sample[0..4], .little);
-            const cc_nonce = sample[4..16].*;
-            var full_mask: [64]u8 = undefined;
-            std.crypto.stream.chacha.ChaCha20IETF.xor(&full_mask, &(.{0} ** 64), counter, km.hp32, cc_nonce);
-            aad_buf[0] ^= full_mask[0] & first_byte_mask;
-            for (aad_buf[pn_start..aad_end], 1..) |*b, mi| {
-                b.* ^= full_mask[mi];
-            }
-        },
+    aad_buf[0] ^= hp_mask[0] & first_byte_mask;
+    for (aad_buf[pn_start..aad_end], 1..) |*b, mi| {
+        b.* ^= hp_mask[mi];
     }
 
     // Decode the truncated wire PN, then reconstruct the full PN per RFC 9000
@@ -388,6 +400,67 @@ test "initial: AES-256-GCM long-header round-trip" {
         null,
         .aes256_gcm,
     );
+    try testing.expectEqualSlices(u8, plaintext, decrypted[0..dec.pt_len]);
+}
+
+test "initial: AES-256 HP actually uses hp32 (regression for §5.4.3 violation)" {
+    // RFC 9001 §5.4.3: "Header protection has the same key length as the
+    // packet protection key."  Before this fix, both the AES-128 and
+    // AES-256 cipher arms in `protect/unprotectLongHeaderPacket` derived
+    // the HP mask via `km.hp_ctx.hpMask(sample)` — i.e. AES-128 over the
+    // 16-byte `km.hp` field — for both ciphers.  Round-trip tests didn't
+    // catch the divergence because both sides shared the broken impl.
+    //
+    // This test pins the wire format: under .aes256_gcm, the HP mask is
+    // computed as AES-256-ECB(km.hp32, sample) — the same primitive a
+    // spec-compliant peer would apply on decrypt.  We synthesize a
+    // KeyMaterial where `km.hp` (16 bytes) and `km.hp32[0..16]` differ,
+    // encrypt, then manually reproduce the AES-256 HP and verify the
+    // protected first byte matches.
+
+    const testing = std.testing;
+    var km: KeyMaterial = .{ .secret = [_]u8{0x55} ** 32 };
+    km.expand();
+    // Deliberately desync hp vs hp32 so the buggy AES-128(hp) path would
+    // produce a different mask than the correct AES-256(hp32) path.
+    km.hp = [_]u8{0xCC} ** 16;
+    @memset(&km.hp32, 0xAA);
+    km.initCachedContexts();
+
+    const header = [_]u8{ 0xe0, 0x00, 0x00, 0x00, 0x01, 0x08, 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08, 0x00, 0x40, 0x10 };
+    const plaintext = "aes256 hp test payload";
+
+    var dst: [512]u8 = undefined;
+    const written = try protectLongHeaderPacket(&dst, &header, 0, 0, plaintext, &km, .aes256_gcm);
+
+    // Reproduce the §5.4.2 HP sample: 4 bytes past the start of the PN,
+    // 16 bytes long.  pn_start = header.len (we passed pn_len_wire = 0,
+    // i.e. 1-byte PN).
+    const pn_start: usize = header.len;
+    const sample_start = pn_start + hp_sample_offset;
+    var sample: [hp_sample_len]u8 = undefined;
+    @memcpy(&sample, dst[sample_start .. sample_start + hp_sample_len]);
+
+    // Expected mask under AES-256-ECB(km.hp32, sample).
+    var expected_mask: [16]u8 = undefined;
+    const ctx = std.crypto.core.aes.Aes256.initEnc(km.hp32);
+    ctx.encrypt(&expected_mask, &sample);
+
+    // Long header → low-nibble mask (0x0f).  The protected first byte must
+    // equal the plain first byte XOR'd with the AES-256 mask byte.
+    const expected_first = header[0] ^ (expected_mask[0] & 0x0f);
+    try testing.expectEqual(expected_first, dst[0]);
+
+    // And it must NOT equal what the old (buggy) AES-128(km.hp) path
+    // would have produced — that's the regression we're locking in.
+    const wrong_mask = km.hp_ctx.hpMask(sample);
+    const wrong_first = header[0] ^ (wrong_mask[0] & 0x0f);
+    try testing.expect(dst[0] != wrong_first);
+
+    // And round-trip still works (asymmetric correctness implied by the
+    // oracle check above, but a positive end-to-end signal is cheap).
+    var decrypted: [128]u8 = undefined;
+    const dec = try unprotectLongHeaderPacket(&decrypted, dst[0..written], pn_start, written, &km, null, .aes256_gcm);
     try testing.expectEqualSlices(u8, plaintext, decrypted[0..dec.pt_len]);
 }
 

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -510,106 +510,97 @@ pub fn build1RttPacketFull(
     return initial_mod.protectLongHeaderPacket(out, hdr_buf[0..hp], pn, 0, payload, km, cipher);
 }
 
-/// Decrypt a 1-RTT packet, selecting AES or ChaCha20 based on the cipher flag.
-/// Decrypt a 1-RTT packet with proper packet number decompression
-/// expected_recv_pn: the last received packet number in this packet number space (null if first packet)
-/// Returns both plaintext length and the decompressed packet number.
+/// Decrypt a 1-RTT short-header packet with full packet-number
+/// reconstruction (RFC 9000 §17.1) under the connection's negotiated AEAD
+/// (RFC 9001 §5.1, §5.3).  `cipher` selects across the full §5.3 matrix:
+///
+///   - `.aes128_gcm`        → AES-128-GCM + AES-128-ECB header protection
+///   - `.aes256_gcm`        → AES-256-GCM + AES-256-ECB header protection
+///   - `.chacha20_poly1305` → ChaCha20-Poly1305 + ChaCha20-based HP
+///
+/// Forwards to `unprotectLongHeaderPacket`, which already handles all three
+/// suites and keys off the header high bit to pick the long/short HP
+/// first-byte mask — correct for short headers despite the name.  Prior to
+/// this change the function took a `chacha20: bool` and ran the AES branch
+/// (hard-coded AES-128) for anything not flagged ChaCha20, so an AES-256
+/// connection silently decrypted 1-RTT under AES-128 keys (the inbound
+/// twin of the bug #157 closed on the send side).
+///
+/// `expected_recv_pn` is the largest packet number previously received in
+/// the application packet-number space, or `null` for the very first
+/// packet.  Used to disambiguate the truncated wire PN.
 fn unprotect1RttPacketWithPnTracking(
     dst: []u8,
     buf: []const u8,
     pn_start: usize,
     km: *const KeyMaterial,
-    chacha20: bool,
+    cipher: PacketCipher,
     expected_recv_pn: ?u64,
 ) !struct { pt_len: usize, pn: u64 } {
-    // Compute HP mask once — reused for both first-byte and PN field unmasking.
-    const mask = computeHpMask(buf, pn_start, km, chacha20) orelse return error.BufferTooShort;
-    const first_byte_mask: u8 = 0x1f; // short header: protect low 5 bits
-
-    // Unmask first byte to discover actual PN length (1–4 bytes).
-    const actual_pn_len: usize = ((buf[0] ^ (mask[0] & first_byte_mask)) & 0x03) + 1;
-    const aad_end = pn_start + actual_pn_len;
-
-    // Build a small mutable AAD buffer containing only the header bytes that
-    // need unmasking.  Maximum size: 1 (first byte) + 20 (max DCID) + 4 (max PN) = 25.
-    // This replaces the previous 1600-byte full-packet copy.
-    var aad_buf: [32]u8 = undefined;
-    if (aad_end > aad_buf.len or aad_end > buf.len) return error.BufferTooShort;
-    @memcpy(aad_buf[0..aad_end], buf[0..aad_end]);
-
-    // Remove header protection from the local copy.
-    aad_buf[0] ^= mask[0] & first_byte_mask;
-    for (aad_buf[pn_start..aad_end], 1..) |*b, i| {
-        b.* ^= mask[i];
-    }
-
-    // Decode truncated packet number from the unmasked bytes.
-    var truncated_pn: u64 = 0;
-    for (aad_buf[pn_start..aad_end]) |b| {
-        truncated_pn = (truncated_pn << 8) | b;
-    }
-
-    // Decompress full packet number relative to the last received PN.
-    const pn_len_bits: u3 = @intCast(actual_pn_len - 1);
-    const pn = initial_mod.decompressPacketNumber(truncated_pn, expected_recv_pn, pn_len_bits);
-
-    // Decrypt: ciphertext is read directly from the receive buffer — no copy.
-    const nonce = aead_mod.buildNonce(km.iv, pn);
-    const ciphertext = buf[aad_end..];
-    if (ciphertext.len < 16) return error.BufferTooShort;
-    const plaintext_len = ciphertext.len - 16;
-    if (dst.len < plaintext_len) return error.BufferTooSmall;
-
-    const aad = aad_buf[0..aad_end];
-    if (chacha20) {
-        try aead_mod.decryptChaCha20Poly1305(dst[0..plaintext_len], ciphertext, aad, km.key32, nonce);
-    } else {
-        try km.aes_ctx.decrypt(dst[0..plaintext_len], ciphertext, aad, nonce);
-    }
-    return .{ .pt_len = plaintext_len, .pn = pn };
+    const r = try initial_mod.unprotectLongHeaderPacket(
+        dst,
+        buf,
+        pn_start,
+        buf.len,
+        km,
+        expected_recv_pn,
+        cipher,
+    );
+    return .{ .pt_len = r.pt_len, .pn = r.pn };
 }
 
+/// Decrypt a 1-RTT packet without expected-PN tracking.  Thin wrapper used
+/// by tests and raw decode helpers; production receive paths must use
+/// `unprotect1RttPacketWithPnTracking` so the truncated wire PN is
+/// reconstructed against the largest previously received PN.
 pub fn unprotect1RttPacket(
     dst: []u8,
     buf: []const u8,
     pn_start: usize,
     km: *const KeyMaterial,
-    chacha20: bool,
+    cipher: PacketCipher,
 ) !usize {
-    if (chacha20) {
-        return initial_mod.unprotectPacketChaCha20(dst, buf, pn_start, buf.len, km);
-    }
-    // No expected-PN tracking on this thin wrapper (test/helper path).
-    const r = try initial_mod.unprotectInitialPacket(dst, buf, pn_start, buf.len, km, null);
+    const r = try initial_mod.unprotectLongHeaderPacket(dst, buf, pn_start, buf.len, km, null, cipher);
     return r.pt_len;
 }
 
-/// Compute the 16-byte header-protection mask for a 1-RTT short-header packet.
-/// Encapsulates the AES-128 / ChaCha20 choice so callers only call this once.
-/// Returns null when `buf` is too short to contain the HP sample.
-fn computeHpMask(buf: []const u8, pn_start: usize, km: *const KeyMaterial, chacha20: bool) ?[16]u8 {
+/// Compute the 16-byte header-protection mask for a 1-RTT short-header
+/// packet under the negotiated AEAD (RFC 9001 §5.4).  Returns null when
+/// `buf` is too short to contain the HP sample.
+fn computeHpMask(buf: []const u8, pn_start: usize, km: *const KeyMaterial, cipher: PacketCipher) ?[16]u8 {
     const sample_start = pn_start + initial_mod.hp_sample_offset;
     if (buf.len < sample_start + initial_mod.hp_sample_len) return null;
     var sample: [initial_mod.hp_sample_len]u8 = undefined;
     @memcpy(&sample, buf[sample_start .. sample_start + initial_mod.hp_sample_len]);
     var mask: [16]u8 = undefined;
-    if (chacha20) {
-        const counter = std.mem.readInt(u32, sample[0..4], .little);
-        const cc_nonce = sample[4..16].*;
-        var full_mask: [64]u8 = undefined;
-        std.crypto.stream.chacha.ChaCha20IETF.xor(&full_mask, &(.{0} ** 64), counter, km.hp32, cc_nonce);
-        @memcpy(&mask, full_mask[0..16]);
-    } else {
-        mask = km.hp_ctx.hpMask(sample);
+    switch (cipher) {
+        // The cached AES context is keyed from `km.hp` (16 bytes) at
+        // `initCachedContexts` time, so it's correct for AES-128.  For
+        // AES-256 we run a one-shot AES-256-ECB block over the sample
+        // using `km.hp32` (32 bytes) — `tls_hs.deriveQuicKeys` populates
+        // both slots unconditionally so the 32-byte key is always present.
+        .aes128_gcm => mask = km.hp_ctx.hpMask(sample),
+        .aes256_gcm => {
+            var cipher_ctx = std.crypto.core.aes.Aes256.initEnc(km.hp32);
+            cipher_ctx.encrypt(&mask, &sample);
+        },
+        .chacha20_poly1305 => {
+            const counter = std.mem.readInt(u32, sample[0..4], .little);
+            const cc_nonce = sample[4..16].*;
+            var full_mask: [64]u8 = undefined;
+            std.crypto.stream.chacha.ChaCha20IETF.xor(&full_mask, &(.{0} ** 64), counter, km.hp32, cc_nonce);
+            @memcpy(&mask, full_mask[0..16]);
+        },
     }
     return mask;
 }
 
-/// Return the unprotected first byte of a 1-RTT short-header packet.
-/// Removes AES-128 header protection to reveal the Key Phase bit (0x04).
-/// Returns null if the packet is too short to sample.
-fn peekUnprotectedFirstByte(buf: []const u8, pn_start: usize, km: *const KeyMaterial, chacha20: bool) ?u8 {
-    const mask = computeHpMask(buf, pn_start, km, chacha20) orelse return null;
+/// Return the unprotected first byte of a 1-RTT short-header packet under
+/// the negotiated AEAD's header-protection scheme.  Used to read the Key
+/// Phase bit (0x04) before committing to a full decrypt.  Returns null if
+/// the packet is too short to sample.
+fn peekUnprotectedFirstByte(buf: []const u8, pn_start: usize, km: *const KeyMaterial, cipher: PacketCipher) ?u8 {
+    const mask = computeHpMask(buf, pn_start, km, cipher) orelse return null;
     return buf[0] ^ (mask[0] & 0x1f); // short header: mask the low 5 bits
 }
 
@@ -1263,9 +1254,12 @@ pub const ConnState = struct {
 
     // AEAD for Handshake / 0-RTT / 1-RTT (Initial always AES-128-GCM).
     packet_cipher: PacketCipher = .aes128_gcm,
-    // Cipher suite in use for 1-RTT packets (true = ChaCha20-Poly1305).
+    // Mirror of `packet_cipher == .chacha20_poly1305`.  Kept around for the
+    // remaining 1-RTT *send-side* callers (which still take `chacha20: bool`)
+    // and the debug log in `processLongHeaderPacket`.  Receive-side paths
+    // now read `packet_cipher` directly so the full §5.3 AEAD matrix
+    // (incl. AES-256) is honored on inbound packets.
     use_chacha20: bool = false,
-
     // QUIC version in use for this connection (true = QUIC v2 / RFC 9369).
     // Controls initial-secret derivation, long-header type bits, and Retry tag.
     use_v2: bool = false,
@@ -3200,7 +3194,7 @@ pub const Server = struct {
 
                 // Detect peer-initiated key update via the UNPROTECTED key phase bit.
                 // Must remove HP first before reading bit 2 (RFC 9001 §5.4.1).
-                const unprotected_first = peekUnprotectedFirstByte(buf, pn_start, &conn.app_client_km, conn.use_chacha20) orelse continue;
+                const unprotected_first = peekUnprotectedFirstByte(buf, pn_start, &conn.app_client_km, conn.packet_cipher) orelse continue;
                 const incoming_phase = (unprotected_first & 0x04) != 0;
 
                 // Try current recv keys first. Only use next key generation when the
@@ -3215,7 +3209,7 @@ pub const Server = struct {
                         buf,
                         pn_start,
                         &conn.app_client_km,
-                        conn.use_chacha20,
+                        conn.packet_cipher,
                         conn.app_recv_pn,
                     )) |r| {
                         srv_decrypted_pn = r.pn;
@@ -3228,7 +3222,7 @@ pub const Server = struct {
                             buf,
                             pn_start,
                             &nk,
-                            conn.use_chacha20,
+                            conn.packet_cipher,
                             conn.app_recv_pn,
                         )) |r| {
                             conn.app_client_km = nk;
@@ -6651,7 +6645,7 @@ pub const Client = struct {
         // Detect key phase flip from server using the UNPROTECTED header byte.
         // The Key Phase bit (0x04) is masked by header protection, so we must
         // remove HP first before reading it (RFC 9001 §5.4.1).
-        const unprotected_first = peekUnprotectedFirstByte(buf, pn_start, &self.conn.app_server_km, self.conn.use_chacha20) orelse {
+        const unprotected_first = peekUnprotectedFirstByte(buf, pn_start, &self.conn.app_server_km, self.conn.packet_cipher) orelse {
             if (buf.len == 834) {
                 dbg("io: client 834-byte packet FAILED peekUnprotectedFirstByte!\n", .{});
             }
@@ -6694,7 +6688,7 @@ pub const Client = struct {
             buf,
             pn_start,
             &self.conn.app_server_km,
-            self.conn.use_chacha20,
+            self.conn.packet_cipher,
             self.conn.app_recv_pn,
         ) catch |err| {
             if (buf.len == 834) {
@@ -8225,4 +8219,45 @@ test "build1RttPacketFull: cipher param actually selects the AEAD (regression fo
     try std.testing.expect(!std.mem.eql(u8, buf_aes128[0..n_aes128], buf_aes256[0..n_aes256]));
     try std.testing.expect(!std.mem.eql(u8, buf_aes128[0..n_aes128], buf_chacha[0..n_chacha]));
     try std.testing.expect(!std.mem.eql(u8, buf_aes256[0..n_aes256], buf_chacha[0..n_chacha]));
+}
+
+test "unprotect1RttPacketWithPnTracking: cipher param plumbed through (AES-256 round-trip)" {
+    // Pre-fix, the receive wrapper took `chacha20: bool` and routed AES-256
+    // connections through the AES-128 keying path — the inbound twin of the
+    // send-side bug closed by #157.  This test exercises the full §5.3
+    // matrix via a 1-RTT round-trip: build under each cipher, decrypt via
+    // the receive wrapper with the same cipher, assert plaintext recovery.
+
+    var km: KeyMaterial = .{};
+    km.secret = [_]u8{0xA5} ** 32;
+    km.expand();
+
+    const dcid = try ConnectionId.fromSlice(&[_]u8{ 0x01, 0x02, 0x03, 0x04 });
+    const plaintext = [_]u8{0x42} ** 32;
+    const pn: u64 = 7;
+
+    inline for (.{ initial_mod.PacketCipher.aes128_gcm, initial_mod.PacketCipher.aes256_gcm, initial_mod.PacketCipher.chacha20_poly1305 }) |cipher| {
+        var send_buf: [256]u8 = undefined;
+        const n = try initial_mod.protectLongHeaderPacket(
+            &send_buf,
+            blk: {
+                // Build the short header inline to mirror build1RttPacketFull.
+                var hdr: [64]u8 = undefined;
+                hdr[0] = 0x40;
+                @memcpy(hdr[1 .. 1 + dcid.len], dcid.slice());
+                break :blk hdr[0 .. 1 + dcid.len];
+            },
+            pn,
+            0, // pn_len wire = 0 → 1 byte
+            &plaintext,
+            &km,
+            cipher,
+        );
+
+        var recv_buf: [256]u8 = undefined;
+        const pn_start: usize = 1 + dcid.len;
+        const r = try unprotect1RttPacketWithPnTracking(&recv_buf, send_buf[0..n], pn_start, &km, cipher, null);
+        try std.testing.expectEqual(@as(u64, pn), r.pn);
+        try std.testing.expectEqualSlices(u8, &plaintext, recv_buf[0..r.pt_len]);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the **receive-side half** of the RFC 9001 §5.3 AEAD audit (#157 closed the send side) and fixes a related **§5.4.3 violation** on the header-protection key for AES-256.

The §5.4.3 fix is technically a pre-existing bug — both \`protectLongHeaderPacket\` and \`unprotectLongHeaderPacket\` were running AES-128(\`km.hp\`) for HP on both the AES-128 and AES-256 cipher arms. Round-trip tests passed because both sides shared the broken impl; the bug only manifests against a spec-compliant peer (interop). Since this PR is already touching the receive HP path it's the natural place to fix both sides.

## §5.4.3 header-protection fix

RFC 9001 §5.4.3: *\"Header protection has the same key length as the packet protection key.\"*

So AES-256 HP must run AES-256-ECB over the 32-byte \`km.hp32\`, not AES-128 over \`km.hp\`. Fixed in both \`protectLongHeaderPacket\` and \`unprotectLongHeaderPacket\`. Affects every caller — Handshake (#136), 0-RTT (#155), 1-RTT send (#157), and the new receive paths in this PR.

## 1-RTT receive cipher-aware

- Replace \`chacha20: bool\` with \`cipher: PacketCipher\` on \`unprotect1RttPacketWithPnTracking\`, \`unprotect1RttPacket\`, \`computeHpMask\`, \`peekUnprotectedFirstByte\`.
- Body of \`unprotect1RttPacketWithPnTracking\` now forwards to \`unprotectLongHeaderPacket\` (single source of truth for all three §5.3 ciphers; long/short header HP first-byte mask handled by the existing high-bit check).
- Update 5 receive-side call sites in \`io.zig\` to pass \`conn.packet_cipher\`.

## What's NOT in this PR

The 14 send-side call sites still pass \`conn.use_chacha20\` — they're owned by [#157](https://github.com/ch4r10t33r/zquic/pull/157). The \`use_chacha20\` field stays on \`ConnState\` for now (still needed by send-side and the key-update debug log) with a comment marking it transitional. A small cleanup to remove the field falls out naturally once #157 lands.

## Stacking note

This PR is independent of #157 and applies cleanly to current master (\`a2b97bc\`). After both merge, the only overlap is the \`use_chacha20\` field reference count dropping — no diff conflicts.

## Tests

- \`initial: AES-256 HP actually uses hp32 (regression for §5.4.3 violation)\` — **oracle test** that desyncs \`km.hp\` and \`km.hp32\`, encrypts under \`.aes256_gcm\`, reproduces the AES-256-ECB(\`km.hp32\`) mask externally, and asserts the protected first byte matches (and explicitly does NOT match what the old AES-128(\`km.hp\`) path would have produced).
- \`unprotect1RttPacketWithPnTracking: cipher param plumbed through (AES-256 round-trip)\` — end-to-end round-trip via the receive wrapper under all three §5.3 ciphers.

## Test plan

- [x] \`zig fmt --check .\`
- [x] \`zig build test\` — 194/194 pass (incl. 2 new regression tests)
- [x] \`zig build examples\` clean