### PR TITLE
io: demote per-tick CC backpressure trace from warn to debug

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1183,12 +1183,12 @@ fn maybeLogPendingStreamStall(conn: *ConnState, side: []const u8) void {
             conn.fc_send_max,
         },
     );
-    // Backpressure CC trace (visible at info): distinguishes a cwnd pinned by
+    // Backpressure CC trace (visible at debug): distinguishes a cwnd pinned by
     // repeated losses (`cong_events` climbing) from ACK-clock starvation
     // (`acked` flat / few ACKs).  `state` shows whether we are stuck in
     // congestion-avoidance; RTT (ms) shows whether the path RTT is being
     // measured at all on a sub-ms localhost link.
-    log.warn(
+    log.debug(
         "io: {s} CC trace blocked_by={s} cwnd={} ssthresh={} state={s} bif={} cong_events={} acked={} srtt_ms={} min_rtt_ms={} latest_rtt_ms={} local_send_drops={}",
         .{
             side,


### PR DESCRIPTION
The CC trace (`io: ... CC trace blocked_by=pacer ...`) fires on every blocked send tick and is a diagnostic, not a fault. On a healthy loopback link it spams the warn-level operator log. Demoted to `debug` — still available under `-Dlog=debug`, silent at normal levels. No behavior change.