### PR TITLE
tls/handshake: fix buildCertificateRequest signature_algorithms wire format (v1.6.11)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zquic,
     .fingerprint = 0x947d823dd45c34db,
-    .version = "1.6.10",
+    .version = "1.6.11",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zig_varint = .{

--- a/src/tls/handshake.zig
+++ b/src/tls/handshake.zig
@@ -681,11 +681,16 @@ pub fn buildCertificateRequest(out: []u8) !usize {
     var ep: usize = 0;
     writeU16(ext_buf[ep..], EXT_SIGNATURE_ALGORITHMS);
     ep += 2;
-    const algo_bytes: [4]u8 = .{ 0x04, 0x03, 0x05, 0x03 };
-    writeU16(ext_buf[ep..], algo_bytes.len);
+    // extension_data = SignatureSchemeList: u16 list_len + schemes (same layout as
+    // appendClientHelloSignatureAlgorithms — omitting list_len breaks go/crypto/tls).
+    writeU16(ext_buf[ep..], 6); // ext data: list_len(2) + 2× u16 schemes
     ep += 2;
-    @memcpy(ext_buf[ep..][0..algo_bytes.len], &algo_bytes);
-    ep += algo_bytes.len;
+    writeU16(ext_buf[ep..], 4); // signature list length in bytes
+    ep += 2;
+    writeU16(ext_buf[ep..], SIG_ECDSA_SECP256R1_SHA256);
+    ep += 2;
+    writeU16(ext_buf[ep..], SIG_ECDSA_SECP384R1_SHA384);
+    ep += 2;
 
     const body_len = 1 + 2 + ep;
     if (out.len < 4 + body_len) return error.BufferTooSmall;
@@ -1992,6 +1997,23 @@ test "leafCertificateDerFromCertificateHandshakeMessage round trip" {
     const n = try buildCertificate(&buf, &der_in);
     const leaf = try leafCertificateDerFromCertificateHandshakeMessage(buf[0..n]);
     try testing.expectEqualSlices(u8, &der_in, leaf);
+}
+
+test "buildCertificateRequest signature_algorithms extension wire format" {
+    const testing = std.testing;
+    var buf: [64]u8 = undefined;
+    const n = try buildCertificateRequest(&buf);
+    try testing.expect(n > 4);
+    try testing.expectEqual(MSG_CERTIFICATE_REQUEST, buf[0]);
+    // body: ctx_len=0, extensions_len=10, ext type=13, ext_data_len=6, list_len=4, 0x0403, 0x0503
+    const body = buf[4..n];
+    try testing.expectEqual(@as(u8, 0), body[0]); // empty request context
+    try testing.expectEqual(@as(u16, 10), readU16(body[1..])); // extensions block
+    try testing.expectEqual(@as(u16, EXT_SIGNATURE_ALGORITHMS), readU16(body[3..]));
+    try testing.expectEqual(@as(u16, 6), readU16(body[5..])); // extension data
+    try testing.expectEqual(@as(u16, 4), readU16(body[7..])); // SignatureSchemeList length
+    try testing.expectEqual(SIG_ECDSA_SECP256R1_SHA256, readU16(body[9..]));
+    try testing.expectEqual(SIG_ECDSA_SECP384R1_SHA384, readU16(body[11..]));
 }
 
 test "handshake: client-server secrets are mirrored" {


### PR DESCRIPTION
## Summary
\`CertificateRequest\` was emitting a raw four-byte blob
\`0x04 0x03 0x05 0x03\` inside the \`signature_algorithms\` extension.
TLS 1.3 (RFC 8446 §4.2.3) requires \`SignatureSchemeList\` to carry an
inner \`u16\` list_len before the schemes — without it every spec-
compliant verifier (rustls in rust-libp2p, go/crypto/tls, BoringSSL
in cpp-libp2p, …) rejects the handshake. This blocks **every** cross-
impl mutual-TLS QUIC dial in libp2p land.

Reproducer surfaced this week trying to dial ream (rust-libp2p) +
qlean (cpp-libp2p) from a zeam node in lean-quickstart's local-devnet:
every outbound dial timed out at 20s with no progress past the
EncryptedExtensions phase. Same shape as the cross-impl rows in
zquic's own Interop Runner CI.

## Change
- Emit \`ext_data_len(2) + list_len(2) + N×u16\` per spec.
- Offer \`ECDSA-P256-SHA256\` (0x0403) + \`ECDSA-P384-SHA384\` (0x0503) —
  same schemes the rest of the file accepts.
- New unit test asserts the byte-for-byte layout so any future drift
  here trips immediately.
- Bumps the package version to **1.6.11** so downstream consumers
  (zig-libp2p → zeam) can pin a tagged release.

## Test plan
- [x] \`zig build test\` — full suite green.
- [x] Manual: byte layout matches RFC 8446 §4.2.3 SignatureSchemeList
      encoding (extensions_len=10, ext type=13, ext_data_len=6,
      list_len=4, then two u16 schemes).