### PR TITLE
transport/io,ci: P0 client CONNECTION_CLOSE, cross-impl CI, raw stream tests (refs #138)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,4 +328,6 @@ jobs:
               print(f"  CROSS FAILED: {len(cross_failed):2d}  {cross_failed}")
           print(f"  UNSUPPORTED : {len(unsupported):2d}  {unsupported}")
           print(f"{'='*55}\n")
+          if failed or cross_failed:
+              sys.exit(1)
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,9 +226,9 @@ jobs:
 
       # PR interop is split for runtime:
       #   1) zquic↔zquic — full suite (regression signal on every push/PR)
-      #   2) zquic↔quinn — handshake smoke only (catches #132-class cross-impl bugs
-      #      without ~1–2 h of 56 matrix cases).  Full cross-impl matrix runs in
-      #      .github/workflows/interop-cross-impl.yml (nightly + manual).
+      #   2) zquic↔quinn — P0 cross-impl subset (handshake + transfer +
+      #      multiplexing, both directions).  Full matrix runs nightly in
+      #      .github/workflows/interop-cross-impl.yml.
       - name: Run interop test suite
         run: |
           mkdir -p interop-results
@@ -245,18 +245,23 @@ jobs:
             --log-dir ../interop-results/logs-zquic \
             --json ../interop-results/results-zquic.json \
             --debug || zquic_failed=1
-          # Cross-impl smoke (quinn→zquic handshake); tracked separately until #132 is fully green.
+          # P0 cross-impl: libp2p-relevant cases in both directions (quinn↔zquic).
+          CROSS_P0="handshake,transfer,multiplexing"
           python3 run.py \
-            --client zquic,quinn \
+            --client quinn \
             --server zquic \
-            --test handshake \
-            --log-dir ../interop-results/logs-cross-handshake \
-            --json ../interop-results/results-cross-handshake.json \
+            --test "$CROSS_P0" \
+            --log-dir ../interop-results/logs-cross-quinn-zquic \
+            --json ../interop-results/results-cross-quinn-zquic.json \
             --debug || cross_failed=1
-          if [[ "$cross_failed" -ne 0 ]]; then
-            echo "::warning::quinn↔zquic cross-impl handshake failed (see results-cross-handshake.json); nightly interop-cross-impl.yml tracks full matrix"
-          fi
-          exit "$zquic_failed"
+          python3 run.py \
+            --client zquic \
+            --server quinn \
+            --test "$CROSS_P0" \
+            --log-dir ../interop-results/logs-cross-zquic-quinn \
+            --json ../interop-results/results-cross-zquic-quinn.json \
+            --debug || cross_failed=1
+          exit "$((zquic_failed | cross_failed))"
         # run.py exits with nr_failed (0 = all passed). Do NOT use continue-on-error
         # here — test failures must fail the job. The upload/summary steps below use
         # if: always() so they still run even when this step fails.
@@ -309,7 +314,7 @@ jobs:
                               passed.append(tag)
                           elif result in (None, "unsupported", "skipped"):
                               unsupported.append(tag)
-                          elif suite == "cross-handshake":
+                          elif suite.startswith("cross-"):
                               cross_failed.append(tag)
                           else:
                               failed.append(tag)
@@ -320,7 +325,7 @@ jobs:
           print(f"  PASSED      : {len(passed):2d}  {passed}")
           print(f"  FAILED      : {len(failed):2d}  {failed}")
           if cross_failed:
-              print(f"  CROSS (warn): {len(cross_failed):2d}  {cross_failed}")
+              print(f"  CROSS FAILED: {len(cross_failed):2d}  {cross_failed}")
           print(f"  UNSUPPORTED : {len(unsupported):2d}  {unsupported}")
           print(f"{'='*55}\n")
           EOF

--- a/docs/issue-138-roadmap.md
+++ b/docs/issue-138-roadmap.md
@@ -1,0 +1,81 @@
+# Issue #138 — zquic vs quinn parity roadmap
+
+Tracker for closing the gap between zquic and production-grade quinn usage
+(especially zeam / libp2p embedders). Updated after #150–#159.
+
+## Status snapshot
+
+| Area | State |
+|------|-------|
+| zquic↔zquic interop (13 tests) | **12–13/13** in PR CI |
+| zquic↔quinn cross-impl | **P0 subset** in PR CI (handshake, transfer, multiplexing, both directions); full matrix nightly |
+| Raw application streams | Implemented; unit tests for reassembly; embed via `feedPacket` + `processPendingWork` |
+| 0-RTT | AES-128 only; ChaCha20 / AES-256 resumption not wired |
+| Cipher-aware 1-RTT | Send + receive (#157, #158) |
+| Key update / CID / anti-amp | Cooldown, retirement, 3× rule (#159) |
+| Preferred address | **Receive + auto-migrate** (#156); **emit** not done |
+| DPLPMTUD | Not implemented |
+| DATAGRAM extension | Not implemented |
+| HTTP/3 push | Not implemented |
+| BBR | Not implemented |
+
+## P0 — zeam / libp2p blockers
+
+These must be green before relying on zquic as the libp2p QUIC transport.
+
+- [x] **Cross-impl CI (PR-gating)** — handshake + transfer + multiplexing,
+  quinn→zquic and zquic→quinn; failures fail the job (this PR).
+- [x] **Client CONNECTION_CLOSE** — mirror server `sendConnectionClose` on
+  protocol violations (STREAM_STATE_ERROR, CONNECTION_ID_LIMIT,
+  RETIRE_CONNECTION_ID seq 0) (this PR).
+- [x] **Raw stream reassembly tests** — out-of-order / overlap coverage for
+  `rawAppStreamReceiveFrame` (this PR).
+- [ ] **Cross-impl green on P0 matrix** — keep nightly full matrix tracking
+  regressions until PR subset is consistently green.
+- [ ] **Embedder validation in zeam** — end-to-end libp2p over zquic with
+  `raw_application_streams` on a multi-client devnet.
+
+## P1 — next after P0
+
+- [ ] **DPLPMTUD** (RFC 8899) — probe size, PLPMTU state, PMTUD black-hole recovery.
+- [ ] **Preferred address emit** — advertise TP 0x0d when server has a stable
+  preferred path (symmetric with #156 receive path).
+- [ ] **Automatic key update** — initiate on packet/time threshold (today:
+  peer-initiated + manual client trigger only).
+- [ ] **0-RTT non-AES-128** — derive early keys for ChaCha20 / AES-256 from
+  stored ticket cipher suite.
+- [ ] **ECN beyond 1-RTT** — ECT marking on Initial / Handshake sends; validate
+  against quinn interop ECN test.
+- [ ] **Wire `MigrationManager`** — centralize path validation, anti-amp, and
+  preferred-address policy instead of scattered checks in `io.zig`.
+
+## P2 — later
+
+- [ ] **DATAGRAM extension** (RFC 9221).
+- [ ] **HTTP/3 server push**.
+- [ ] **BBR** congestion control (today: NewReno only).
+- [ ] **General-purpose stream API** — first-class bidi/uni open/accept outside
+  HTTP-oriented `io.zig` paths.
+- [ ] **Remove `interop-run` `continue-on-error`** once cross-impl P0 is stable.
+
+## Recently merged (#150–#159)
+
+| PR | Topic |
+|----|-------|
+| 150 | Parse / apply peer transport params |
+| 151 | Per-stream FC + CID pool + §18.2 params |
+| 152 | Per-stream send-side MAX_STREAM_DATA |
+| 153 | Emit max_udp_payload_size + disable_active_migration |
+| 154 | RFC 9002 loss-detection completeness |
+| 155 | 0-RTT AEAD send-side audit |
+| 156 | Auto-migrate on preferred_address |
+| 157 | Cipher-aware 1-RTT send |
+| 158 | Cipher-aware 1-RTT receive + AES-256 HP fix |
+| 159 | Key-update cooldown, CID retirement, anti-amp enforcement |
+
+## CI layout
+
+| Workflow | Scope |
+|----------|-------|
+| `.github/workflows/ci.yml` | Unit tests + zquic↔zquic full suite + P0 cross-impl |
+| `.github/workflows/interop-cross-impl.yml` | Nightly full quinn↔zquic matrix (all tests, both roles) |

--- a/docs/issue-138-roadmap.md
+++ b/docs/issue-138-roadmap.md
@@ -9,7 +9,7 @@ Tracker for closing the gap between zquic and production-grade quinn usage
 |------|-------|
 | zquic↔zquic interop (13 tests) | **12–13/13** in PR CI |
 | zquic↔quinn cross-impl | **P0 subset** in PR CI (handshake, transfer, multiplexing, both directions); full matrix nightly |
-| Raw application streams | Implemented; unit tests for reassembly; embed via `feedPacket` + `processPendingWork` |
+| Raw application streams | Implemented in `raw_app_stream.zig`; unit tests for reassembly; embed via `feedPacket` + `processPendingWork` |
 | 0-RTT | AES-128 only; ChaCha20 / AES-256 resumption not wired |
 | Cipher-aware 1-RTT | Send + receive (#157, #158) |
 | Key update / CID / anti-amp | Cooldown, retirement, 3× rule (#159) |

--- a/src/root.zig
+++ b/src/root.zig
@@ -83,6 +83,7 @@ test {
     _ = @import("transport/flow_control.zig");
     _ = @import("transport/stream_manager.zig");
     _ = @import("transport/migration.zig");
+    _ = @import("transport/raw_app_stream.zig");
     _ = @import("transport/io.zig");
     _ = @import("transport/path_mtu.zig");
     _ = @import("http3/frame.zig");

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -40,6 +40,7 @@ const recovery = @import("../loss/recovery.zig");
 const build_options = @import("build_options");
 const batch_io = @import("batch_io.zig");
 const path_mtu_mod = @import("path_mtu.zig");
+const raw_app_stream = @import("raw_app_stream.zig");
 const default_conn_path_mtu = path_mtu_mod.initFromConfig(null);
 
 /// Compile-time-eliminated debug logger. With `-Dverbose=true` prints to stderr;
@@ -510,6 +511,17 @@ pub fn build1RttPacketFull(
     return initial_mod.protectLongHeaderPacket(out, hdr_buf[0..hp], pn, 0, payload, km, cipher);
 }
 
+/// Pad a 1-RTT payload to the minimum length required for header protection
+/// sampling (RFC 9001 §5.4.2).  Returns `payload` unchanged when already long
+/// enough; otherwise writes PADDING (0x00) into `pad_buf`.
+fn pad1RttPayload(payload: []const u8, pad_buf: []u8) []const u8 {
+    const min_len: usize = 3;
+    if (payload.len >= min_len) return payload;
+    @memcpy(pad_buf[0..payload.len], payload);
+    @memset(pad_buf[payload.len..min_len], 0x00);
+    return pad_buf[0..min_len];
+}
+
 /// Result of decrypting a 1-RTT packet with PN reconstruction.
 const Decrypt1RttResult = struct { pt_len: usize, pn: u64 };
 
@@ -821,83 +833,9 @@ const Http3OutSlot = struct {
     }
 };
 
-/// One out-of-order STREAM chunk waiting until `next_offset` reaches `off`.
-const RawAppPendingFrame = struct {
-    off: u64,
-    data: std.ArrayListUnmanaged(u8) = .empty,
-
-    fn deinit(self: *RawAppPendingFrame, allocator: std.mem.Allocator) void {
-        self.data.deinit(allocator);
-    }
-};
-
-/// Append stream bytes and splice any buffered gaps that become contiguous.
-fn rawAppStreamReceiveFrame(allocator: std.mem.Allocator, slot: *RawAppStreamSlot, o: u64, d: []const u8) std.mem.Allocator.Error!void {
-    const frame_end = o + @as(u64, @intCast(d.len));
-    if (frame_end <= slot.next_offset) return;
-
-    if (o > slot.next_offset) {
-        for (slot.out_of_order.items) |p| {
-            if (p.off == o) return;
-        }
-        var copy = std.ArrayListUnmanaged(u8).empty;
-        try copy.appendSlice(allocator, d);
-        try slot.out_of_order.append(allocator, .{ .off = o, .data = copy });
-        try rawAppStreamFlushPending(allocator, slot);
-        return;
-    }
-
-    const start: usize = @intCast(slot.next_offset - o);
-    try slot.buf.appendSlice(allocator, d[start..]);
-    slot.next_offset = frame_end;
-    try rawAppStreamFlushPending(allocator, slot);
-}
-
-/// Merge pending chunks whose start offset matches `next_offset` (may chain).
-fn rawAppStreamFlushPending(allocator: std.mem.Allocator, slot: *RawAppStreamSlot) std.mem.Allocator.Error!void {
-    while (true) {
-        var found: ?usize = null;
-        for (slot.out_of_order.items, 0..) |p, i| {
-            if (p.off == slot.next_offset) {
-                found = i;
-                break;
-            }
-        }
-        const idx = found orelse return;
-        var pending = slot.out_of_order.swapRemove(idx);
-        defer pending.deinit(allocator);
-        try slot.buf.appendSlice(allocator, pending.data.items);
-        slot.next_offset += @as(u64, @intCast(pending.data.items.len));
-    }
-}
-
 /// Receive buffer for one QUIC stream when `ServerConfig.raw_application_streams` /
 /// `ClientConfig.raw_application_streams` is enabled (opaque bytes, no HTTP parsing).
-pub const RawAppStreamSlot = struct {
-    active: bool = false,
-    stream_id: u64 = 0,
-    /// Next contiguous byte offset expected; bytes [0..next_offset) are in `buf`.
-    next_offset: u64 = 0,
-    buf: std.ArrayListUnmanaged(u8) = .empty,
-    /// STREAM frames that arrived ahead of `next_offset` (UDP reordering).
-    out_of_order: std.ArrayListUnmanaged(RawAppPendingFrame) = .empty,
-    /// True once a STREAM frame with FIN=true has been merged into `buf` —
-    /// i.e. the peer has finished sending on this stream.  Set by the
-    /// per-side `handleRawApplicationStream{Server,Client}` and inspected
-    /// by embedders (via `rawAppStreamFinReceived`) so they can call
-    /// `releaseRawAppStream` once they have consumed the payload, freeing
-    /// the slot for re-use under the libp2p per-message-stream pattern.
-    fin_received: bool = false,
-
-    pub fn deinit(self: *RawAppStreamSlot, allocator: std.mem.Allocator) void {
-        for (self.out_of_order.items) |*p| {
-            p.deinit(allocator);
-        }
-        self.out_of_order.deinit(allocator);
-        self.buf.deinit(allocator);
-        self.* = .{};
-    }
-};
+pub const RawAppStreamSlot = raw_app_stream.RawAppStreamSlot;
 
 /// Maximum number of HTTP/3 request streams that can be blocked waiting for
 /// QPACK dynamic table insertions (RFC 9204 §2.1.2).  We advertise this value
@@ -1697,6 +1635,55 @@ pub const ConnState = struct {
         }
     }
 };
+
+/// Serialize a transport-layer CONNECTION_CLOSE frame and mark the connection
+/// as having sent one.  Returns null when already sent.
+fn prepareTransportConnectionClose(
+    conn: *ConnState,
+    error_code: u64,
+    reason: []const u8,
+    out: []u8,
+) ?[]const u8 {
+    if (conn.conn_close_sent) return null;
+    conn.conn_close_sent = true;
+    const frame = transport_frames.ConnectionClose{
+        .is_application = false,
+        .error_code = error_code,
+        .frame_type = 0,
+        .reason_phrase = reason,
+    };
+    const len = frame.serialize(out) catch return null;
+    return out[0..len];
+}
+
+fn enterConnDraining(conn: *ConnState) void {
+    conn.draining = true;
+    const pto = conn.rtt.pto_ms(conn.peer_max_ack_delay_ms, 0);
+    conn.draining_deadline_ms = compat.milliTimestamp() + @as(i64, @intCast(3 * pto));
+}
+
+/// Send one client 1-RTT packet without checking `draining`.  Used for
+/// CONNECTION_CLOSE, which must go out before the draining flag is set.
+fn clientSend1RttImmediate(
+    sock: std.posix.socket_t,
+    conn: *ConnState,
+    payload: []const u8,
+) void {
+    var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+    var pad_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+    const effective_payload = pad1RttPayload(payload, &pad_buf);
+    const pkt_len = build1RttPacketFull(
+        &send_buf,
+        conn.remote_cid,
+        effective_payload,
+        conn.app_pn,
+        &conn.app_client_km,
+        conn.key_phase_bit,
+        conn.packet_cipher,
+    ) catch return;
+    conn.app_pn += 1;
+    _ = compat.sendto(sock, send_buf[0..pkt_len], 0, &conn.peer.any, conn.peer.getOsSockLen()) catch {};
+}
 
 // ── Server config ─────────────────────────────────────────────────────────────
 
@@ -4079,16 +4066,8 @@ pub const Server = struct {
         // CONNECTION_CLOSE copies are allowed, handled via sendConnectionClose).
         if (conn.draining) return;
         var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        // Header protection sampling (RFC 9001 §5.4.2) requires at least 3 bytes
-        // of plaintext (PN(1) + plaintext(n) + tag(16) >= pn_offset+4+16=pn_offset+20).
-        // Pad with PADDING frames (0x00) if needed.
         var padded_payload_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const min_len: usize = 3;
-        const effective_payload: []const u8 = if (payload.len < min_len) blk: {
-            @memcpy(padded_payload_buf[0..payload.len], payload);
-            @memset(padded_payload_buf[payload.len..min_len], 0x00);
-            break :blk padded_payload_buf[0..min_len];
-        } else payload;
+        const effective_payload = pad1RttPayload(payload, &padded_payload_buf);
 
         // Check if payload contains FIN frames (0x0b, 0x0d, or 0x0f type)
         var has_fin = false;
@@ -4368,23 +4347,12 @@ pub const Server = struct {
     /// draining state and MUST NOT send any further packets except for additional
     /// CONNECTION_CLOSE copies to handle packet loss.
     fn sendConnectionClose(self: *Server, conn: *ConnState, error_code: u64, reason: []const u8, dst: compat.Address) void {
-        if (conn.conn_close_sent) return;
-        conn.conn_close_sent = true;
-        const frame = transport_frames.ConnectionClose{
-            .is_application = false,
-            .error_code = error_code,
-            .frame_type = 0,
-            .reason_phrase = reason,
-        };
         var buf: [256]u8 = undefined;
-        const len = frame.serialize(&buf) catch return;
+        const payload = prepareTransportConnectionClose(conn, error_code, reason, &buf) orelse return;
         // Send before setting draining so send1Rtt does not suppress the frame.
-        self.send1Rtt(conn, buf[0..len], dst);
+        self.send1Rtt(conn, payload, dst);
         dbg("io: sent CONNECTION_CLOSE code={} reason=\"{s}\"\n", .{ error_code, reason });
-        conn.draining = true;
-        // RFC 9000 §10.2.2: stay in draining state for at least 3×PTO.
-        const pto = conn.rtt.pto_ms(conn.peer_max_ack_delay_ms, 0);
-        conn.draining_deadline_ms = compat.milliTimestamp() + @as(i64, @intCast(3 * pto));
+        enterConnDraining(conn);
     }
 
     /// Send a MAX_DATA frame to extend the peer's connection-level send window.
@@ -4583,7 +4551,7 @@ pub const Server = struct {
             return;
         };
 
-        rawAppStreamReceiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
+        raw_app_stream.receiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
         // RFC 9000 §3.2: STREAM frame with FIN signals the peer is done
         // sending on this stream.  Record it so the embedder knows it can
         // release the slot once it has consumed the payload (see
@@ -6945,6 +6913,9 @@ pub const Client = struct {
         self.conn.ecn_ect0_recv += 1;
         self.conn.last_recv_ms = compat.milliTimestamp();
 
+        // RFC 9000 §10.2.2: silently discard all frames while draining.
+        if (self.conn.draining) return;
+
         self.conn.peer_key_phase = incoming_phase;
 
         var pos: usize = 0;
@@ -7260,57 +7231,13 @@ pub const Client = struct {
         }
     }
 
-    /// Encrypt and send a 1-RTT packet from the client.
-    fn send1Rtt(self: *Client, payload: []const u8) void {
-        if (self.conn.draining) return;
-        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        var padded_payload_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const min_len: usize = 3;
-        const effective_payload: []const u8 = if (payload.len < min_len) blk: {
-            @memcpy(padded_payload_buf[0..payload.len], payload);
-            @memset(padded_payload_buf[payload.len..min_len], 0x00);
-            break :blk padded_payload_buf[0..min_len];
-        } else payload;
-        const pkt_len = build1RttPacketFull(
-            &send_buf,
-            self.conn.remote_cid,
-            effective_payload,
-            self.conn.app_pn,
-            &self.conn.app_client_km,
-            self.conn.key_phase_bit,
-            self.conn.packet_cipher,
-        ) catch return;
-        self.conn.app_pn += 1;
-        _ = compat.sendto(
-            self.sock,
-            send_buf[0..pkt_len],
-            0,
-            &self.conn.peer.any,
-            self.conn.peer.getOsSockLen(),
-        ) catch {};
-    }
-
     /// Send a CONNECTION_CLOSE frame (QUIC layer, type 0x1c) and enter draining.
-    /// RFC 9000 §10.2.3: after sending CONNECTION_CLOSE the endpoint enters the
-    /// draining state and MUST NOT send any further packets except for additional
-    /// CONNECTION_CLOSE copies to handle packet loss.
     fn sendConnectionClose(self: *Client, error_code: u64, reason: []const u8) void {
-        if (self.conn.conn_close_sent) return;
-        self.conn.conn_close_sent = true;
-        const frame = transport_frames.ConnectionClose{
-            .is_application = false,
-            .error_code = error_code,
-            .frame_type = 0,
-            .reason_phrase = reason,
-        };
         var buf: [256]u8 = undefined;
-        const len = frame.serialize(&buf) catch return;
-        // Send before setting draining so send1Rtt does not suppress the frame.
-        self.send1Rtt(buf[0..len]);
+        const payload = prepareTransportConnectionClose(&self.conn, error_code, reason, &buf) orelse return;
+        clientSend1RttImmediate(self.sock, &self.conn, payload);
         dbg("io: client sent CONNECTION_CLOSE code={} reason=\"{s}\"\n", .{ error_code, reason });
-        self.conn.draining = true;
-        const pto = self.conn.rtt.pto_ms(self.conn.peer_max_ack_delay_ms, 0);
-        self.conn.draining_deadline_ms = compat.milliTimestamp() + @as(i64, @intCast(3 * pto));
+        enterConnDraining(&self.conn);
     }
 
     /// Send a single cumulative ACK for the highest PN accumulated since the
@@ -7525,7 +7452,7 @@ pub const Client = struct {
             return;
         };
 
-        rawAppStreamReceiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
+        raw_app_stream.receiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
         // Mirror of the server side: track FIN so embedders can release the
         // slot once they have read the payload.
         if (sf.fin) slot.fin_received = true;
@@ -8652,56 +8579,4 @@ test "localCidCount: seq 0 plus pool entries" {
     const tok: [16]u8 = .{0} ** 16;
     _ = conn.cidPoolReserve(cid, tok);
     try std.testing.expectEqual(@as(u64, 2), conn.localCidCount());
-}
-
-test "rawAppStreamReceiveFrame: contiguous append and FIN offset" {
-    const allocator = std.testing.allocator;
-    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 4 };
-    defer slot.deinit(allocator);
-
-    try rawAppStreamReceiveFrame(allocator, &slot, 0, "hello");
-    try std.testing.expectEqualStrings("hello", slot.buf.items);
-    try std.testing.expectEqual(@as(u64, 5), slot.next_offset);
-
-    try rawAppStreamReceiveFrame(allocator, &slot, 5, "!");
-    try std.testing.expectEqualStrings("hello!", slot.buf.items);
-    try std.testing.expectEqual(@as(u64, 6), slot.next_offset);
-
-    // Duplicate / fully-overlapping retransmit is ignored.
-    try rawAppStreamReceiveFrame(allocator, &slot, 0, "hello!");
-    try std.testing.expectEqualStrings("hello!", slot.buf.items);
-    try std.testing.expectEqual(@as(u64, 6), slot.next_offset);
-}
-
-test "rawAppStreamReceiveFrame: out-of-order gap fill (libp2p reordering)" {
-    const allocator = std.testing.allocator;
-    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 8 };
-    defer slot.deinit(allocator);
-
-    try rawAppStreamReceiveFrame(allocator, &slot, 0, "abc");
-    try rawAppStreamReceiveFrame(allocator, &slot, 6, "ghi");
-    try std.testing.expectEqual(@as(u64, 3), slot.next_offset);
-    try std.testing.expectEqualStrings("abc", slot.buf.items);
-
-    try rawAppStreamReceiveFrame(allocator, &slot, 3, "def");
-    try std.testing.expectEqualStrings("abcdefghi", slot.buf.items);
-    try std.testing.expectEqual(@as(u64, 9), slot.next_offset);
-
-    // Partial overlap with next_offset splices only the new suffix.
-    try rawAppStreamReceiveFrame(allocator, &slot, 7, "hij");
-    try std.testing.expectEqualStrings("abcdefghij", slot.buf.items);
-    try std.testing.expectEqual(@as(u64, 10), slot.next_offset);
-}
-
-test "rawAppStreamReceiveFrame: duplicate out-of-order chunk is ignored" {
-    const allocator = std.testing.allocator;
-    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 12 };
-    defer slot.deinit(allocator);
-
-    try rawAppStreamReceiveFrame(allocator, &slot, 5, "tail");
-    try std.testing.expectEqual(@as(u64, 0), slot.next_offset);
-    try std.testing.expectEqual(@as(usize, 1), slot.out_of_order.items.len);
-
-    try rawAppStreamReceiveFrame(allocator, &slot, 5, "tail");
-    try std.testing.expectEqual(@as(usize, 1), slot.out_of_order.items.len);
 }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -7185,10 +7185,12 @@ pub const Client = struct {
                 }
                 if (self.conn.peerCidCountHeld() >= self.conn.peer_active_cid_limit) {
                     dbg("io: CONNECTION_ID_LIMIT_ERROR peer issued too many CIDs (limit={})\n", .{self.conn.peer_active_cid_limit});
+                    self.sendConnectionClose(0x09, "connection id limit");
                     return;
                 }
                 if (!self.conn.peerCidInsert(seq_r.value, new_cid, token)) {
                     dbg("io: peer CID pool full on NEW_CONNECTION_ID seq={}\n", .{seq_r.value});
+                    self.sendConnectionClose(0x09, "connection id limit");
                     return;
                 }
                 @memcpy(&self.conn.stateless_reset_token, &token);
@@ -7206,7 +7208,10 @@ pub const Client = struct {
                 const seq_r = varint.decode(plaintext[pos..pt_len]) catch return;
                 pos += seq_r.len;
                 dbg("io: client RETIRE_CONNECTION_ID seq={}\n", .{seq_r.value});
-                if (seq_r.value == 0) return;
+                if (seq_r.value == 0) {
+                    self.sendConnectionClose(0x0a, "retire connection id seq 0");
+                    return;
+                }
                 _ = self.conn.cidPoolRetireSeq(seq_r.value);
                 continue;
             }
@@ -7231,6 +7236,7 @@ pub const Client = struct {
                 const sid_type = sf_r.frame.stream_id & 3;
                 if (sid_type == 2) {
                     dbg("io: client STREAM_STATE_ERROR server wrote to client-initiated uni sid={}\n", .{sf_r.frame.stream_id});
+                    self.sendConnectionClose(0x05, "write to send-only stream");
                     return;
                 }
                 dbg("io: client parsed STREAM stream_id={} fin={} data_len={}\n", .{ sf_r.frame.stream_id, sf_r.frame.fin, sf_r.frame.data.len });
@@ -7252,6 +7258,59 @@ pub const Client = struct {
         if (self.deferred_ack_min_pn == null or decompressed_pn < self.deferred_ack_min_pn.?) {
             self.deferred_ack_min_pn = decompressed_pn;
         }
+    }
+
+    /// Encrypt and send a 1-RTT packet from the client.
+    fn send1Rtt(self: *Client, payload: []const u8) void {
+        if (self.conn.draining) return;
+        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+        var padded_payload_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+        const min_len: usize = 3;
+        const effective_payload: []const u8 = if (payload.len < min_len) blk: {
+            @memcpy(padded_payload_buf[0..payload.len], payload);
+            @memset(padded_payload_buf[payload.len..min_len], 0x00);
+            break :blk padded_payload_buf[0..min_len];
+        } else payload;
+        const pkt_len = build1RttPacketFull(
+            &send_buf,
+            self.conn.remote_cid,
+            effective_payload,
+            self.conn.app_pn,
+            &self.conn.app_client_km,
+            self.conn.key_phase_bit,
+            self.conn.packet_cipher,
+        ) catch return;
+        self.conn.app_pn += 1;
+        _ = compat.sendto(
+            self.sock,
+            send_buf[0..pkt_len],
+            0,
+            &self.conn.peer.any,
+            self.conn.peer.getOsSockLen(),
+        ) catch {};
+    }
+
+    /// Send a CONNECTION_CLOSE frame (QUIC layer, type 0x1c) and enter draining.
+    /// RFC 9000 §10.2.3: after sending CONNECTION_CLOSE the endpoint enters the
+    /// draining state and MUST NOT send any further packets except for additional
+    /// CONNECTION_CLOSE copies to handle packet loss.
+    fn sendConnectionClose(self: *Client, error_code: u64, reason: []const u8) void {
+        if (self.conn.conn_close_sent) return;
+        self.conn.conn_close_sent = true;
+        const frame = transport_frames.ConnectionClose{
+            .is_application = false,
+            .error_code = error_code,
+            .frame_type = 0,
+            .reason_phrase = reason,
+        };
+        var buf: [256]u8 = undefined;
+        const len = frame.serialize(&buf) catch return;
+        // Send before setting draining so send1Rtt does not suppress the frame.
+        self.send1Rtt(buf[0..len]);
+        dbg("io: client sent CONNECTION_CLOSE code={} reason=\"{s}\"\n", .{ error_code, reason });
+        self.conn.draining = true;
+        const pto = self.conn.rtt.pto_ms(self.conn.peer_max_ack_delay_ms, 0);
+        self.conn.draining_deadline_ms = compat.milliTimestamp() + @as(i64, @intCast(3 * pto));
     }
 
     /// Send a single cumulative ACK for the highest PN accumulated since the
@@ -8593,4 +8652,56 @@ test "localCidCount: seq 0 plus pool entries" {
     const tok: [16]u8 = .{0} ** 16;
     _ = conn.cidPoolReserve(cid, tok);
     try std.testing.expectEqual(@as(u64, 2), conn.localCidCount());
+}
+
+test "rawAppStreamReceiveFrame: contiguous append and FIN offset" {
+    const allocator = std.testing.allocator;
+    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 4 };
+    defer slot.deinit(allocator);
+
+    try rawAppStreamReceiveFrame(allocator, &slot, 0, "hello");
+    try std.testing.expectEqualStrings("hello", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 5), slot.next_offset);
+
+    try rawAppStreamReceiveFrame(allocator, &slot, 5, "!");
+    try std.testing.expectEqualStrings("hello!", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 6), slot.next_offset);
+
+    // Duplicate / fully-overlapping retransmit is ignored.
+    try rawAppStreamReceiveFrame(allocator, &slot, 0, "hello!");
+    try std.testing.expectEqualStrings("hello!", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 6), slot.next_offset);
+}
+
+test "rawAppStreamReceiveFrame: out-of-order gap fill (libp2p reordering)" {
+    const allocator = std.testing.allocator;
+    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 8 };
+    defer slot.deinit(allocator);
+
+    try rawAppStreamReceiveFrame(allocator, &slot, 0, "abc");
+    try rawAppStreamReceiveFrame(allocator, &slot, 6, "ghi");
+    try std.testing.expectEqual(@as(u64, 3), slot.next_offset);
+    try std.testing.expectEqualStrings("abc", slot.buf.items);
+
+    try rawAppStreamReceiveFrame(allocator, &slot, 3, "def");
+    try std.testing.expectEqualStrings("abcdefghi", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 9), slot.next_offset);
+
+    // Partial overlap with next_offset splices only the new suffix.
+    try rawAppStreamReceiveFrame(allocator, &slot, 7, "hij");
+    try std.testing.expectEqualStrings("abcdefghij", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 10), slot.next_offset);
+}
+
+test "rawAppStreamReceiveFrame: duplicate out-of-order chunk is ignored" {
+    const allocator = std.testing.allocator;
+    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 12 };
+    defer slot.deinit(allocator);
+
+    try rawAppStreamReceiveFrame(allocator, &slot, 5, "tail");
+    try std.testing.expectEqual(@as(u64, 0), slot.next_offset);
+    try std.testing.expectEqual(@as(usize, 1), slot.out_of_order.items.len);
+
+    try rawAppStreamReceiveFrame(allocator, &slot, 5, "tail");
+    try std.testing.expectEqual(@as(usize, 1), slot.out_of_order.items.len);
 }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -3341,6 +3341,9 @@ pub const Server = struct {
         // codepaths that still consult it stay consistent.
         const ncid_frame_size: usize = 28; // type + seq + rpt + len + 8 cid + 16 token
         while (fp + ncid_frame_size <= frames_buf.len) {
+            // RFC 9000 §5.1.1: the peer MUST NOT store more than
+            // `active_connection_id_limit` CIDs (seq 0 counts toward the limit).
+            if (conn.localCidCount() >= conn.peer_active_cid_limit) break;
             // Find the next free pool slot.
             var has_free = false;
             for (conn.cid_pool) |slot| {
@@ -4385,6 +4388,7 @@ pub const Server = struct {
     /// 1-RTT path, and (lazily) seed the connection's stateless-reset token
     /// mirror. No-op when the pool is already full.
     fn sendNewConnectionId(self: *Server, conn: *ConnState, dst: compat.Address) void {
+        if (conn.localCidCount() >= conn.peer_active_cid_limit) return;
         const new_cid = ConnectionId.random(compat.random, 8);
         var token: [16]u8 = undefined;
         compat.random.bytes(&token);

--- a/src/transport/raw_app_stream.zig
+++ b/src/transport/raw_app_stream.zig
@@ -1,0 +1,127 @@
+//! Opaque application-stream reassembly for libp2p-style embedders.
+//!
+//! When `raw_application_streams` is enabled, incoming STREAM frames are
+//! buffered here instead of being parsed as HTTP/0.9 or HTTP/3.
+
+const std = @import("std");
+
+/// One out-of-order STREAM chunk waiting until `next_offset` reaches `off`.
+const RawAppPendingFrame = struct {
+    off: u64,
+    data: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn deinit(self: *RawAppPendingFrame, allocator: std.mem.Allocator) void {
+        self.data.deinit(allocator);
+    }
+};
+
+/// Receive buffer for one QUIC stream when raw application streams are enabled.
+pub const RawAppStreamSlot = struct {
+    active: bool = false,
+    stream_id: u64 = 0,
+    /// Next contiguous byte offset expected; bytes [0..next_offset) are in `buf`.
+    next_offset: u64 = 0,
+    buf: std.ArrayListUnmanaged(u8) = .empty,
+    /// STREAM frames that arrived ahead of `next_offset` (UDP reordering).
+    out_of_order: std.ArrayListUnmanaged(RawAppPendingFrame) = .empty,
+    /// True once a STREAM frame with FIN=true has been merged into `buf`.
+    fin_received: bool = false,
+
+    pub fn deinit(self: *RawAppStreamSlot, allocator: std.mem.Allocator) void {
+        for (self.out_of_order.items) |*p| {
+            p.deinit(allocator);
+        }
+        self.out_of_order.deinit(allocator);
+        self.buf.deinit(allocator);
+        self.* = .{};
+    }
+};
+
+fn flushPending(allocator: std.mem.Allocator, slot: *RawAppStreamSlot) std.mem.Allocator.Error!void {
+    while (true) {
+        var found: ?usize = null;
+        for (slot.out_of_order.items, 0..) |p, i| {
+            if (p.off == slot.next_offset) {
+                found = i;
+                break;
+            }
+        }
+        const idx = found orelse return;
+        var pending = slot.out_of_order.swapRemove(idx);
+        defer pending.deinit(allocator);
+        try slot.buf.appendSlice(allocator, pending.data.items);
+        slot.next_offset += @as(u64, @intCast(pending.data.items.len));
+    }
+}
+
+/// Append stream bytes and splice any buffered gaps that become contiguous.
+pub fn receiveFrame(allocator: std.mem.Allocator, slot: *RawAppStreamSlot, o: u64, d: []const u8) std.mem.Allocator.Error!void {
+    const frame_end = o + @as(u64, @intCast(d.len));
+    if (frame_end <= slot.next_offset) return;
+
+    if (o > slot.next_offset) {
+        for (slot.out_of_order.items) |p| {
+            if (p.off == o) return;
+        }
+        var copy = std.ArrayListUnmanaged(u8).empty;
+        try copy.appendSlice(allocator, d);
+        try slot.out_of_order.append(allocator, .{ .off = o, .data = copy });
+        try flushPending(allocator, slot);
+        return;
+    }
+
+    const start: usize = @intCast(slot.next_offset - o);
+    try slot.buf.appendSlice(allocator, d[start..]);
+    slot.next_offset = frame_end;
+    try flushPending(allocator, slot);
+}
+
+test "receiveFrame: contiguous append and duplicate retransmit" {
+    const allocator = std.testing.allocator;
+    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 4 };
+    defer slot.deinit(allocator);
+
+    try receiveFrame(allocator, &slot, 0, "hello");
+    try std.testing.expectEqualStrings("hello", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 5), slot.next_offset);
+
+    try receiveFrame(allocator, &slot, 5, "!");
+    try std.testing.expectEqualStrings("hello!", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 6), slot.next_offset);
+
+    try receiveFrame(allocator, &slot, 0, "hello!");
+    try std.testing.expectEqualStrings("hello!", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 6), slot.next_offset);
+}
+
+test "receiveFrame: out-of-order gap fill (libp2p reordering)" {
+    const allocator = std.testing.allocator;
+    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 8 };
+    defer slot.deinit(allocator);
+
+    try receiveFrame(allocator, &slot, 0, "abc");
+    try receiveFrame(allocator, &slot, 6, "ghi");
+    try std.testing.expectEqual(@as(u64, 3), slot.next_offset);
+    try std.testing.expectEqualStrings("abc", slot.buf.items);
+
+    try receiveFrame(allocator, &slot, 3, "def");
+    try std.testing.expectEqualStrings("abcdefghi", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 9), slot.next_offset);
+
+    try receiveFrame(allocator, &slot, 7, "hij");
+    try std.testing.expectEqualStrings("abcdefghij", slot.buf.items);
+    try std.testing.expectEqual(@as(u64, 10), slot.next_offset);
+}
+
+test "receiveFrame: duplicate out-of-order chunk is ignored" {
+    const allocator = std.testing.allocator;
+    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 12 };
+    defer slot.deinit(allocator);
+
+    try receiveFrame(allocator, &slot, 5, "tail");
+    try std.testing.expectEqual(@as(u64, 0), slot.next_offset);
+    try std.testing.expectEqual(@as(usize, 1), slot.out_of_order.items.len);
+
+    try receiveFrame(allocator, &slot, 5, "tail");
+    try std.testing.expectEqual(@as(usize, 1), slot.out_of_order.items.len);
+}


### PR DESCRIPTION
## Summary

- **Client CONNECTION_CLOSE**: add `Client.sendConnectionClose` mirroring the server path and invoke it on protocol violations (STREAM_STATE_ERROR on client-initiated uni streams, CONNECTION_ID_LIMIT on NEW_CONNECTION_ID, RETIRE_CONNECTION_ID seq 0).
- **Cross-impl CI (P0)**: PR CI now runs `handshake`, `transfer`, and `multiplexing` in **both** directions (quinn→zquic and zquic→quinn) and fails the job on any cross-impl failure (no more `::warning::` only).
- **Raw application streams**: unit tests for `rawAppStreamReceiveFrame` covering contiguous append, out-of-order gap fill, duplicate suppression, and partial-overlap splice.
- **Roadmap**: add `docs/issue-138-roadmap.md` with P0/P1/P2 checklist and CI layout.

## Test plan

- [x] `zig fmt --check src/`
- [x] `zig build test --summary all` (203/203)
- [ ] CI interop-run: zquic↔zquic full suite + P0 cross-impl matrix