### PR TITLE
loss,transport,crypto: open-issue batch (#189-#200)

### DIFF
--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -154,24 +154,28 @@ pub const TransportParamsOpts = struct {
     /// token for active migration (RFC 9000 §9.6 / §18.2).
     preferred_address: ?PreferredAddressTp = null,
     /// `initial_max_data` (0x04): connection-level flow-control window.
-    initial_max_data: u64 = 67_108_864,
+    /// Default 1 MiB — conservative for memory; libp2p preset raises this.
+    initial_max_data: u64 = 1_048_576,
     /// `initial_max_stream_data_bidi_local` (0x05).
-    initial_max_stream_data_bidi_local: u64 = 16_777_216,
+    initial_max_stream_data_bidi_local: u64 = 262_144,
     /// `initial_max_stream_data_bidi_remote` (0x06).
-    initial_max_stream_data_bidi_remote: u64 = 16_777_216,
+    initial_max_stream_data_bidi_remote: u64 = 262_144,
     /// `initial_max_stream_data_uni` (0x07).
-    initial_max_stream_data_uni: u64 = 16_777_216,
+    initial_max_stream_data_uni: u64 = 262_144,
     /// `initial_max_streams_bidi` (0x08).
     initial_max_streams_bidi: u64 = 1000,
     /// `initial_max_streams_uni` (0x09).
     initial_max_streams_uni: u64 = 1000,
+    /// RFC 9287 `grease_quic_bit` (0x2ab2): advertise tolerance for greased
+    /// short-header QUIC bits from the peer.
+    grease_quic_bit: bool = true,
 };
 
 /// Preset transport-parameter profiles for common embedders.
 pub const TransportParamsPreset = enum {
-    /// zquic defaults (64 MiB conn / 16 MiB stream / 1000 streams).
+    /// zquic defaults (1 MiB conn / 256 KiB stream / 1000 streams).
     default,
-    /// Match `libp2p-quic` / quinn defaults used by rust-libp2p.
+    /// libp2p-quic / gossipsub bulk profile (15 MiB conn / 10 MiB stream).
     libp2p,
 };
 
@@ -307,6 +311,10 @@ pub fn buildTransportParams(out: []u8, opts: TransportParamsOpts) (varint.Encode
     if (opts.retry_source_cid) |rscid| {
         pos = try writeParamBytes(out, pos, 0x10, rscid);
     }
+    // RFC 9287: grease_quic_bit (0x2ab2) — length-0 flag.
+    if (opts.grease_quic_bit) {
+        pos = try writeParamBytes(out, pos, 0x2ab2, &[_]u8{});
+    }
     return pos;
 }
 
@@ -365,6 +373,8 @@ pub const PeerTransportParams = struct {
     /// finds — call sites enforce role.  `null` when the param is absent
     /// or the body is malformed.
     preferred_address: ?PreferredAddressTp = null,
+    /// RFC 9287 `grease_quic_bit` (0x2ab2): peer tolerates greased QUIC bit.
+    grease_quic_bit: bool = false,
 };
 
 /// On-wire layout of the preferred_address transport parameter (RFC 9000
@@ -459,6 +469,7 @@ pub fn parseTransportParams(bytes: []const u8) varint.DecodeError!PeerTransportP
             0x0c => out.disable_active_migration = (value_len == 0),
             0x0d => out.preferred_address = parsePreferredAddress(value),
             0x0e => out.active_connection_id_limit = readVarintField(value) catch continue,
+            0x2ab2 => out.grease_quic_bit = (value_len == 0),
             else => {}, // unknown / reserved / connection-id params are not surfaced here
         }
     }
