### PR TITLE
fix(crypto): guard decompressPacketNumber against u64 over/underflow

### DIFF
--- a/src/crypto/initial.zig
+++ b/src/crypto/initial.zig
@@ -56,9 +56,19 @@ pub fn decompressPacketNumber(truncated_pn: u64, expected_pn: ?u64, pn_len_bits:
     const upper_bound = expected_next + range_half;
 
     if (candidate_pn < lower_bound) {
+        // Guard against overflow when adding pn_range (very high candidate_pn).
+        if (candidate_pn > std.math.maxInt(u64) - pn_range) return candidate_pn;
         return candidate_pn + pn_range;
     }
     if (candidate_pn >= upper_bound) {
+        // Guard against underflow: only subtract pn_range when it actually
+        // fits.  RFC 9000 Appendix A's reconstruction algorithm assumes
+        // candidate_pn ≥ pn_range here, but in early-handshake / many-conn
+        // scenarios the candidate can be less than pn_range — in which case
+        // the subtraction would trap on integer overflow.  Falling back to
+        // candidate_pn is the conservative choice (the AEAD will then catch
+        // any wrong-PN guess as a decrypt failure).
+        if (candidate_pn < pn_range) return candidate_pn;
         return candidate_pn - pn_range;
     }
     return candidate_pn;


### PR DESCRIPTION
## Bug

`decompressPacketNumber` returns `candidate_pn ± pn_range` after a window check, but the window check does **not** guarantee the arithmetic stays in u64 range:

- `candidate_pn - pn_range` underflows when the truncated PN reconstructs to a value smaller than `pn_range` itself. Common in early-handshake / many-connection scenarios where `expected_pn` is low.
- `candidate_pn + pn_range` can overflow on the symmetric path (very high candidate_pn).

The underflow path **traps as `integer overflow` panic** in production. Reproducible via zig-libp2p's new 5-node gossipsub mesh test (https://github.com/ch4r10t33r/zig-libp2p/pull/158) — multiple concurrent QUIC connections with low PN counters hit the case during Handshake.

## Stack trace (from PR #158 CI failure)

```
thread 2416 panic: integer overflow
zquic/src/crypto/initial.zig:62:29: in decompressPacketNumber
    return candidate_pn - pn_range;
                       ^
zquic/src/crypto/initial.zig:266:38: in unprotectLongHeaderPacket
zquic/src/transport/io.zig:620:49:  in decryptLongPacket
zquic/src/transport/io.zig:6519:38: in processHandshakePacket
zquic/src/transport/io.zig:6336:58: in processPacket
zquic/src/transport/io.zig:5491:27: in feedPacket
zig-libp2p/src/transport/quic_endpoint.zig:347:39: in drive
```

## Fix

When the adjustment would over/underflow, fall back to the unadjusted candidate. The downstream AEAD then rejects any wrong-PN guess as a decrypt failure (RFC 9001 §5.5: "the peer is expected to discard") — the conservative, spec-allowed behaviour.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` green
- [ ] After merge: bump libp2p to this zquic master; PR #158 (5-node test) goes green.