### PR TITLE
io: fix double-free of retransmit buffer on pending-queue-full (SIGSEGV under load)

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -11403,6 +11403,81 @@ test "raw-app server-initiated bidi: client receives multi-frame payload in orde
     try std.testing.expect(!lb.client.releaseRawAppStream(sid)); // idempotent
 }
 
+test "raw-app server-initiated bidi: SERVER receives a CLIENT reply on the same stream (full duplex)" {
+    // The req/resp-over-inbound path (zig-libp2p) needs the *reverse* direction
+    // of the gossip fallback: after the server opens a bidi stream and sends a
+    // request, the CLIENT must be able to reply on that same server-initiated
+    // stream and have the SERVER receive it. All prior server-initiated tests
+    // are server→client only, so this duplex direction was never covered.
+    const allocator = std.testing.allocator;
+    const client = try allocator.create(Client);
+    defer allocator.destroy(client);
+
+    const lb = try rawSetupLoopback(allocator, client);
+    defer lb.server.deinit();
+    defer lb.client.deinit();
+
+    const conn = rawServerConnectedConn(lb.server).?;
+    const sid = try lb.server.openRawAppStream(conn);
+    try std.testing.expectEqual(@as(u64, 1), sid % 4);
+
+    var drop = RawDrop{};
+
+    // 1. Server sends a request and FINs its send side — matching libp2p
+    //    req/resp (request → CloseWrite). The recv side stays open for the reply.
+    const request = "PING-FROM-SERVER";
+    {
+        var sent = false;
+        var got = false;
+        const deadline = compat.milliTimestamp() + 5_000;
+        while (compat.milliTimestamp() < deadline) {
+            if (!sent) {
+                const acc = lb.server.sendRawStreamData(conn, sid, 0, request, true);
+                if (acc > 0) sent = true;
+            }
+            rawPumpOnce(lb.server, lb.client, lb.server_addr, &drop);
+            if (lb.client.rawAppRecvBuffer(sid)) |b| {
+                if (b.len == request.len) {
+                    got = true;
+                    break;
+                }
+            }
+        }
+        try std.testing.expect(got);
+    }
+
+    // 2. Client replies in TWO frames at increasing offsets, FIN on the last —
+    //    mimics multistream-ack-then-response, the real req/resp-over-inbound
+    //    byte pattern. The SERVER must reassemble both and see the FIN.
+    const reply_a = "ACK/multistream";
+    const reply_b = "PONG-FROM-CLIENT";
+    const reply_total = reply_a.len + reply_b.len;
+    var got_reply = false;
+    {
+        var sent_a = false;
+        var sent_b = false;
+        const deadline = compat.milliTimestamp() + 5_000;
+        while (compat.milliTimestamp() < deadline) {
+            if (!sent_a) {
+                if (lb.client.sendRawStreamData(sid, 0, reply_a, false) > 0) sent_a = true;
+            } else if (!sent_b) {
+                if (lb.client.sendRawStreamData(sid, reply_a.len, reply_b, true) > 0) sent_b = true;
+            }
+            rawPumpOnce(lb.server, lb.client, lb.server_addr, &drop);
+            if (rawAppRecvBuffer(conn, sid)) |b| {
+                if (b.len == reply_total and rawAppStreamFinReceived(conn, sid)) {
+                    got_reply = true;
+                    break;
+                }
+            }
+        }
+    }
+    try std.testing.expect(got_reply);
+    const got = rawAppRecvBuffer(conn, sid).?;
+    try std.testing.expectEqualSlices(u8, reply_a, got[0..reply_a.len]);
+    try std.testing.expectEqualSlices(u8, reply_b, got[reply_a.len..]);
+}
+
 test "raw-app server-initiated bidi: bulk multi-MB transfer drains across cwnd/ACK cycles" {
     // Regression for the zeam delayed-node sync stall: a responder that writes a
     // large (multi-MB) reqresp response all at once (e.g. blocks_by_range) must

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1115,8 +1115,14 @@ fn enqueuePendingStreamSend(
 }
 
 /// Like `enqueuePendingStreamSend` but takes ownership of an already-heap
-/// `owned` buffer (loss-retransmit path).  Frees `owned` on coalesce-append
-/// or on duplicate-offset dedup.
+/// `owned` buffer (loss-retransmit path).  On a `true` return it has consumed
+/// `owned` — either stored it, or freed it (coalesce-append / duplicate-offset
+/// dedup).  On a `false` return it did NOT consume `owned`; the caller still
+/// owns the buffer and must free it (every call site does
+/// `if (!enqueuePendingStreamSendOwned(...)) allocator.free(owned)`).  Freeing
+/// `owned` on the false paths here too caused a DOUBLE-FREE → jemalloc heap
+/// corruption under sustained backpressure (pending queue full) → SIGSEGV in a
+/// later `onAck` free.
 fn enqueuePendingStreamSendOwned(
     conn: *ConnState,
     allocator: std.mem.Allocator,
@@ -1154,13 +1160,11 @@ fn enqueuePendingStreamSendOwned(
             // already returns true for any duplicate).
             if (owned.ptr != last.data.ptr) {
                 if (conn.pending_stream_send_bytes +| owned.len > pending_stream_send_bytes_cap) {
-                    allocator.free(owned);
-                    return false;
+                    return false; // caller owns `owned` on false (not consumed)
                 }
                 const new_len = last.data.len + owned.len;
                 const grown = allocator.realloc(last.data, new_len) catch {
-                    allocator.free(owned);
-                    return false;
+                    return false; // caller owns `owned`; last.data untouched
                 };
                 @memcpy(grown[last.data.len..][0..owned.len], owned);
                 allocator.free(owned);
@@ -1172,12 +1176,10 @@ fn enqueuePendingStreamSendOwned(
         }
     }
     if (conn.pending_stream_sends.items.len >= pending_stream_send_cap) {
-        allocator.free(owned);
-        return false;
+        return false; // caller owns `owned` on false (not consumed)
     }
     if (conn.pending_stream_send_bytes +| owned.len > pending_stream_send_bytes_cap) {
-        allocator.free(owned);
-        return false;
+        return false; // caller owns `owned` on false (not consumed)
     }
     conn.pending_stream_sends.append(allocator, .{
         .stream_id = stream_id,
@@ -1185,8 +1187,7 @@ fn enqueuePendingStreamSendOwned(
         .fin = fin,
         .data = owned,
     }) catch {
-        allocator.free(owned);
-        return false;
+        return false; // caller owns `owned` on false (append failed, not stored)
     };
     conn.pending_stream_send_bytes +|= owned.len;
     return true;
@@ -10982,6 +10983,32 @@ test "pending stream send: cap rejects past per-conn entry budget" {
     // draining so the embedder reconnects (silently dropping would
     // corrupt the stream offset).
     try std.testing.expect(!enqueuePendingStreamSend(&conn, std.testing.allocator, 4, @intCast(i * 2), "x", false));
+}
+
+test "pending stream send (owned): false return leaves `owned` to the caller (no double-free)" {
+    // Regression for the devnet SIGSEGV: enqueuePendingStreamSendOwned must NOT
+    // free `owned` on a false return. Every call site does
+    // `if (!enqueuePendingStreamSendOwned(...)) allocator.free(owned)`, so
+    // freeing here too double-freed under sustained backpressure (pending queue
+    // full — the exact logged condition) → jemalloc heap corruption → SIGSEGV in
+    // a later `onAck` free. std.testing.allocator panics on the double-free, so
+    // reaching the end of this test clean is the assertion.
+    const a = std.testing.allocator;
+    var conn = makeConnForStreamTest();
+    defer freePendingStreamSends(&conn, a);
+
+    // Fill to the per-conn entry cap so the next owned-enqueue hits the
+    // queue-full false path.
+    var i: usize = 0;
+    while (i < pending_stream_send_cap) : (i += 1) {
+        try std.testing.expect(enqueuePendingStreamSend(&conn, a, 4, @intCast(i * 2), "x", false));
+    }
+
+    // Exercise the OWNED variant on the full queue exactly as the callers do.
+    const owned = try a.dupe(u8, "retransmit-me");
+    const queued = enqueuePendingStreamSendOwned(&conn, a, 4, 10_000_000, owned, false);
+    try std.testing.expect(!queued); // full → false
+    if (!queued) a.free(owned); // single, correct free — NOT a double-free
 }
 
 test "pending stream send: oversized write fans out into per-packet entries" {


### PR DESCRIPTION
## Crash

Live 32-validator devnet, nodes crash-looping:
```
warning(zquic): io: client pending-stream-send queue full (4096 entries, 4882050 bytes) ... backpressure
Segmentation fault at address 0x0
  arena_dalloc_large (jemalloc)
  Allocator.zig:160 rawFree
  io.zig:9337 process1RttPacket      (← ld.onAck → freeStreamDataChecked)
  endpoint.zig:384 drive  /  runtime.zig driveLoop
```

## Root cause — double-free

`enqueuePendingStreamSendOwned` freed `owned` on **every** false-return path (queue-entry cap, byte cap, realloc/append failure, coalesce byte cap). But **all seven call sites** also free on false:
```zig
if (!enqueuePendingStreamSendOwned(...)) allocator.free(owned);
```
So when the pending-stream-send queue is full — 4096 entries / ~5 MB, only reached under sustained real-network backpressure — the retransmit buffer is freed **twice**, corrupting jemalloc's heap. The crash surfaces later as a SIGSEGV in the next `onAck` free. Unit tests and light load never fill the queue, so it only bit the live devnet.

## Fix

False-return contract is "did NOT consume `owned` — caller frees". Removed the redundant `allocator.free(owned)` from the five false paths; the true paths (coalesce-append, duplicate-offset dedup) still consume/free as before. Regression test fills the queue to cap and runs the owned-enqueue through the caller pattern under `std.testing.allocator` (panics on double-free).

Full suite: 238/238 pass; `zig fmt --check` clean.

(Branch also carries a prior test-only commit adding full-duplex server-initiated-stream coverage.)