### PR TITLE
loss: fix cwnd collapse — exit recovery only on post-recovery ACK (RFC 9002 §7.3.2)

### DIFF
--- a/src/loss/congestion.zig
+++ b/src/loss/congestion.zig
@@ -57,12 +57,19 @@ pub const NewReno = struct {
     }
 
     /// Called when packets are acknowledged.
-    pub fn onAck(self: *NewReno, bytes_acked: u64) void {
+    pub fn onAck(self: *NewReno, bytes_acked: u64, largest_acked_pn: u64) void {
         self.total_bytes_acked +|= bytes_acked;
         self.bytes_in_flight -|= bytes_acked;
 
         if (self.state == .recovery) {
-            // Exit recovery once the end-of-recovery packet is acked.
+            // RFC 9002 §7.3.2: exit recovery only when an ACK covers a packet
+            // sent *after* the recovery period began. Exiting on the first ACK
+            // (and clearing `end_of_recovery`) defeats the once-per-flight loss
+            // gate in `onLoss`, letting one congestion episode cut cwnd many
+            // times to the floor. See Cubic.onAck for the full rationale.
+            if (self.end_of_recovery) |eor| {
+                if (largest_acked_pn <= eor) return; // pre-recovery ack: no growth, stay in recovery
+            }
             self.state = .congestion_avoidance;
             self.end_of_recovery = null;
         }
@@ -146,9 +153,9 @@ pub const CongestionController = union(enum) {
         };
     }
 
-    pub fn onAck(self: *CongestionController, bytes_acked: u64) void {
+    pub fn onAck(self: *CongestionController, bytes_acked: u64, largest_acked_pn: u64) void {
         switch (self.*) {
-            inline else => |*cc| cc.onAck(bytes_acked),
+            inline else => |*cc| cc.onAck(bytes_acked, largest_acked_pn),
         }
     }
 
@@ -248,7 +255,7 @@ test "new_reno: slow start growth" {
     const initial_cwnd = cc.cwnd;
 
     cc.onPacketSent(mss);
-    cc.onAck(mss);
+    cc.onAck(mss, 1);
     // In slow start, cwnd should grow by bytes_acked
     try testing.expectEqual(initial_cwnd + mss, cc.cwnd);
 }
@@ -287,7 +294,7 @@ test "new_reno: congestion avoidance" {
 
     const initial_cwnd = cc.cwnd;
     // ACK a full cwnd worth of bytes → cwnd increases by 1 MSS
-    cc.onAck(cc.cwnd);
+    cc.onAck(cc.cwnd, 1);
     try testing.expectEqual(initial_cwnd + mss, cc.cwnd);
 }
 
@@ -298,7 +305,7 @@ test "new_reno: can_send check" {
     cc.bytes_in_flight = 2 * mss;
 
     try testing.expect(!cc.canSend(1));
-    cc.onAck(mss);
+    cc.onAck(mss, 1);
     try testing.expect(cc.canSend(mss));
 }
 
@@ -338,7 +345,7 @@ test "congestion_controller: tagged union dispatches correctly" {
     nr.onPacketSent(mss);
     try testing.expectEqual(@as(u64, mss), nr.getBytesInFlight());
     try testing.expect(nr.canSend(mss));
-    nr.onAck(mss);
+    nr.onAck(mss, 1);
     try testing.expectEqual(@as(u64, 0), nr.getBytesInFlight());
 
     // CUBIC variant

--- a/src/loss/cubic.zig
+++ b/src/loss/cubic.zig
@@ -62,12 +62,24 @@ pub const Cubic = struct {
         return .{};
     }
 
-    /// Called when packets are acknowledged.
-    pub fn onAck(self: *Cubic, bytes_acked: u64) void {
+    /// Called when packets are acknowledged. `largest_acked_pn` is the largest
+    /// packet number newly acknowledged by this ACK; it gates recovery exit.
+    pub fn onAck(self: *Cubic, bytes_acked: u64, largest_acked_pn: u64) void {
         self.total_bytes_acked +|= bytes_acked;
         self.bytes_in_flight -|= bytes_acked;
 
         if (self.state == .recovery) {
+            // RFC 9002 §7.3.2: remain in recovery — and keep reacting to loss
+            // only once per round trip — until an ACK arrives for a packet sent
+            // *after* the recovery period began. Exiting on the first ACK and
+            // clearing `end_of_recovery` (as this code previously did) destroys
+            // the once-per-flight loss gate in `onLoss`: the next loss detected
+            // from the same flight re-enters recovery and cuts cwnd again, so a
+            // single congestion episode collapses cwnd to the floor over many
+            // ACKs (congestion_events climbing into the thousands).
+            if (self.end_of_recovery) |eor| {
+                if (largest_acked_pn <= eor) return; // pre-recovery ack: no growth, stay in recovery
+            }
             self.state = .congestion_avoidance;
             self.end_of_recovery = null;
         }
@@ -218,7 +230,7 @@ test "cubic: slow start growth" {
     const initial_cwnd = cc.cwnd;
 
     cc.onPacketSent(mss);
-    cc.onAck(mss);
+    cc.onAck(mss, 1);
     try testing.expectEqual(initial_cwnd + mss, cc.cwnd);
 }
 
@@ -237,6 +249,42 @@ test "cubic: loss triggers recovery with β=0.7" {
     try testing.expectEqual(@as(u64, 100), cc.w_max);
 }
 
+test "cubic: one congestion episode cuts cwnd once across many ACKs" {
+    const testing = std.testing;
+    var cc = Cubic.init();
+    cc.state = .congestion_avoidance;
+    cc.cwnd = 100 * mss;
+    cc.bytes_in_flight = 100 * mss;
+
+    // A flight (PNs 0..40) suffers loss. Loss is detected on PN 30 first, then
+    // the loss detector dribbles out more losses (PNs 20, 25) on later ACKs of
+    // the SAME flight — exactly what packet/time-threshold detection does.
+    // ACKs and losses interleave, as in the real recv loop (onAck then onLoss).
+    cc.onLoss(30); // recovery starts; end_of_recovery = 30
+    try testing.expectEqual(nr.CcState.recovery, cc.state);
+    const after_first = cc.cwnd; // 70 * mss
+    try testing.expectEqual(@as(u64, 1), cc.congestion_events);
+
+    // ACK of a pre-recovery packet (PN 10 <= 30): must NOT exit recovery and
+    // must NOT let the next loss re-trigger a cut.
+    cc.onAck(mss, 10);
+    try testing.expectEqual(nr.CcState.recovery, cc.state);
+    cc.onLoss(25); // same flight, <= end_of_recovery → gated, no second cut
+    cc.onAck(mss, 12);
+    cc.onLoss(20); // still gated
+    try testing.expectEqual(@as(u64, 1), cc.congestion_events);
+    try testing.expectEqual(after_first, cc.cwnd); // cwnd unchanged — no cascade
+
+    // An ACK for a packet sent AFTER recovery began (PN 41 > 30) ends recovery.
+    cc.onAck(mss, 41);
+    try testing.expectEqual(nr.CcState.congestion_avoidance, cc.state);
+
+    // A genuinely new congestion episode (PN past end_of_recovery) cuts again.
+    cc.onLoss(50);
+    try testing.expectEqual(@as(u64, 2), cc.congestion_events);
+    try testing.expectEqual(nr.CcState.recovery, cc.state);
+}
+
 test "cubic: integer cube root" {
     const testing = std.testing;
     try testing.expectEqual(@as(u64, 0), intCbrt(0));
@@ -253,6 +301,6 @@ test "cubic: can_send check" {
     cc.cwnd = 2 * mss;
     cc.bytes_in_flight = 2 * mss;
     try testing.expect(!cc.canSend(1));
-    cc.onAck(mss);
+    cc.onAck(mss, 1);
     try testing.expect(cc.canSend(mss));
 }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -4850,7 +4850,7 @@ pub const Server = struct {
                 // bytes_acked is the sum of real packet sizes from the loss
                 // detector, keeping bytes_in_flight accurate.
                 if (ld_result.bytes_acked > 0) {
-                    conn.cc.onAck(ld_result.bytes_acked);
+                    conn.cc.onAck(ld_result.bytes_acked, largest_ack);
                 }
                 if (conn.plpmtu.probe_pn) |probe_pn| {
                     if (largest_ack >= probe_pn) {
@@ -9256,7 +9256,7 @@ pub const Client = struct {
                     pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
                     continue;
                 };
-                if (ld_result.bytes_acked > 0) self.conn.cc.onAck(ld_result.bytes_acked);
+                if (ld_result.bytes_acked > 0) self.conn.cc.onAck(ld_result.bytes_acked, largest_ack);
                 if (self.conn.plpmtu.probe_pn) |probe_pn| {
                     if (largest_ack >= probe_pn) {
                         self.conn.plpmtu.onProbeAcked(probe_pn);
@@ -11041,7 +11041,7 @@ test "client 1-RTT send: loss detector and CC bytes_in_flight stay coupled" {
 
     var lost_buf: [8]recovery.SentPacket = undefined;
     const ld_result = try conn.ld.onAck(pn, 0, 0, 1000, &conn.rtt, &lost_buf, std.testing.allocator);
-    if (ld_result.bytes_acked > 0) conn.cc.onAck(ld_result.bytes_acked);
+    if (ld_result.bytes_acked > 0) conn.cc.onAck(ld_result.bytes_acked, pn);
     try std.testing.expectEqual(@as(u64, 0), conn.cc.getBytesInFlight());
 }
 


### PR DESCRIPTION
## Root cause

`Cubic.onAck` / `NewReno.onAck` exited congestion recovery on the **first ACK** received during recovery and cleared `end_of_recovery` — the once-per-flight gate that `onLoss` uses (`largest_lost_pn <= end_of_recovery → return`).

The recv loop calls `cc.onAck` **before** `cc.onLoss` for the same ACK frame. So any ACK that both acknowledges data and carries a newly-detected loss would:
1. clear the gate in `onAck`, then
2. re-enter recovery in `onLoss` and multiplicatively cut cwnd **again**.

Packet/time-threshold loss detection spreads a single flight's losses across several ACKs, so one real congestion episode cut cwnd **once per ACK** instead of once per round trip. Result observed on the live devnet:

```
blocked_by=cc cwnd=13500 ssthresh=13500 state=recovery bif=12381 cong_events=2595 local_send_drops=0
```

cwnd pinned at the `minimum_window` floor (13500 B), permanently in `recovery`, `congestion_events` climbing into the thousands on a *loopback* link. This throttled zeam's send so hard the libp2p persistent `/meshsub` gossip outbox couldn't drain within the 20 s wedge timeout → redial (the residual send-side outbox-stuck from the #172 validation).

## Fix

Per RFC 9002 §7.3.2, exit recovery only when an ACK covers a packet sent **after** the recovery period began (`largest_acked_pn > end_of_recovery`). ACKs of pre-recovery packets neither grow cwnd nor clear the gate. The largest acked PN is threaded through `CongestionController.onAck` to both controllers.

## Test

New regression test: one congestion episode cuts cwnd exactly once across interleaved ACKs/losses, an ACK of a pre-recovery packet does not exit recovery, and a genuinely new episode (PN past `end_of_recovery`) still cuts. Full suite 230/230.