### PR TITLE
io: add rawAppStreamFullyReceived (FIN + contiguous-complete) for reqresp completion

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -6101,12 +6101,17 @@ pub const Server = struct {
 
         raw_app_stream.receiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
         // RFC 9000 §3.2: STREAM frame with FIN signals the peer is done
-        // sending on this stream.  Record it so the embedder knows it can
-        // release the slot once it has consumed the payload (see
-        // releaseRawAppStream).  Without this, libp2p's per-message-stream
-        // gossipsub pattern exhausts the 64 slots within ~30s and all
-        // subsequent inbound streams are silently dropped.
-        if (sf.fin) slot.fin_received = true;
+        // sending on this stream.  Record it (plus the final size) so the
+        // embedder knows it can release the slot once it has consumed the
+        // payload (see releaseRawAppStream) and can distinguish "stream
+        // complete" from "FIN seen but data still arriving" via `fullyReceived`.
+        // Without the FIN flag, libp2p's per-message-stream gossipsub pattern
+        // exhausts the 64 slots within ~30s and all subsequent inbound streams
+        // are silently dropped.
+        if (sf.fin) {
+            slot.fin_received = true;
+            slot.fin_offset = sf.offset + @as(u64, @intCast(sf.data.len));
+        }
     }
 
     fn openHttp09OutSlot(_: *Server, conn: *ConnState, stream_id: u64, fs_path: []const u8) ?u16 {
@@ -7225,6 +7230,19 @@ pub fn rawAppStreamFinReceived(conn: *ConnState, stream_id: u64) bool {
     return false;
 }
 
+/// True only when the peer has FIN'd **and** every byte up to the final size
+/// has been contiguously reassembled — i.e. the response is genuinely complete
+/// (covers the empty-response case: a 0-byte FIN at offset 0 is fully received).
+/// Prefer this over `rawAppStreamFinReceived` for "is the response done?"
+/// decisions: a trailing 0-byte FIN frame can be processed before the
+/// cwnd-queued payload, so `fin_received` alone races ahead of the data.
+pub fn rawAppStreamFullyReceived(conn: *ConnState, stream_id: u64) bool {
+    for (&conn.raw_app_streams) |*slot| {
+        if (slot.active and slot.stream_id == stream_id) return slot.fullyReceived();
+    }
+    return false;
+}
+
 /// Free the raw-app slot holding `stream_id` so the connection's 64-slot
 /// table can absorb the next inbound stream.  Returns true if a matching
 /// slot was found.  Calling this on a slot whose FIN has not yet been
@@ -8199,6 +8217,15 @@ pub const Client = struct {
     pub fn rawAppStreamFinReceived(self: *const Client, stream_id: u64) bool {
         for (&self.raw_app_recv) |*slot| {
             if (slot.active and slot.stream_id == stream_id) return slot.fin_received;
+        }
+        return false;
+    }
+
+    /// Mirror of the connection-level `rawAppStreamFullyReceived`: FIN seen
+    /// **and** all bytes up to the final size contiguously reassembled.
+    pub fn rawAppStreamFullyReceived(self: *const Client, stream_id: u64) bool {
+        for (&self.raw_app_recv) |*slot| {
+            if (slot.active and slot.stream_id == stream_id) return slot.fullyReceived();
         }
         return false;
     }
@@ -9826,9 +9853,13 @@ pub const Client = struct {
         };
 
         raw_app_stream.receiveFrame(self.allocator, slot, sf.offset, sf.data) catch return;
-        // Mirror of the server side: track FIN so embedders can release the
-        // slot once they have read the payload.
-        if (sf.fin) slot.fin_received = true;
+        // Mirror of the server side: track FIN + final size so embedders can
+        // release the slot once they have read the payload, and distinguish
+        // "complete" from "FIN seen but data still arriving" via `fullyReceived`.
+        if (sf.fin) {
+            slot.fin_received = true;
+            slot.fin_offset = sf.offset + @as(u64, @intCast(sf.data.len));
+        }
     }
 
     fn http09DeliverStreamBytes(s: *StreamDownload, reorder: *quic_tls_mod.CryptoReorderBuf, offset: u64, data: []const u8) void {

--- a/src/transport/raw_app_stream.zig
+++ b/src/transport/raw_app_stream.zig
@@ -24,8 +24,23 @@ pub const RawAppStreamSlot = struct {
     buf: std.ArrayListUnmanaged(u8) = .empty,
     /// STREAM frames that arrived ahead of `next_offset` (UDP reordering).
     out_of_order: std.ArrayListUnmanaged(RawAppPendingFrame) = .empty,
-    /// True once a STREAM frame with FIN=true has been merged into `buf`.
+    /// True once a STREAM frame with FIN=true has been seen on this stream.
+    /// NOTE: the FIN bit can arrive (on a small trailing frame) before the
+    /// earlier bulk data has been reassembled, so `fin_received` alone does
+    /// NOT mean the stream is complete — use `fullyReceived`.
     fin_received: bool = false,
+    /// Final stream size, recorded from the FIN frame (`offset + len`). Only
+    /// meaningful once `fin_received` is true.
+    fin_offset: u64 = 0,
+
+    /// True only when the peer has FIN'd **and** all bytes up to the final
+    /// size have been contiguously reassembled into `buf`. This is the signal
+    /// embedders must use to decide "the response is complete" — `fin_received`
+    /// races ahead of the data because a trailing 0-byte FIN frame (the libp2p
+    /// reqresp half-close) can be processed before the cwnd-queued payload.
+    pub fn fullyReceived(self: *const RawAppStreamSlot) bool {
+        return self.fin_received and self.next_offset >= self.fin_offset;
+    }
 
     pub fn deinit(self: *RawAppStreamSlot, allocator: std.mem.Allocator) void {
         for (self.out_of_order.items) |*p| {
@@ -111,6 +126,36 @@ test "receiveFrame: out-of-order gap fill (libp2p reordering)" {
     try receiveFrame(allocator, &slot, 7, "hij");
     try std.testing.expectEqualStrings("abcdefghij", slot.buf.items);
     try std.testing.expectEqual(@as(u64, 10), slot.next_offset);
+}
+
+test "fullyReceived: FIN ahead of data is not complete until the gap fills" {
+    const allocator = std.testing.allocator;
+    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 4 };
+    defer slot.deinit(allocator);
+
+    // Trailing FIN frame (offset 6, 0 bytes) arrives before the bulk payload —
+    // the libp2p reqresp half-close racing ahead of cwnd-queued data. The
+    // caller records fin_received + fin_offset (as io.zig does on the FIN bit).
+    slot.fin_received = true;
+    slot.fin_offset = 6;
+    try std.testing.expect(!slot.fullyReceived()); // no data yet (next_offset=0)
+
+    try receiveFrame(allocator, &slot, 0, "abc");
+    try std.testing.expect(!slot.fullyReceived()); // 3/6 bytes contiguous
+
+    try receiveFrame(allocator, &slot, 3, "def");
+    try std.testing.expect(slot.fullyReceived()); // 6/6 — complete
+}
+
+test "fullyReceived: empty (0-byte) FIN is immediately complete" {
+    const allocator = std.testing.allocator;
+    var slot: RawAppStreamSlot = .{ .active = true, .stream_id = 4 };
+    defer slot.deinit(allocator);
+
+    // Empty reqresp response: a 0-byte FIN at offset 0 (peer has no data).
+    slot.fin_received = true;
+    slot.fin_offset = 0;
+    try std.testing.expect(slot.fullyReceived());
 }
 
 test "receiveFrame: duplicate out-of-order chunk is ignored" {


### PR DESCRIPTION
`rawAppStreamFinReceived` flips true the instant any FIN bit is seen — but the libp2p reqresp half-close is a trailing **0-byte FIN frame at the final offset** that can be processed **before** the cwnd-queued payload. So `fin_received` races ahead of the data: an embedder using it to decide "response complete" sees a true FIN with an empty/partial buffer and finishes early, dropping the response.

Adds `RawAppStreamSlot.fullyReceived()` = `fin_received and next_offset >= fin_offset`, where `fin_offset` (final size) is recorded when the FIN bit is seen on both the server and client raw-app recv paths. Exposed as `rawAppStreamFullyReceived` on `ConnState` and `Client`. True only once all bytes up to the final size are contiguously reassembled; the empty-response case (0-byte FIN at offset 0) is immediately complete.

Consumed by zig-libp2p's reqresp requester to complete on an empty/complete response instead of hanging to the request timeout, without truncating a large in-flight response. Unit tests added; full suite 234/234.