### PR TITLE
ack: coalesce adjacent app-ACK ranges to prevent gap-underflow panic

### DIFF
--- a/src/frames/ack.zig
+++ b/src/frames/ack.zig
@@ -130,10 +130,13 @@ pub const AckFrame = struct {
             var prev_smallest = first.smallest;
             while (i < self.range_count) : (i += 1) {
                 const r = self.ranges[i];
-                // gap = prev_smallest - r.largest - 2
-                const gap = prev_smallest - r.largest - 2;
+                // gap = prev_smallest - r.largest - 2. Defensive: ranges are
+                // expected to be non-overlapping and ≥2 apart (callers coalesce
+                // first), but a malformed/adjacent pair must never panic the
+                // node on an integer overflow — saturate to 0 instead.
+                const gap = if (prev_smallest -| r.largest >= 2) prev_smallest - r.largest - 2 else 0;
                 try w.writeVarint(gap);
-                try w.writeVarint(r.largest - r.smallest);
+                try w.writeVarint(r.largest -| r.smallest);
                 prev_smallest = r.smallest;
             }
         }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -261,14 +261,36 @@ const AppAckTracker = struct {
                 }
             }
         }
+        // Coalesce adjacent / overlapping ranges. `observe` can extend a range
+        // until it is flush against (or overlapping) a neighbour without
+        // merging the two, leaving e.g. [12,15] and [5,11]. The wire gap
+        // encoding is `prev_smallest - largest - 2`, which underflows (and
+        // panics the node on an integer overflow) for any pair with a zero or
+        // negative gap. Merge them so consecutive ranges always have ≥1 PN of
+        // gap between them.
+        var m: usize = 0;
+        var c: usize = 0;
+        while (c < n) {
+            var cur = sorted[c];
+            c += 1;
+            // `sorted` is descending by smallest, so subsequent entries are
+            // lower; fold any whose top touches/overlaps `cur`'s bottom.
+            while (c < n and sorted[c].largest +| 1 >= cur.smallest) {
+                if (sorted[c].smallest < cur.smallest) cur.smallest = sorted[c].smallest;
+                if (sorted[c].largest > cur.largest) cur.largest = sorted[c].largest;
+                c += 1;
+            }
+            sorted[m] = cur;
+            m += 1;
+        }
         var frame = ack_frame_mod.AckFrame{
             .largest_acknowledged = sorted[0].largest,
             .ack_delay = 0,
             .ranges = undefined,
-            .range_count = n,
+            .range_count = m,
             .ecn = ecn,
         };
-        for (0..n) |k| {
+        for (0..m) |k| {
             frame.ranges[k] = sorted[k];
         }
         return frame.serialize(buf);
@@ -10982,6 +11004,30 @@ test "pending stream send: oversized write fans out into per-packet entries" {
     try std.testing.expectEqual(@as(u64, 0), conn.pending_stream_sends.items[0].offset);
     try std.testing.expect(conn.pending_stream_sends.items[4].fin);
     try std.testing.expect(!conn.pending_stream_sends.items[0].fin);
+}
+
+test "AppAckTracker: adjacent ranges coalesce and serialize without integer overflow" {
+    // Regression: under load `observe` could extend one range until it sat
+    // flush against another (e.g. [5,11] and [12,15]) without merging. The
+    // wire gap encoding `prev_smallest - largest - 2` then underflowed and
+    // panicked the whole node (seen on the 32-validator devnet, crashing
+    // `flushConnAppAck`).
+    var t = AppAckTracker{};
+    for ([_]u64{ 5, 6, 7, 8, 9, 10 }) |pn| _ = t.observe(pn); // range [5,10]
+    for ([_]u64{ 12, 13, 14, 15 }) |pn| _ = t.observe(pn); // range [12,15]
+    _ = t.observe(11); // extends [5,10] -> [5,11], now ADJACENT to [12,15]
+    try std.testing.expect(t.range_count >= 2);
+
+    var buf: [256]u8 = undefined;
+    const n = try t.buildWireFrame(&buf, null); // must NOT panic
+    try std.testing.expect(n > 0);
+
+    // Re-parse: a valid ACK acknowledging the full 5..15 span.
+    // Re-parse (serialize writes the type byte; parse expects it stripped).
+    // A valid ACK acknowledging the full 5..15 span — coalesced to one range.
+    const parsed = try ack_frame_mod.AckFrame.parse(buf[1..n], false);
+    try std.testing.expectEqual(@as(u64, 15), parsed.frame.largest_acknowledged);
+    try std.testing.expectEqual(@as(usize, 1), parsed.frame.range_count);
 }
 
 test "build1RttPacketFull: cipher param actually selects the AEAD (regression for AES-128 fallthrough)" {


### PR DESCRIPTION
## Problem

Node crash observed on a real 32-validator multi-machine devnet:

```
thread 41 panic: integer overflow
  .../src/transport/io.zig:274:9 in serialize
  io.zig flushConnAppAck
  io.zig flushAllConnAppAcks
  zig_libp2p .../runtime.zig driveLoop
```

`AppAckTracker.observe()` can produce ACK ranges that are **adjacent/touching** (e.g. `[5..11]` and `[12..15]` after a bridging packet number arrives). When the frame is serialized, the inter-range gap is encoded as `prev_smallest - cur_largest - 2`. For adjacent ranges this underflows `u64` → `integer overflow` panic, killing the node from the drive loop.

## Fix

- **`AppAckTracker.buildWireFrame`**: coalesce adjacent/overlapping ranges (descending sort already present) into a single range before building the `AckFrame`, so the wire carries the minimal valid range set.
- **`AckFrame.serialize`**: compute the gap with saturating subtraction, clamping to 0 when ranges touch — defense-in-depth for any other caller passing unmerged ranges.

## Test

Regression test observes `5..10`, `12..15`, then `11` (which bridges the two into a single `5..15` span); asserts `buildWireFrame` produces one coalesced range and the wire re-parses to `largest_acknowledged=15` without panic.

Full suite: 236/236 pass; `zig fmt --check` clean.