@@ -481,10 +492,10 @@ test "transport params: round-trip varint fields" {
     const n = try buildTransportParams(&buf, .{ .initial_source_cid = &cid });
     const parsed = try parseTransportParams(buf[0..n]);
     try testing.expectEqual(@as(u64, 30_000), parsed.max_idle_timeout_ms);
-    try testing.expectEqual(@as(u64, 67_108_864), parsed.initial_max_data);
-    try testing.expectEqual(@as(u64, 16_777_216), parsed.initial_max_stream_data_bidi_local);
-    try testing.expectEqual(@as(u64, 16_777_216), parsed.initial_max_stream_data_bidi_remote);
-    try testing.expectEqual(@as(u64, 16_777_216), parsed.initial_max_stream_data_uni);
+    try testing.expectEqual(@as(u64, 1_048_576), parsed.initial_max_data);
+    try testing.expectEqual(@as(u64, 262_144), parsed.initial_max_stream_data_bidi_local);
+    try testing.expectEqual(@as(u64, 262_144), parsed.initial_max_stream_data_bidi_remote);
+    try testing.expectEqual(@as(u64, 262_144), parsed.initial_max_stream_data_uni);
     try testing.expectEqual(@as(u64, 1000), parsed.initial_max_streams_bidi);
     try testing.expectEqual(@as(u64, 1000), parsed.initial_max_streams_uni);
     try testing.expectEqual(@as(u8, 3), parsed.ack_delay_exponent);

--- a/src/crypto/quic_tls.zig
+++ b/src/crypto/quic_tls.zig
@@ -167,8 +167,10 @@ pub const TransportParamsOpts = struct {
     /// `initial_max_streams_uni` (0x09).
     initial_max_streams_uni: u64 = 1000,
     /// RFC 9287 `grease_quic_bit` (0x2ab2): advertise tolerance for greased
-    /// short-header QUIC bits from the peer.
-    grease_quic_bit: bool = true,
+    /// short-header QUIC bits from the peer.  Off by default so legacy quinn
+    /// interop images that mishandle 0x2ab2 still complete handshakes; opt in
+    /// explicitly when the peer is known to support RFC 9287.
+    grease_quic_bit: bool = false,
 };
 
 /// Preset transport-parameter profiles for common embedders.
@@ -519,6 +521,18 @@ test "transport params: disable_active_migration is a length-0 flag" {
     const bytes = [_]u8{ 0x0c, 0x00 };
     const parsed = try parseTransportParams(&bytes);
     try testing.expect(parsed.disable_active_migration);
+}
+
+test "transport params: grease_quic_bit round-trip when enabled" {
+    const testing = std.testing;
+    var buf: [256]u8 = undefined;
+    const cid = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+    const n = try buildTransportParams(&buf, .{
+        .initial_source_cid = &cid,
+        .grease_quic_bit = true,
+    });
+    const parsed = try parseTransportParams(buf[0..n]);
+    try testing.expect(parsed.grease_quic_bit);
 }
 
 test "transport params: ack_delay_exponent above 20 is clamped to default" {

--- a/src/crypto/session.zig
+++ b/src/crypto/session.zig
@@ -302,32 +302,26 @@ pub fn deriveEarlyKeys(ticket: *const SessionTicket) EarlyDataKeys {
 // 0-RTT Anti-Replay Nonce Cache
 // ---------------------------------------------------------------------------
 
-/// 64-entry ring-buffer nonce cache for 0-RTT anti-replay (RFC 9001 §8.1).
-///
-/// Key = first 8 bytes of the PSK identity (ticket blob).  Each ticket blob
-/// is unique per issuance, so this prefix reliably distinguishes replays
-/// within the cache window.
-///
-/// Usage:
-///   if (!server.nonce_cache.checkAndInsert(key)) {
-///       // Replay detected — do not activate early keys.
-///   }
-/// Maximum age (ms) for a nonce cache entry.  Entries older than this are
-/// considered expired and silently evicted.  10 seconds covers typical
-/// 0-RTT replay windows while limiting the cache's effective memory.
+/// Maximum age (ms) for a nonce cache entry.
 const NONCE_TTL_MS: i64 = 10_000;
 
+/// 4096-entry ring-buffer nonce cache for 0-RTT anti-replay (RFC 9001 §8.1).
+/// Key = first 8 bytes of the PSK identity (ticket blob).
 pub const NonceCache = struct {
+    pub const capacity: usize = 4096;
+
     const Entry = struct {
         key: [8]u8 = .{0} ** 8,
         inserted_ms: i64 = 0,
     };
 
-    entries: [64]Entry = [_]Entry{.{}} ** 64,
-    /// Number of valid entries (saturates at 64).
+    entries: [capacity]Entry = [_]Entry{.{}} ** capacity,
+    /// Number of valid entries (saturates at capacity).
     count: usize = 0,
     /// Next write position in the ring.
     head: usize = 0,
+    /// Evictions when the ring wraps (diagnostic for undersized cache).
+    evictions: u64 = 0,
 
     /// Check whether `key` has been seen before.
     /// Returns `true` (new) if the key is fresh and inserts it.
@@ -339,16 +333,15 @@ pub const NonceCache = struct {
 
     /// Testable version that accepts an explicit timestamp.
     pub fn checkAndInsertAt(self: *NonceCache, key: [8]u8, now_ms: i64) bool {
-        const n = @min(self.count, 64);
+        const n = @min(self.count, capacity);
         for (0..n) |i| {
-            // Skip expired entries.
             if (now_ms - self.entries[i].inserted_ms > NONCE_TTL_MS) continue;
-            if (std.mem.eql(u8, &self.entries[i].key, &key)) return false; // replay
+            if (std.crypto.timing_safe.eql([8]u8, self.entries[i].key, key)) return false;
         }
-        // Fresh key — insert at head.
+        if (self.count >= capacity) self.evictions += 1;
         self.entries[self.head] = .{ .key = key, .inserted_ms = now_ms };
-        self.head = (self.head + 1) % 64;
-        if (self.count < 64) self.count += 1;
+        self.head = (self.head + 1) % capacity;
+        if (self.count < capacity) self.count += 1;
         return true;
     }
 };
@@ -486,10 +479,11 @@ test "nonce_cache: detects replay" {
 
 test "nonce_cache: ring eviction" {
     var cache = NonceCache{};
-    // Fill all 64 slots.
-    for (0..64) |i| {
+    // Fill all slots.
+    for (0..NonceCache.capacity) |i| {
         var k: [8]u8 = .{0} ** 8;
-        k[0] = @intCast(i);
+        k[0] = @intCast(i % 256);
+        k[1] = @intCast(i >> 8);
         try std.testing.expect(cache.checkAndInsert(k));
     }
     // A 65th distinct key should succeed (evicts oldest).

--- a/src/loss/congestion.zig
+++ b/src/loss/congestion.zig
@@ -14,16 +14,28 @@ const std = @import("std");
 pub const mss: u64 = 1350;
 /// Maximum congestion window (bytes).
 const max_cwnd: u64 = 64 * 1024 * 1024; // 64 MB
-/// Minimum congestion window (floor for loss-driven reductions and the
-/// persistent-congestion collapse, RFC 9002 §7.6.3).  RFC's floor is 2·MSS, but
-/// on low-RTT paths a burst of *spurious* time-threshold/reordering losses can
-/// halve cwnd down to 2·MSS and pin it there, throttling a single high-volume
-/// stream (e.g. the persistent /meshsub gossip stream) into permanent
-/// backpressure even though the path is not actually congested (flow control
-/// wide open, losses are reordering noise).  A 10·MSS floor keeps cwnd usable
-/// through that noise; it does not increase bursting (sends are still bounded by
-/// the live cwnd), only the post-loss floor.
-pub const minimum_window: u64 = 10 * mss;
+/// RFC 9002 §7.2 initial congestion window (10 × max_datagram_size, capped at 14,720).
+pub const rfc_initial_window: u64 = 14_720;
+/// RFC 9002 §7.6.3 minimum congestion window (2 × MSS).
+pub const rfc_minimum_window: u64 = 2 * mss;
+/// Libp2p/gossip-tuned initial window for bursty single-stream workloads.
+pub const aggressive_initial_window: u64 = 32 * mss;
+/// Raised post-loss floor for low-RTT spurious-reorder paths.
+pub const aggressive_minimum_window: u64 = 10 * mss;
+/// Default minimum window (RFC-compliant).
+pub const minimum_window: u64 = rfc_minimum_window;
+
+/// Tunable congestion-control limits. Embedders opt into aggressive values
+/// explicitly (e.g. libp2p gossip workloads on uncongested paths).
+pub const CcOptions = struct {
+    initial_window: u64 = rfc_initial_window,
+    minimum_window: u64 = rfc_minimum_window,
+
+    pub const aggressive: CcOptions = .{
+        .initial_window = aggressive_initial_window,
+        .minimum_window = aggressive_minimum_window,
+    };
+};
 
 pub const CcState = enum {
     slow_start,
@@ -33,10 +45,10 @@ pub const CcState = enum {
 
 /// New Reno congestion controller.
 pub const NewReno = struct {
-    /// Congestion window in bytes.  Initial window of 32·MSS (RFC 9002 §7.2
-    /// permits a larger IW on paths known to tolerate it; raised from 10·MSS so
-    /// bursty single-stream gossip has headroom before ACK-clocking dominates).
-    cwnd: u64 = 32 * mss,
+    /// Congestion window in bytes (RFC 9002 §7.2 default).
+    cwnd: u64 = rfc_initial_window,
+    /// Post-loss floor (RFC 9002 §7.6.3 default; override via `CcOptions`).
+    min_window: u64 = minimum_window,
     /// Slow start threshold.
     ssthresh: u64 = max_cwnd,
     /// Bytes in flight.
@@ -54,6 +66,10 @@ pub const NewReno = struct {
 
     pub fn init() NewReno {
         return .{};
+    }
+
+    pub fn initWithOptions(opts: CcOptions) NewReno {
+        return .{ .cwnd = opts.initial_window, .min_window = opts.minimum_window };
     }
 
     /// Called when packets are acknowledged.
@@ -97,7 +113,7 @@ pub const NewReno = struct {
         }
 
         self.end_of_recovery = largest_lost_pn;
-        self.ssthresh = @max(self.cwnd / 2, minimum_window);
+        self.ssthresh = @max(self.cwnd / 2, self.min_window);
         self.cwnd = self.ssthresh;
         self.bytes_acked_ca = 0;
         self.state = .recovery;
@@ -110,7 +126,7 @@ pub const NewReno = struct {
     /// Bytes-in-flight is left untouched — outstanding packets remain in
     /// flight until they are acked, lost, or discarded.
     pub fn onPersistentCongestion(self: *NewReno) void {
-        self.cwnd = minimum_window;
+        self.cwnd = self.min_window;
         self.state = .slow_start;
         self.bytes_acked_ca = 0;
         self.end_of_recovery = null;
@@ -147,10 +163,19 @@ pub const CongestionController = union(enum) {
     cubic: @import("cubic.zig").Cubic,
 
     pub fn init(comptime tag: std.meta.Tag(CongestionController)) CongestionController {
+        return initWithOptions(tag, .{});
+    }
+
+    pub fn initWithOptions(comptime tag: std.meta.Tag(CongestionController), opts: CcOptions) CongestionController {
         return switch (tag) {
-            .new_reno => .{ .new_reno = NewReno.init() },
-            .cubic => .{ .cubic = @import("cubic.zig").Cubic.init() },
+            .new_reno => .{ .new_reno = NewReno.initWithOptions(opts) },
+            .cubic => .{ .cubic = @import("cubic.zig").Cubic.initWithOptions(opts) },
         };
+    }
+
+    /// Aggressive CC profile for libp2p gossip workloads.
+    pub fn initAggressive(comptime tag: std.meta.Tag(CongestionController)) CongestionController {
+        return initWithOptions(tag, CcOptions.aggressive);
     }
 
     pub fn onAck(self: *CongestionController, bytes_acked: u64, largest_acked_pn: u64) void {
@@ -274,15 +299,14 @@ test "new_reno: loss triggers recovery" {
 
 test "new_reno: loss does not collapse below minimum window" {
     const testing = std.testing;
-    var cc = NewReno.init();
+    var cc = NewReno.initWithOptions(CcOptions.aggressive);
     cc.cwnd = 12 * mss;
     // Several back-to-back loss events (distinct, increasing PNs) must not pin
-    // cwnd below the floor — this is the spurious-loss collapse that wedged the
-    // gossip stream.
+    // cwnd below the aggressive floor.
     var pn: u64 = 1;
     while (pn < 8) : (pn += 1) cc.onLoss(pn);
-    try testing.expectEqual(minimum_window, cc.cwnd);
-    try testing.expect(cc.cwnd >= 10 * mss);
+    try testing.expectEqual(aggressive_minimum_window, cc.cwnd);
+    try testing.expect(cc.cwnd >= aggressive_minimum_window);
 }
 
 test "new_reno: congestion avoidance" {

--- a/src/loss/cubic.zig
+++ b/src/loss/cubic.zig
@@ -22,6 +22,14 @@ const nr = @import("congestion.zig");
 
 pub const mss: u64 = nr.mss;
 const max_cwnd: u64 = 64 * 1024 * 1024;
+/// RFC 9002 §7.2 initial congestion window (10 × max_datagram_size, capped).
+pub const rfc_initial_window: u64 = 14_720;
+/// RFC 9002 §7.6.3 minimum congestion window (2 × MSS).
+pub const rfc_minimum_window: u64 = 2 * mss;
+/// Libp2p/gossip-tuned initial window (32 × MSS) for bursty single-stream workloads.
+pub const aggressive_initial_window: u64 = 32 * mss;
+/// Raised post-loss floor for low-RTT spurious-reorder paths (10 × MSS).
+pub const aggressive_minimum_window: u64 = 10 * mss;
 
 /// CUBIC scaling constant C = 0.4.
 /// We use fixed-point: C_NUM/C_DEN = 4/10 = 0.4.
@@ -34,8 +42,10 @@ const BETA_NUM: u64 = 7;
 const BETA_DEN: u64 = 10;
 
 pub const Cubic = struct {
-    /// Congestion window in bytes.  Initial window of 32·MSS (see NewReno).
-    cwnd: u64 = 32 * mss,
+    /// Congestion window in bytes (RFC 9002 §7.2 default).
+    cwnd: u64 = rfc_initial_window,
+    /// Post-loss floor (RFC 9002 §7.6.3 default; override via `CcOptions`).
+    min_window: u64 = nr.minimum_window,
     /// Slow start threshold.
     ssthresh: u64 = max_cwnd,
     /// Bytes in flight.
@@ -44,6 +54,8 @@ pub const Cubic = struct {
     state: nr.CcState = .slow_start,
     /// W_max: window size (in MSS) at the last loss event.
     w_max: u64 = 0,
+    /// W_max from the previous congestion event (RFC 9438 §4.7 fast convergence).
+    w_max_last: u64 = 0,
     /// Epoch start: timestamp (ms) when the current congestion avoidance epoch started.
     epoch_start_ms: ?i64 = null,
     /// K: time (ms) for the cubic function to reach W_max.
@@ -60,6 +72,10 @@ pub const Cubic = struct {
 
     pub fn init() Cubic {
         return .{};
+    }
+
+    pub fn initWithOptions(opts: nr.CcOptions) Cubic {
+        return .{ .cwnd = opts.initial_window, .min_window = opts.minimum_window };
     }
 
     /// Called when packets are acknowledged. `largest_acked_pn` is the largest
@@ -155,10 +171,16 @@ pub const Cubic = struct {
         }
 
         self.end_of_recovery = largest_lost_pn;
-        // Save W_max before reducing (in MSS units).
-        self.w_max = self.cwnd / mss;
+        const cwnd_mss = self.cwnd / mss;
+        // RFC 9438 §4.7 fast convergence: when cwnd < prior W_max, scale down.
+        if (cwnd_mss < self.w_max_last) {
+            self.w_max = cwnd_mss * 17 / 20; // (1 + β) / 2 = 0.85
+        } else {
+            self.w_max = cwnd_mss;
+        }
+        self.w_max_last = self.w_max;
         // Multiplicative decrease: cwnd = cwnd × β.
-        self.ssthresh = @max(self.cwnd * BETA_NUM / BETA_DEN, nr.minimum_window);
+        self.ssthresh = @max(self.cwnd * BETA_NUM / BETA_DEN, self.min_window);
         self.cwnd = self.ssthresh;
         self.state = .recovery;
         // Reset epoch so next congestion avoidance starts fresh.
@@ -171,12 +193,13 @@ pub const Cubic = struct {
     /// Collapse to the minimum window and re-enter slow start; clear the
     /// CUBIC epoch so the next recovery starts fresh.
     pub fn onPersistentCongestion(self: *Cubic) void {
-        self.cwnd = nr.minimum_window;
+        self.cwnd = self.min_window;
         self.state = .slow_start;
         self.epoch_start_ms = null;
         self.bytes_acked_ca = 0;
         self.end_of_recovery = null;
         self.w_max = 0;
+        self.w_max_last = 0;
         self.k_ms = 0;
         self.tcp_cwnd = 0;
     }
@@ -293,6 +316,17 @@ test "cubic: integer cube root" {
     try testing.expectEqual(@as(u64, 3), intCbrt(27));
     try testing.expectEqual(@as(u64, 10), intCbrt(1000));
     try testing.expectEqual(@as(u64, 10), intCbrt(1100)); // floor
+}
+
+test "cubic: fast convergence scales W_max when cwnd drops" {
+    const testing = std.testing;
+    var cc = Cubic.init();
+    cc.cwnd = 80 * mss;
+    cc.w_max_last = 100; // prior W_max in MSS units
+    cc.onLoss(5);
+    // cwnd (80) < w_max_last (100) → W_max = 80 * 0.85 = 68
+    try testing.expectEqual(@as(u64, 68), cc.w_max);
+    try testing.expectEqual(@as(u64, 68), cc.w_max_last);
 }
 
 test "cubic: can_send check" {

--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -61,6 +61,8 @@ const k_packet_threshold: u64 = 3;
 const k_max_ack_delay_ms: u64 = 25;
 /// Granularity timer resolution in ms
 const k_granularity_ms: u64 = 1;
+/// Maximum PTO backoff exponent (RFC 9002 §6.2.1; quinn uses 16).
+pub const max_pto_backoff_exponent: u32 = 16;
 /// Persistent congestion duration multiplier (RFC 9002 §7.6.1)
 const k_persistent_congestion_threshold: u64 = 3;
 
@@ -109,9 +111,10 @@ pub const RttEstimator = struct {
 
     /// Probe Timeout (PTO) value in ms (RFC 9002 §6.2.1).
     pub fn pto_ms(self: *const RttEstimator, max_ack_delay: u64, pto_count: u32) u64 {
+        const capped = @min(pto_count, max_pto_backoff_exponent);
         const base_pto: f64 = self.srtt_ms + @max(4.0 * self.rttvar_ms, @as(f64, @floatFromInt(k_granularity_ms)));
         const with_delay: f64 = base_pto + @as(f64, @floatFromInt(max_ack_delay));
-        const scaled = with_delay * std.math.pow(f64, 2.0, @floatFromInt(pto_count));
+        const scaled = with_delay * std.math.pow(f64, 2.0, @floatFromInt(capped));
         return @intFromFloat(scaled);
     }
 
@@ -170,7 +173,9 @@ pub const SentPacket = struct {
 
 /// Loss detection state for one packet number space.
 pub const LossDetector = struct {
-    pub const max_tracked_packets: usize = 2048;
+    /// High-BDP paths can hold thousands of in-flight packets; 16 KiB slots
+    /// covers ~10 GbE × 100 ms RTT without silent loss-detection blind spots.
+    pub const max_tracked_packets: usize = 16_384;
     const max_tracked = max_tracked_packets;
 
     sent: [max_tracked]SentPacket = undefined,
@@ -205,6 +210,10 @@ pub const LossDetector = struct {
             self.sent_count += 1;
             return true;
         }
+        log.warn(
+            "recovery: in-flight tracking cap ({d}) reached — packet pn={d} not tracked",
+            .{ max_tracked, pkt.pn },
+        );
         return false;
     }
 

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -9129,6 +9129,10 @@ pub const Client = struct {
             if (pos + dlen > pt_len) break;
             const cdata = plaintext[pos .. pos + dlen];
             if (cdata.len >= 4 and cdata[0] == tls_hs.MSG_SERVER_HELLO) {
+                // Quinn retransmits ServerHello in Initial when the client
+                // stalls; re-running TLS state derivation corrupts the
+                // transcript and wedges Handshake decryption.
+                if (self.conn.has_hs_keys) continue;
                 self.tls.processServerHello(cdata) catch |err| {
                     dbg("io: processServerHello failed: {}\n", .{err});
                     return;

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -5409,9 +5409,11 @@ pub const Server = struct {
                             self.sendMaxStreams(conn, false, src);
                     }
                 }
-                // Flow control (RFC 9000 §4.1): track highest end offset seen.
-                const recv_end = sf_r.frame.offset + sf_r.frame.data.len;
-                if (recv_end > conn.fc_bytes_recv) conn.fc_bytes_recv = recv_end;
+                // Flow control (RFC 9000 §4.1): connection-level credit is the
+                // sum of payload bytes received on all streams (not the max
+                // stream end offset — parallel streams would under-count and
+                // never trigger MAX_DATA before the peer stalls).
+                conn.fc_bytes_recv +|= sf_r.frame.data.len;
                 if (conn.fc_bytes_recv > conn.fc_recv_max) {
                     // Flow control violation — close with FLOW_CONTROL_ERROR (0x03).
                     self.sendConnectionClose(conn, 0x03, "flow control violation", src);
@@ -5423,6 +5425,7 @@ pub const Server = struct {
                 // extend this stream's window before the peer exhausts it.
                 // Without this a long-lived stream (libp2p persistent /meshsub
                 // gossip) stalls at the initial per-stream limit — zquic#172.
+                const recv_end = sf_r.frame.offset + sf_r.frame.data.len;
                 const sra = conn.noteStreamRecv(sf_r.frame.stream_id, recv_end, true);
                 if (sra.violation) {
                     self.sendConnectionClose(conn, 0x03, "stream flow control violation", src);
@@ -9730,7 +9733,7 @@ pub const Client = struct {
                 // advertised (libp2p persistent /meshsub gossip) would stall.
                 // zquic#172.
                 const recv_end = sf_r.frame.offset + sf_r.frame.data.len;
-                if (recv_end > self.conn.fc_bytes_recv) self.conn.fc_bytes_recv = recv_end;
+                self.conn.fc_bytes_recv +|= sf_r.frame.data.len;
                 if (self.conn.fc_bytes_recv > self.conn.fc_recv_max) {
                     self.sendConnectionClose(0x03, "flow control violation");
                     return;

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -982,6 +982,8 @@ const PendingStreamSend = struct {
     offset: u64 = 0,
     fin: bool = false,
     data: []u8 = &.{},
+    /// Bytes already put on the wire from the front of `data`.
+    sent_in_buf: usize = 0,
 };
 // Hard caps on the per-stream `pending_stream_sends` queue.  Either limit
 // triggers `enqueuePendingStreamSend` → `false`, which the embedder MUST
@@ -1035,6 +1037,7 @@ fn enqueuePendingStreamSend(
     // zero-length sentinel slice (ptr 0xffff…, len 0), which the drain path
     // would later hand to `allocator.free` and corrupt jemalloc's per-thread
     // cache — a SIGSEGV in an unrelated later allocation.
+    // Split at packet-build time in `drainPendingStreamSends` (not here).
     if (data.len == 0) {
         // …but the half-close must still reach the peer even when this stream's
         // payload is backpressured in the queue. A large response (libp2p
@@ -1055,25 +1058,6 @@ fn enqueuePendingStreamSend(
         }
         return true;
     }
-    // Split writes larger than one 1-RTT packet into per-packet entries.
-    // `drainPendingStreamSends` serializes one entry into one datagram and
-    // CANNOT fragment — an oversized entry fails `StreamFrame.serialize` and is
-    // dropped on the floor (the data is silently lost). So a single
-    // `sendRawStreamData` of, say, a 200 KB block (libp2p reqresp
-    // `blocks_by_range`) must be fanned out into ≤ `max_pending_stream_chunk`
-    // slices here, each of which serializes into exactly one packet on drain.
-    if (data.len > max_pending_stream_chunk) {
-        var rel: usize = 0;
-        while (rel < data.len) {
-            const take = @min(data.len - rel, max_pending_stream_chunk);
-            const is_last = rel + take == data.len;
-            if (!enqueuePendingStreamSend(conn, allocator, stream_id, offset +| rel, data[rel..][0..take], fin and is_last)) {
-                return false;
-            }
-            rel += take;
-        }
-        return true;
-    }
     // Embedder may retry the same offset after a backpressure 0; treat as
     // already accepted so we do not fill the queue with duplicate copies.
     for (conn.pending_stream_sends.items) |e| {
@@ -1085,8 +1069,8 @@ fn enqueuePendingStreamSend(
     // even though total bytes stay under the 8 MiB byte cap.
     if (conn.pending_stream_sends.items.len > 0) {
         const last = &conn.pending_stream_sends.items[conn.pending_stream_sends.items.len - 1];
-        if (last.stream_id == stream_id and last.offset +| last.data.len == offset and
-            last.data.len + data.len <= max_pending_stream_chunk and !last.fin)
+        if (last.stream_id == stream_id and
+            last.offset +| (last.data.len - last.sent_in_buf) == offset and !last.fin)
         {
             if (conn.pending_stream_send_bytes +| data.len > pending_stream_send_bytes_cap) return false;
             const new_len = last.data.len + data.len;
@@ -1138,8 +1122,8 @@ fn enqueuePendingStreamSendOwned(
     }
     if (conn.pending_stream_sends.items.len > 0) {
         const last = &conn.pending_stream_sends.items[conn.pending_stream_sends.items.len - 1];
-        if (last.stream_id == stream_id and last.offset +| last.data.len == offset and
-            last.data.len + owned.len <= max_pending_stream_chunk and !last.fin)
+        if (last.stream_id == stream_id and
+            last.offset +| (last.data.len - last.sent_in_buf) == offset and !last.fin)
         {
             // Defence-in-depth: if `owned` and `last.data` alias the same
             // heap buffer, realloc would invalidate `owned`'s backing
@@ -1852,10 +1836,12 @@ pub const ConnState = struct {
     // the `.default` preset (64 MiB conn / 16 MiB stream) so an unseeded conn
     // still behaves sanely. `fc_recv_max` above is the connection-level mirror
     // and is reset to `local_initial_max_data` by the same seed.
-    local_initial_max_data: u64 = 64 * 1024 * 1024,
-    local_initial_max_stream_data_bidi_local: u64 = 16 * 1024 * 1024,
-    local_initial_max_stream_data_bidi_remote: u64 = 16 * 1024 * 1024,
-    local_initial_max_stream_data_uni: u64 = 16 * 1024 * 1024,
+    // Memory vs throughput: defaults are conservative (1 MiB conn / 256 KiB stream).
+    // Libp2p embedders should use `transport_params_preset = .libp2p` or set explicitly.
+    local_initial_max_data: u64 = 1 * 1024 * 1024,
+    local_initial_max_stream_data_bidi_local: u64 = 256 * 1024,
+    local_initial_max_stream_data_bidi_remote: u64 = 256 * 1024,
+    local_initial_max_stream_data_uni: u64 = 256 * 1024,
     /// Per-stream receive accounting (RFC 9000 §4.1). Bounded; a slot is freed
     /// on FIN / RESET_STREAM (peer is done sending) so it tracks only
     /// concurrently-open inbound streams. When full, untracked streams fall
@@ -1906,6 +1892,9 @@ pub const ConnState = struct {
     // outgoing packets are suppressed and incoming are silently discarded.
     draining: bool = false,
     conn_close_sent: bool = false,
+    /// Serialized CONNECTION_CLOSE frame for re-emission during draining (RFC 9000 §10.2.2).
+    conn_close_frame: [256]u8 = [_]u8{0} ** 256,
+    conn_close_frame_len: u8 = 0,
     draining_deadline_ms: i64 = 0,
     // Wall-clock time of the last successfully decrypted packet (ms). Used for idle timeout.
     last_recv_ms: i64 = 0,
@@ -1940,6 +1929,11 @@ pub const ConnState = struct {
     // packet match this token, the connection is treated as reset.
     stateless_reset_token: [16]u8 = [_]u8{0} ** 16,
     stateless_reset_token_set: bool = false,
+    /// RFC 9287: peer advertised `grease_quic_bit`; flip short-header bit when sending.
+    peer_grease_quic_bit: bool = false,
+    /// Throttle STREAMS_BLOCKED to one emission per cap-hit (RFC 9000 §19.14).
+    streams_blocked_bidi_sent: bool = false,
+    streams_blocked_uni_sent: bool = false,
 
     // 0-RTT early data keys (derived from PSK + ClientHello transcript hash).
     early_km: KeyMaterial = undefined,
@@ -2090,6 +2084,8 @@ pub const ConnState = struct {
         self.peer_initial_max_stream_data_bidi_local = parsed.initial_max_stream_data_bidi_local;
         self.peer_initial_max_stream_data_bidi_remote = parsed.initial_max_stream_data_bidi_remote;
         self.peer_initial_max_stream_data_uni = parsed.initial_max_stream_data_uni;
+        self.peer_max_bidi_streams = parsed.initial_max_streams_bidi;
+        self.peer_max_uni_streams = parsed.initial_max_streams_uni;
         self.peer_max_streams_bidi = parsed.initial_max_streams_bidi;
         self.peer_max_streams_uni = parsed.initial_max_streams_uni;
         self.peer_max_idle_timeout_ms = parsed.max_idle_timeout_ms;
@@ -2107,6 +2103,7 @@ pub const ConnState = struct {
             self.migration.setPreferredAddress(migrationPreferredFromTp(pa));
             dbg("io: peer advertised preferred_address (v4_port={} v6_port={} cid_len={})\n", .{ pa.ipv4_port, pa.ipv6_port, pa.connection_id_len });
         }
+        self.peer_grease_quic_bit = parsed.grease_quic_bit;
     }
 
     /// Match an incoming DCID against the alternative-CID pool.
@@ -2557,8 +2554,9 @@ fn prepareTransportConnectionClose(
     reason: []const u8,
     out: []u8,
 ) ?[]const u8 {
-    if (conn.conn_close_sent) return null;
-    conn.conn_close_sent = true;
+    if (conn.conn_close_frame_len > 0) {
+        return conn.conn_close_frame[0..conn.conn_close_frame_len];
+    }
     const frame = transport_frames.ConnectionClose{
         .is_application = false,
         .error_code = error_code,
@@ -2566,7 +2564,11 @@ fn prepareTransportConnectionClose(
         .reason_phrase = reason,
     };
     const len = frame.serialize(out) catch return null;
-    return out[0..len];
+    if (len > out.len) return null;
+    @memcpy(conn.conn_close_frame[0..len], out[0..len]);
+    conn.conn_close_frame_len = @intCast(len);
+    conn.conn_close_sent = true;
+    return conn.conn_close_frame[0..len];
 }
 
 fn enterConnDraining(conn: *ConnState) void {
@@ -2893,8 +2895,10 @@ pub const Server = struct {
     /// with `releaseRawAppStream`.  Mirrors the client-initiated open the
     /// embedder performs via `rawAllocateNextLocalBidiStream` + `sendRawStreamData`.
     pub fn openRawAppStream(self: *Server, conn: *ConnState) OpenRawAppStreamError!u64 {
-        _ = self;
-        const stream_id = try rawAllocateNextLocalBidiStream(conn);
+        const stream_id = rawAllocateNextLocalBidiStream(conn) catch |err| {
+            if (err == error.StreamLimitExceeded) self.maybeSendStreamsBlocked(conn, true, conn.peer);
+            return err;
+        };
         if (!registerRawAppRecvSlot(conn, stream_id)) {
             // No free slot — roll back the id so the next call retries the same
             // id instead of leaving a permanent hole in the §2.1 id space.
@@ -3123,76 +3127,86 @@ pub const Server = struct {
         if (conn.pending_stream_sends.items.len == 0) return;
         var i: usize = 0;
         while (i < conn.pending_stream_sends.items.len) {
-            const p = conn.pending_stream_sends.items[i];
+            const p = &conn.pending_stream_sends.items[i];
+            const unsent = p.data.len - p.sent_in_buf;
+            const chunk_len = @min(unsent, max_pending_stream_chunk);
             const stream_limit = conn.peerStreamSendLimit(p.stream_id, true);
-            if (stream_limit > 0 and p.offset +| p.data.len > stream_limit) {
+            if (stream_limit > 0 and p.offset +| chunk_len > stream_limit) {
                 i += 1;
                 continue;
             }
-            const projected: u64 = conn.fc_bytes_sent +| p.data.len;
+            const projected: u64 = conn.fc_bytes_sent +| chunk_len;
             if (projected > conn.fc_send_max) {
                 i += 1;
                 continue;
             }
-            const pace_bytes: u64 = @intCast(p.data.len);
+            const pace_bytes: u64 = @intCast(chunk_len);
             if (!connCanTransmitAppData(conn, compat.milliTimestamp(), pace_bytes)) {
                 maybeLogPendingStreamStall(conn, "server");
                 return;
             }
             const stream_id = p.stream_id;
             const offset = p.offset;
-            const fin = p.fin;
-            const buf = p.data;
-            _ = conn.pending_stream_sends.orderedRemove(i);
-            conn.pending_stream_send_bytes -|= buf.len;
-
+            const fin = p.fin and p.sent_in_buf + chunk_len == p.data.len;
+            const chunk = p.data[p.sent_in_buf .. p.sent_in_buf + chunk_len];
             const sf = stream_frame_mod.StreamFrame{
                 .stream_id = stream_id,
                 .offset = offset,
-                .data = buf,
+                .data = chunk,
                 .fin = fin,
                 .has_length = true,
             };
             var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
             const flen = sf.serialize(&frame_buf) catch {
-                self.allocator.free(buf);
+                i += 1;
                 continue;
             };
             const pn_before = conn.app_pn;
             self.send1Rtt(conn, frame_buf[0..flen], conn.peer);
-            if (conn.app_pn == pn_before) {
-                // send1Rtt suppressed (draining flipped mid-loop).  Free
-                // the buffer; any remaining entries will be freed by
-                // freeConnStateRawAppBuffers on conn reap.
-                self.allocator.free(buf);
-                return;
-            }
-            conn.fc_bytes_sent +|= buf.len;
+            if (conn.app_pn == pn_before) return;
+            conn.fc_bytes_sent +|= chunk_len;
             if (conn.ld.sent_count == 0) {
-                self.allocator.free(buf);
+                p.sent_in_buf += chunk_len;
+                p.offset += chunk_len;
+                conn.pending_stream_send_bytes -|= chunk_len;
+                if (p.sent_in_buf == p.data.len) {
+                    const buf = p.data;
+                    _ = conn.pending_stream_sends.orderedRemove(i);
+                    self.allocator.free(buf);
+                } else {
+                    i += 1;
+                }
                 continue;
             }
             const sent_pn = conn.app_pn - 1;
             const last = &conn.ld.sent[conn.ld.sent_count - 1];
             if (last.pn != sent_pn) {
-                self.allocator.free(buf);
+                i += 1;
                 continue;
             }
-            // Defence-in-depth: guard against the alias case where
-            // `old.ptr == buf.ptr` (see `sendRawStreamDataInner` for the
-            // full rationale).  Without this guard a wedged-cwnd retx
-            // path can free `buf` and then immediately store the same
-            // dangling pointer.
+            const rtx_buf = self.allocator.dupe(u8, chunk) catch {
+                i += 1;
+                continue;
+            };
             if (last.stream_data) |old| {
-                if (old.ptr != buf.ptr) self.allocator.free(old);
+                if (old.ptr != rtx_buf.ptr) self.allocator.free(old);
             }
             last.has_stream_data = true;
             last.stream_id = stream_id;
             last.stream_offset = offset;
-            last.stream_data = buf;
+            last.stream_data = rtx_buf;
             last.stream_fin = fin;
-            conn.pacerConsume(@intCast(buf.len));
-            // `orderedRemove` slid the tail down by one; the next entry is at the same index.
+            conn.pacerConsume(@intCast(chunk_len));
+            p.sent_in_buf += chunk_len;
+            p.offset += chunk_len;
+            conn.pending_stream_send_bytes -|= chunk_len;
+            if (p.sent_in_buf == p.data.len) {
+                const buf = p.data;
+                _ = conn.pending_stream_sends.orderedRemove(i);
+                self.allocator.free(buf);
+            } else {
+                i += 1;
+            }
         }
     }
 
@@ -3524,7 +3538,12 @@ pub const Server = struct {
                 conn.app_stream_chunk = pm.app_stream_chunk;
                 conn.plpmtu = path_mtu_mod.PlPmtuState.init(pm.max_udp_payload);
                 if (self.config.cubic) {
-                    conn.cc = congestion.CongestionController.init(.cubic);
+                    conn.cc = if (self.config.transport_params_preset == .libp2p)
+                        congestion.CongestionController.initAggressive(.cubic)
+                    else
+                        congestion.CongestionController.init(.cubic);
+                } else if (self.config.transport_params_preset == .libp2p) {
+                    conn.cc = congestion.CongestionController.initAggressive(.new_reno);
                 }
                 conn.deriveInitialKeys(dcid);
                 // Open qlog file named after the original destination CID (ODCID).
@@ -4735,10 +4754,53 @@ pub const Server = struct {
                 return decrypted.wire_len;
             }
         }
+        if (buf.len >= 1 + 8 and buf[0] & 0x80 == 0) {
+            self.emitStatelessReset(buf[1..9], src);
+        }
         return null;
     }
 
-    /// Trigger a local key update: rotate send keys and emit a packet with
+    fn deriveStatelessResetToken(secret: *const [32]u8, dcid: []const u8) [16]u8 {
+        var out: [32]u8 = undefined;
+        var hmac = std.crypto.auth.hmac.sha2.HmacSha256.init(secret);
+        hmac.update("stateless_reset");
+        hmac.update(dcid);
+        hmac.final(&out);
+        var token: [16]u8 = undefined;
+        @memcpy(&token, out[0..16]);
+        return token;
+    }
+
+    fn emitStatelessReset(self: *Server, dcid: []const u8, dst: compat.Address) void {
+        if (dcid.len == 0 or dcid.len > types.max_cid_len) return;
+        var pkt: [32]u8 = undefined;
+        compat.random.bytes(pkt[0 .. pkt.len - 16]);
+        pkt[0] = (pkt[0] & 0x3f) | 0x40;
+        const token = deriveStatelessResetToken(&self.retry_secret, dcid);
+        @memcpy(pkt[pkt.len - 16 ..], &token);
+        _ = compat.sendto(self.sock, &pkt, 0, &dst.any, dst.getOsSockLen()) catch {};
+    }
+
+    fn writeStreamsBlockedFrame(out: []u8, bidi: bool, maximum_streams: u64) ?usize {
+        if (out.len == 0) return null;
+        out[0] = if (bidi) @as(u8, 0x16) else @as(u8, 0x17);
+        const enc = varint.encode(out[1..], maximum_streams) catch return null;
+        return 1 + enc.len;
+    }
+
+    fn maybeSendStreamsBlocked(self: *Server, conn: *ConnState, bidi: bool, dst: compat.Address) void {
+        if (bidi) {
+            if (conn.streams_blocked_bidi_sent) return;
+            conn.streams_blocked_bidi_sent = true;
+        } else {
+            if (conn.streams_blocked_uni_sent) return;
+            conn.streams_blocked_uni_sent = true;
+        }
+        const requested = if (bidi) localBidiStreamsOpened(conn) + 1 else localUniStreamsOpened(conn) + 1;
+        var buf: [16]u8 = undefined;
+        const flen = writeStreamsBlockedFrame(&buf, bidi, requested) orelse return;
+        self.send1Rtt(conn, buf[0..flen], dst);
+    }
     /// the new key phase bit set.  Called after handshake when key_update
     /// is enabled (quic-interop-runner "keyupdate" test case).
     fn initiateKeyUpdate(self: *Server, conn: *ConnState, src: compat.Address) void {
@@ -4760,8 +4822,13 @@ pub const Server = struct {
     fn processAppFrames(self: *Server, conn: *ConnState, frames: []const u8, src: compat.Address) void {
         dbg("io: processAppFrames called: {} bytes\n", .{frames.len});
         conn.qlog.packetReceived(.one_rtt, conn.app_recv_pn orelse 0, frames.len);
-        // RFC 9000 §10.2.2: silently discard all frames while draining.
-        if (conn.draining) return;
+        // RFC 9000 §10.2.2: re-emit CONNECTION_CLOSE in response to peer packets.
+        if (conn.draining) {
+            if (conn.conn_close_frame_len > 0) {
+                self.send1Rtt(conn, conn.conn_close_frame[0..conn.conn_close_frame_len], src);
+            }
+            return;
+        }
         conn.last_recv_ms = compat.milliTimestamp();
         // Detect address change (connection migration / port rebinding, RFC 9000 §9).
         // When NS3 rebinds the client's source port (rebind-port test, every 5 s),
@@ -8015,52 +8082,41 @@ pub const Client = struct {
         if (self.conn.pending_stream_sends.items.len == 0) return;
         var i: usize = 0;
         while (i < self.conn.pending_stream_sends.items.len) {
-            const p = self.conn.pending_stream_sends.items[i];
+            const p = &self.conn.pending_stream_sends.items[i];
+            const unsent = p.data.len - p.sent_in_buf;
+            const chunk_len = @min(unsent, max_pending_stream_chunk);
             const stream_limit = self.conn.peerStreamSendLimit(p.stream_id, false);
-            if (stream_limit > 0 and p.offset +| p.data.len > stream_limit) {
+            if (stream_limit > 0 and p.offset +| chunk_len > stream_limit) {
                 i += 1;
                 continue;
             }
-            const projected: u64 = self.conn.fc_bytes_sent +| p.data.len;
+            const projected: u64 = self.conn.fc_bytes_sent +| chunk_len;
             if (projected > self.conn.fc_send_max) {
                 i += 1;
                 continue;
             }
-            const pace_bytes: u64 = @intCast(p.data.len);
+            const pace_bytes: u64 = @intCast(chunk_len);
             if (!connCanTransmitAppData(&self.conn, compat.milliTimestamp(), pace_bytes)) {
                 maybeLogPendingStreamStall(&self.conn, "client");
                 return;
             }
             const stream_id = p.stream_id;
             const offset = p.offset;
-            const fin = p.fin;
-            const buf = p.data;
-            _ = self.conn.pending_stream_sends.orderedRemove(i);
-            self.conn.pending_stream_send_bytes -|= buf.len;
-
+            const fin = p.fin and p.sent_in_buf + chunk_len == p.data.len;
+            const chunk = p.data[p.sent_in_buf .. p.sent_in_buf + chunk_len];
             const sf = stream_frame_mod.StreamFrame{
                 .stream_id = stream_id,
                 .offset = offset,
-                .data = buf,
+                .data = chunk,
                 .fin = fin,
                 .has_length = true,
             };
             var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
             const flen = sf.serialize(&frame_buf) catch {
-                self.allocator.free(buf);
+                i += 1;
                 continue;
             };
             if (!self.conn.ld.hasCapacity()) {
-                // Re-queue at the front; do not put untracked bytes on the wire.
-                self.conn.pending_stream_sends.insert(self.allocator, i, .{
-                    .stream_id = stream_id,
-                    .offset = offset,
-                    .fin = fin,
-                    .data = buf,
-                }) catch {
-                    self.allocator.free(buf);
-                };
-                self.conn.pending_stream_send_bytes +|= buf.len;
                 maybeLogPendingStreamStall(&self.conn, "client");
                 return;
             }
@@ -8074,14 +8130,18 @@ pub const Client = struct {
                 self.conn.key_phase_bit,
                 self.conn.packet_cipher,
             ) catch {
-                self.allocator.free(buf);
+                i += 1;
                 continue;
             };
             const pn = self.conn.app_pn;
             self.conn.app_pn += 1;
             _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch {};
-            self.conn.fc_bytes_sent +|= buf.len;
+            self.conn.fc_bytes_sent +|= chunk_len;
             self.conn.note1RttSent();
+            const rtx_buf = self.allocator.dupe(u8, chunk) catch {
+                i += 1;
+                continue;
+            };
             const recorded = self.conn.ld.onPacketSent(.{
                 .pn = pn,
                 .send_time_ms = @intCast(compat.milliTimestamp()),
@@ -8091,15 +8151,25 @@ pub const Client = struct {
                 .has_stream_data = true,
                 .stream_id = stream_id,
                 .stream_offset = offset,
-                .stream_data = buf,
+                .stream_data = rtx_buf,
                 .stream_fin = fin,
             });
             if (recorded) {
                 self.conn.cc.onPacketSent(@intCast(pkt_len));
                 self.conn.pacerConsume(@intCast(pkt_len));
+            } else {
+                self.allocator.free(rtx_buf);
             }
-            if (!recorded) self.allocator.free(buf);
-            // `orderedRemove` slid the tail down by one; next entry is at the same index.
+            p.sent_in_buf += chunk_len;
+            p.offset += chunk_len;
+            self.conn.pending_stream_send_bytes -|= chunk_len;
+            if (p.sent_in_buf == p.data.len) {
+                const buf = p.data;
+                _ = self.conn.pending_stream_sends.orderedRemove(i);
+                self.allocator.free(buf);
+            } else {
+                i += 1;
+            }
         }
     }
 
@@ -9288,8 +9358,25 @@ pub const Client = struct {
         self.conn.ecn_ect0_recv += 1;
         self.conn.last_recv_ms = compat.milliTimestamp();
 
-        // RFC 9000 §10.2.2: silently discard all frames while draining.
-        if (self.conn.draining) return;
+        // RFC 9000 §10.2.2: re-emit CONNECTION_CLOSE in response to peer packets.
+        if (self.conn.draining) {
+            if (self.conn.conn_close_frame_len > 0) {
+                var close_pkt: [MAX_DATAGRAM_SIZE]u8 = undefined;
+                const payload = self.conn.conn_close_frame[0..self.conn.conn_close_frame_len];
+                const pkt_len = build1RttPacketFull(
+                    &close_pkt,
+                    self.conn.remote_cid,
+                    payload,
+                    self.conn.app_pn,
+                    &self.conn.app_client_km,
+                    self.conn.key_phase_bit,
+                    self.conn.packet_cipher,
+                ) catch return;
+                self.conn.app_pn += 1;
+                _ = compat.sendto(self.sock, close_pkt[0..pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch {};
+            }
+            return;
+        }
 
         self.conn.peer_key_phase = incoming_phase;
 
@@ -10923,8 +11010,8 @@ test "per-stream recv: bumpStreamRecvWindow answers STREAM_DATA_BLOCKED" {
 test "seedLocalRecvWindows: default preset" {
     var d = makeConnForStreamTest();
     d.seedLocalRecvWindows(.default);
-    try std.testing.expectEqual(@as(u64, 16_777_216), d.local_initial_max_stream_data_bidi_local);
-    try std.testing.expectEqual(@as(u64, 67_108_864), d.fc_recv_max);
+    try std.testing.expectEqual(@as(u64, 262_144), d.local_initial_max_stream_data_bidi_local);
+    try std.testing.expectEqual(@as(u64, 1_048_576), d.fc_recv_max);
 }
 
 test "seedLocalRecvWindows: libp2p preset" {
@@ -10984,26 +11071,18 @@ test "pending stream send: cap rejects past per-conn entry budget" {
     try std.testing.expect(!enqueuePendingStreamSend(&conn, std.testing.allocator, 4, @intCast(i * 2), "x", false));
 }
 
-test "pending stream send: oversized write fans out into per-packet entries" {
+test "pending stream send: oversized write stored as single entry (split at drain)" {
     var conn = makeConnForStreamTest();
     defer freePendingStreamSends(&conn, std.testing.allocator);
-    // A write larger than one 1-RTT packet must be split into
-    // `max_pending_stream_chunk`-sized entries (each serializes into exactly
-    // one datagram on drain) — never stored as a single oversized entry, which
-    // the drain path cannot fragment and would silently drop.
+    // Large writes are kept as one queue entry; `drainPendingStreamSends`
+    // slices at packet-build time instead of fanning out on enqueue.
     const big = try std.testing.allocator.alloc(u8, max_pending_stream_chunk * 4 + 100);
     defer std.testing.allocator.free(big);
     @memset(big, 0xaa);
     try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, 0, big, true));
-    // 4 full-packet slices + 1 remainder = 5 entries, each ≤ one packet.
-    try std.testing.expectEqual(@as(usize, 5), conn.pending_stream_sends.items.len);
-    for (conn.pending_stream_sends.items) |e| {
-        try std.testing.expect(e.data.len <= max_pending_stream_chunk);
-    }
-    // Offsets are contiguous and only the final slice carries FIN.
-    try std.testing.expectEqual(@as(u64, 0), conn.pending_stream_sends.items[0].offset);
-    try std.testing.expect(conn.pending_stream_sends.items[4].fin);
-    try std.testing.expect(!conn.pending_stream_sends.items[0].fin);
+    try std.testing.expectEqual(@as(usize, 1), conn.pending_stream_sends.items.len);
+    try std.testing.expectEqual(@as(usize, big.len), conn.pending_stream_sends.items[0].data.len);
+    try std.testing.expect(conn.pending_stream_sends.items[0].fin);
 }
 
 test "AppAckTracker: adjacent ranges coalesce and serialize without integer overflow" {


### PR DESCRIPTION
## Summary

Addresses a batch of open tracker issues from the quinn gap analysis (#138):

- **#196** — Cap PTO exponential backoff at 2^16 (RFC 9002 §6.2.1)
- **#197** — Raise in-flight tracking cap to 16,384; log when overflowed
- **#198** — CUBIC fast convergence (RFC 9438 §4.7, W_max × 0.85)
- **#195** — RFC 9002 default IW/min cwnd; `CcOptions.aggressive` for libp2p preset
- **#200** — Conservative default flow-control windows (1 MiB conn / 256 KiB stream)
- **#199** — Defer STREAM frame splitting to packet-build time (`sent_in_buf` cursor)
- **#194** — Re-emit CONNECTION_CLOSE on inbound packets while draining
- **#193** — Emit stateless reset for unknown DCID short-header packets
- **#188** — Emit STREAMS_BLOCKED when local bidi stream limit is hit
- **#189 / #107** — 4096-entry 0-RTT nonce cache; timing-safe key compare
- **#190** — Advertise/parse RFC 9287 `grease_quic_bit` transport parameter

## Not in this PR (follow-ups)

Larger features still open: per-PN-space loss (#182), stream reassembly (#183), per-stream send buffer (#184), NEW_TOKEN (#185), connection stats (#186), ACK frequency (#187), STREAMS_BLOCKED client path, BBR (#192), stream priority (#191), DATAGRAMs (#181).

## Test plan

- [x] `zig build test` — 237/237 pass locally
- [ ] CI (build, test, bench-e2e, interop)