### PR TITLE
loss: per-PN-space loss detection and PTO timers (RFC 9002 §6.2.3)

### DIFF
--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -140,6 +140,15 @@ pub const RttEstimator = struct {
     }
 };
 
+/// QUIC packet number spaces (RFC 9000 §12.3).
+pub const PacketNumberSpace = enum(u2) {
+    initial,
+    handshake,
+    application,
+};
+
+pub const pn_space_count: usize = 3;
+
 /// A record of a packet that has been sent but not yet acknowledged.
 pub const SentPacket = struct {
     pn: u64,
@@ -147,6 +156,7 @@ pub const SentPacket = struct {
     size: usize,
     ack_eliciting: bool,
     in_flight: bool,
+    space: PacketNumberSpace = .application,
     /// Stream metadata for application-layer retransmission.
     /// When `has_stream_data` is true the packet carried a STREAM frame for
     /// the given stream starting at `stream_offset`.  The loss detector
@@ -180,8 +190,20 @@ pub const LossDetector = struct {
 
     sent: [max_tracked]SentPacket = undefined,
     sent_count: usize = 0,
-    largest_acked: u64 = 0,
-    loss_time_ms: ?u64 = null,
+    largest_acked: [pn_space_count]u64 = [_]u64{0} ** pn_space_count,
+    loss_time_ms: [pn_space_count]?u64 = .{null} ** pn_space_count,
+
+    fn spaceIdx(space: PacketNumberSpace) usize {
+        return @intFromEnum(space);
+    }
+
+    /// True when this PN space still has ack-eliciting packets in flight.
+    pub fn inflightInSpace(self: *const LossDetector, space: PacketNumberSpace) bool {
+        for (self.sent[0..self.sent_count]) |p| {
+            if (p.space == space and p.ack_eliciting and p.in_flight) return true;
+        }
+        return false;
+    }
 
     /// Free any heap-owned retransmit buffers attached to in-flight packets.
     /// Caller passes the same allocator used when populating `stream_data`.
@@ -244,6 +266,7 @@ pub const LossDetector = struct {
     /// (RFC 9000 §19.3: the first range must not underflow the packet number space).
     pub fn onAck(
         self: *LossDetector,
+        space: PacketNumberSpace,
         largest_acked: u64,
         /// First ACK range from the ACK frame (RFC 9000 §19.3.1).
         /// The number of contiguous packets before `largest_acked` that are
@@ -270,12 +293,14 @@ pub const LossDetector = struct {
         // accept of packets [0..largest_acked], so we reject here.
         if (first_ack_range > largest_acked) return error.FrameEncodingError;
 
+        const sidx = spaceIdx(space);
         var rtt_updated = false;
 
-        // Update RTT sample for the largest acknowledged packet.
-        if (largest_acked > self.largest_acked) {
-            self.largest_acked = largest_acked;
+        // Update RTT sample for the largest acknowledged packet in this space.
+        if (largest_acked > self.largest_acked[sidx]) {
+            self.largest_acked[sidx] = largest_acked;
             for (self.sent[0..self.sent_count]) |p| {
+                if (p.space != space) continue;
                 if (p.pn == largest_acked) {
                     const sample = now_ms -| p.send_time_ms;
                     rtt.update(sample, ack_delay_ms);
@@ -316,6 +341,10 @@ pub const LossDetector = struct {
         var i: usize = 0;
         while (i < self.sent_count) {
             const p = self.sent[i];
+            if (p.space != space) {
+                i += 1;
+                continue;
+            }
 
             // Packet is definitively acked: within [smallest_acked .. largest_acked].
             if (p.pn >= smallest_acked and p.pn <= largest_acked) {
@@ -463,7 +492,7 @@ test "loss: packet threshold detection" {
     // Packets 0, 1, 2 are in a gap and should be detected as lost via
     // k_packet_threshold (5 >= 0+3, 1+3, 2+3).
     var lost_buf: [8]SentPacket = undefined;
-    const result = try ld.onAck(5, 0, 0, 200, &rtt, &lost_buf, testing.allocator);
+    const result = try ld.onAck(.application, 5, 0, 0, 200, &rtt, &lost_buf, testing.allocator);
     try testing.expect(result.lost_count >= 2);
 }
 
@@ -475,7 +504,7 @@ test "loss: rejects invalid first_ack_range > largest_acked" {
     // largest_acked=5, first_ack_range=10 → would underflow.
     try testing.expectError(
         error.FrameEncodingError,
-        ld.onAck(5, 10, 0, 200, &rtt, &lost_buf, testing.allocator),
+        ld.onAck(.application, 5, 10, 0, 200, &rtt, &lost_buf, testing.allocator),
     );
 }
 
@@ -495,7 +524,7 @@ test "loss: time-threshold declares old packet lost when gap < k_packet_threshol
     // Ack pn 1 at a time far enough past pn 0's send to trigger time-threshold.
     const now = 200 + loss_delay + 1;
     var lost_buf: [4]SentPacket = undefined;
-    const r = try ld.onAck(1, 0, 0, now, &rtt, &lost_buf, testing.allocator);
+    const r = try ld.onAck(.application, 1, 0, 0, now, &rtt, &lost_buf, testing.allocator);
     try testing.expectEqual(@as(usize, 1), r.lost_count);
     try testing.expectEqual(@as(u64, 0), lost_buf[0].pn);
     try testing.expect(r.largest_lost_pn != null);
@@ -528,7 +557,7 @@ test "loss: persistent congestion across spread-out losses" {
     // large enough that time-threshold also fires on 3 and 4.
     const now = t_last + 30 + rtt.loss_delay_ms() + 1;
     var lost_buf: [16]SentPacket = undefined;
-    const r = try ld.onAck(5, 0, 0, now, &rtt, &lost_buf, testing.allocator);
+    const r = try ld.onAck(.application, 5, 0, 0, now, &rtt, &lost_buf, testing.allocator);
     try testing.expect(r.lost_count >= 3);
     try testing.expect(r.persistent_congestion);
 }
@@ -557,7 +586,7 @@ test "loss: no persistent congestion when ack proves path is delivering" {
     // (largest_acked=4 ≥ 0+3) but pn 1 was acked inside the same ACK, so
     // even if a second loss were present, PC would not apply.
     var lost_buf: [8]SentPacket = undefined;
-    const r = try ld.onAck(4, 3, 0, t0 + pc_dur + 20, &rtt, &lost_buf, testing.allocator);
+    const r = try ld.onAck(.application, 4, 3, 0, t0 + pc_dur + 20, &rtt, &lost_buf, testing.allocator);
     try testing.expect(r.lost_count >= 1);
     try testing.expect(!r.persistent_congestion);
 }
@@ -622,10 +651,10 @@ test "loss: stream_data is freed on ack and transferred on loss" {
     var lost_buf: [8]SentPacket = undefined;
     // Ack pn 0 (frees buf0 internally), then ack pn 5 separately so pn 1
     // is declared lost via k_packet_threshold.
-    const r0 = try ld.onAck(0, 0, 0, 200, &rtt, &lost_buf, a);
+    const r0 = try ld.onAck(.application, 0, 0, 0, 200, &rtt, &lost_buf, a);
     try testing.expectEqual(@as(usize, 0), r0.lost_count);
 
-    const r1 = try ld.onAck(5, 0, 0, 200, &rtt, &lost_buf, a);
+    const r1 = try ld.onAck(.application, 5, 0, 0, 200, &rtt, &lost_buf, a);
     try testing.expect(r1.lost_count >= 1);
     // Find the lost descriptor that owns the heap slice.
     var saw_transfer = false;
@@ -726,7 +755,7 @@ test "loss: stream_data ownership survives adversarial send/ack/retransmit churn
         const largest = top -| rand.uintLessThan(u64, 3);
         const first_range = @min(range, largest);
 
-        const r = ld.onAck(largest, first_range, 0, now, &rtt, &lost_buf, a) catch {
+        const r = ld.onAck(.application, largest, first_range, 0, now, &rtt, &lost_buf, a) catch {
             continue;
         };
 
@@ -745,7 +774,7 @@ test "loss: stream_data ownership survives adversarial send/ack/retransmit churn
         // the time-threshold loss path, exercising large single-ACK losses.
         if (iter % 4096 == 0 and ld.sent_count > 0) {
             now += 10_000;
-            const flush = ld.onAck(next_pn -| 1, 0, 0, now, &rtt, &lost_buf, a) catch continue;
+            const flush = ld.onAck(.application, next_pn -| 1, 0, 0, now, &rtt, &lost_buf, a) catch continue;
             var fi: usize = 0;
             while (fi < flush.lost_count) : (fi += 1) {
                 if (lost_buf[fi].stream_data) |sbuf| a.free(sbuf);
@@ -754,4 +783,21 @@ test "loss: stream_data ownership survives adversarial send/ack/retransmit churn
     }
     // ld.deinit frees any stream_data still tracked — testing.allocator will
     // flag a leak if the ownership accounting dropped a buffer.
+}
+
+test "loss: per-PN-space ACK only affects matching space" {
+    const testing = std.testing;
+    var ld = LossDetector{};
+    var rtt = RttEstimator{};
+
+    _ = ld.onPacketSent(.{ .pn = 0, .send_time_ms = 190, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .handshake });
+    _ = ld.onPacketSent(.{ .pn = 0, .send_time_ms = 195, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .application });
+    _ = ld.onPacketSent(.{ .pn = 1, .send_time_ms = 196, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .application });
+
+    var lost_buf: [8]SentPacket = undefined;
+    const r = try ld.onAck(.application, 1, 1, 0, 200, &rtt, &lost_buf, testing.allocator);
+    try testing.expectEqual(@as(usize, 0), r.lost_count);
+    try testing.expectEqual(@as(usize, 1), ld.sent_count);
+    try testing.expectEqual(PacketNumberSpace.handshake, ld.sent[0].space);
+    try testing.expectEqual(@as(u64, 0), ld.sent[0].pn);
 }

--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -205,6 +205,26 @@ pub const LossDetector = struct {
         return false;
     }
 
+    /// Stop tracking in-flight packets in a PN space (RFC 9001: Initial/Handshake
+    /// keys are discarded once the handshake completes).
+    pub fn abandonSpace(self: *LossDetector, space: PacketNumberSpace, allocator: std.mem.Allocator) void {
+        var i: usize = 0;
+        while (i < self.sent_count) {
+            if (self.sent[i].space == space) {
+                if (self.sent[i].stream_data) |sd| {
+                    _ = freeStreamDataChecked(allocator, sd, self.sent[i].pn, self.sent[i].stream_id);
+                }
+                self.sent[i] = self.sent[self.sent_count - 1];
+                self.sent_count -= 1;
+            } else {
+                i += 1;
+            }
+        }
+        const sidx = spaceIdx(space);
+        self.largest_acked[sidx] = 0;
+        self.loss_time_ms[sidx] = null;
+    }
+
     /// Free any heap-owned retransmit buffers attached to in-flight packets.
     /// Caller passes the same allocator used when populating `stream_data`.
     pub fn deinit(self: *LossDetector, allocator: std.mem.Allocator) void {
@@ -800,4 +820,20 @@ test "loss: per-PN-space ACK only affects matching space" {
     try testing.expectEqual(@as(usize, 1), ld.sent_count);
     try testing.expectEqual(PacketNumberSpace.handshake, ld.sent[0].space);
     try testing.expectEqual(@as(u64, 0), ld.sent[0].pn);
+}
+
+test "loss: abandonSpace drops only the targeted PN space" {
+    const testing = std.testing;
+    var ld = LossDetector{};
+    _ = ld.onPacketSent(.{ .pn = 0, .send_time_ms = 100, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .initial });
+    _ = ld.onPacketSent(.{ .pn = 1, .send_time_ms = 110, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .handshake });
+    _ = ld.onPacketSent(.{ .pn = 2, .send_time_ms = 120, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .application });
+    ld.abandonSpace(.initial, testing.allocator);
+    ld.abandonSpace(.handshake, testing.allocator);
+    try testing.expectEqual(@as(usize, 1), ld.sent_count);
+    try testing.expectEqual(PacketNumberSpace.application, ld.sent[0].space);
+    try testing.expectEqual(@as(u64, 2), ld.sent[0].pn);
+    try testing.expect(!ld.inflightInSpace(.initial));
+    try testing.expect(!ld.inflightInSpace(.handshake));
+    try testing.expect(ld.inflightInSpace(.application));
 }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1213,6 +1213,30 @@ fn connTransmitBlock(conn: *ConnState, bytes: u64) ?TransmitBlock {
     return null;
 }
 
+fn noteConnAckInSpace(conn: *ConnState, space: recovery.PacketNumberSpace, now_ms: i64) void {
+    const idx = @intFromEnum(space);
+    conn.last_ack_ms_by_space[idx] = now_ms;
+    if (now_ms > conn.last_ack_ms) conn.last_ack_ms = now_ms;
+    conn.pto_count[idx] = 0;
+}
+
+fn recordAckElicitingSent(
+    conn: *ConnState,
+    space: recovery.PacketNumberSpace,
+    pn: u64,
+    pkt_len: usize,
+    now_ms: u64,
+) void {
+    _ = conn.ld.onPacketSent(.{
+        .pn = pn,
+        .send_time_ms = now_ms,
+        .size = pkt_len,
+        .ack_eliciting = true,
+        .in_flight = true,
+        .space = space,
+    });
+}
+
 /// Quinn `poll_transmit` gates on cwnd, pacing, and tracked-packet capacity.
 /// `bytes` is the application payload size; we cap the pacer-credit check at
 /// one MSS because each call site ultimately emits at most one MTU-sized
@@ -1922,13 +1946,13 @@ pub const ConnState = struct {
     draining_deadline_ms: i64 = 0,
     // Wall-clock time of the last successfully decrypted packet (ms). Used for idle timeout.
     last_recv_ms: i64 = 0,
-    // PTO (Probe Timeout) state (RFC 9002 §6.2).
-    // last_ack_ms: wall-clock time of the most recent ACK frame we processed.
-    // pto_count:   exponential-backoff multiplier (doubles each consecutive probe).
-    // last_pto_ms: wall-clock time we last sent a PTO probe packet.
+    // PTO (Probe Timeout) state per packet-number space (RFC 9002 §6.2.3).
+    // last_ack_ms: wall-clock time of the most recent ACK in any space (idle timeout).
+    // last_ack_ms_by_space / pto_count / last_pto_ms: per-space PTO accounting.
     last_ack_ms: i64 = 0,
-    pto_count: u32 = 0,
-    last_pto_ms: i64 = 0,
+    last_ack_ms_by_space: [recovery.pn_space_count]i64 = .{0} ** recovery.pn_space_count,
+    pto_count: [recovery.pn_space_count]u32 = .{0} ** recovery.pn_space_count,
+    last_pto_ms: [recovery.pn_space_count]i64 = .{0} ** recovery.pn_space_count,
     /// Wall-clock time we last sent a keepalive PING (independent from
     /// `last_pto_ms` so a keepalive does not poison PTO backoff math).
     /// Drives [`Server.checkPto`] / [`Client.checkPto`] keepalive emission
@@ -4234,6 +4258,7 @@ pub const Server = struct {
             const init_pn_sent = conn.init_pn;
             conn.init_pn += 1;
             conn.migration.anti_amp.onSent(pkt_len);
+            recordAckElicitingSent(conn, .initial, init_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
             coalesced_len = pkt_len;
             conn.qlog.packetSent(.initial, init_pn_sent, pkt_len);
         }
@@ -4275,6 +4300,7 @@ pub const Server = struct {
                 conn.qlog.packetSent(.handshake, hs_pn_sent, pkt_len);
                 conn.hs_pn += 1;
                 conn.migration.anti_amp.onSent(pkt_len);
+                recordAckElicitingSent(conn, .handshake, hs_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
                 coalesced_len += pkt_len;
                 offset += chunk_len;
             }
@@ -4361,6 +4387,7 @@ pub const Server = struct {
         const init_pn_sent = conn.init_pn;
         conn.init_pn += 1;
         conn.migration.anti_amp.onSent(pkt_len);
+        recordAckElicitingSent(conn, .initial, init_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
         conn.qlog.packetSent(.initial, init_pn_sent, pkt_len);
 
         conn.init_resend.store(send_buf[0..pkt_len]);
@@ -4419,6 +4446,7 @@ pub const Server = struct {
 
             conn.hs_pn += 1;
             conn.migration.anti_amp.onSent(pkt_len);
+            recordAckElicitingSent(conn, .handshake, hs_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
             conn.qlog.packetSent(.handshake, hs_pn_sent, pkt_len);
 
             if (conn.hs_resend_count < max_server_flight_resend_datagrams) {
@@ -4525,8 +4553,40 @@ pub const Server = struct {
                 fpos += dlen;
             } else if (plaintext[fpos] == 0x02 or plaintext[fpos] == 0x03) {
                 const is_ecn = plaintext[fpos] == 0x03;
-                fpos += 1;
-                if (fpos > pt_len) break;
+                var ack_pos: usize = fpos + 1;
+                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch break;
+                ack_pos += lar_r.len;
+                const largest_ack = lar_r.value;
+                const del_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += del_r.len;
+                const ack_delay = del_r.value;
+                const cnt_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += cnt_r.len;
+                const fst_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
+                    continue;
+                };
+                const first_ack_range = fst_r.value;
+                var lost_buf: [32]recovery.SentPacket = undefined;
+                const now_ms: i64 = compat.milliTimestamp();
+                if (conn.ld.onAck(
+                    .handshake,
+                    largest_ack,
+                    first_ack_range,
+                    ack_delay,
+                    @intCast(now_ms),
+                    &conn.rtt,
+                    &lost_buf,
+                    self.allocator,
+                )) |_| {
+                    noteConnAckInSpace(conn, .handshake, now_ms);
+                } else |_| {}
                 fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                 continue;
             } else {
@@ -5032,6 +5092,7 @@ pub const Server = struct {
                 // distinguish acked packets from those in gaps.
                 var lost_buf: [32]recovery.SentPacket = undefined;
                 const ld_result = conn.ld.onAck(
+                    .application,
                     largest_ack,
                     first_ack_range,
                     ack_delay,
@@ -5219,8 +5280,7 @@ pub const Server = struct {
                 }
                 // ACK received — reset PTO backoff counter and record timestamp
                 // (RFC 9002 §6.2.1: PTO resets when an ACK is received).
-                conn.last_ack_ms = compat.milliTimestamp();
-                conn.pto_count = 0;
+                noteConnAckInSpace(conn, .application, compat.milliTimestamp());
                 pos += skipAckBody(frames[pos..], ft == 0x03);
                 continue;
             }
@@ -5590,6 +5650,7 @@ pub const Server = struct {
             .size = pkt_len,
             .ack_eliciting = true,
             .in_flight = true,
+            .space = .application,
         });
         // Congestion control: only count the packet toward bytes_in_flight when
         // the loss detector is tracking it.  An untracked packet can never be
@@ -5831,19 +5892,69 @@ pub const Server = struct {
     ///   2. bytes_in_flight is corrected, unblocking subsequent data sends.
     ///
     /// The pto_count field provides exponential back-off (PTO doubles each probe).
+    fn sendPtoProbeInSpace(self: *Server, conn: *ConnState, space: recovery.PacketNumberSpace, dst: compat.Address) bool {
+        return switch (space) {
+            .application => blk: {
+                if (!conn.has_app_keys) break :blk false;
+                const ping_frame = [_]u8{0x01};
+                self.send1Rtt(conn, &ping_frame, dst);
+                break :blk true;
+            },
+            .handshake => self.sendHandshakePtoProbe(conn, dst),
+            .initial => self.sendInitialPtoProbe(conn, dst),
+        };
+    }
+
+    fn sendHandshakePtoProbe(self: *Server, conn: *ConnState, dst: compat.Address) bool {
+        if (!conn.has_hs_keys) return false;
+        var send_buf: [256]u8 = undefined;
+        const ping = [_]u8{0x01};
+        const hs_pn_sent = conn.hs_pn;
+        const pkt_len = buildHandshakePacket(
+            &send_buf,
+            conn.remote_cid,
+            conn.local_cid,
+            &ping,
+            hs_pn_sent,
+            &conn.hs_server_km,
+            conn.quicVersion(),
+            conn.packet_cipher,
+        ) catch return false;
+        conn.hs_pn += 1;
+        recordAckElicitingSent(conn, .handshake, hs_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
+        _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &dst.any, dst.getOsSockLen()) catch return false;
+        return true;
+    }
+
+    fn sendInitialPtoProbe(self: *Server, conn: *ConnState, dst: compat.Address) bool {
+        const init_km = conn.init_keys orelse return false;
+        var send_buf: [256]u8 = undefined;
+        const ping = [_]u8{0x01};
+        const init_pn_sent = conn.init_pn;
+        const pkt_len = buildInitialPacket(
+            &send_buf,
+            conn.remote_cid,
+            conn.local_cid,
+            &.{},
+            &ping,
+            init_pn_sent,
+            &init_km.server,
+            conn.quicVersion(),
+        ) catch return false;
+        conn.init_pn += 1;
+        recordAckElicitingSent(conn, .initial, init_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
+        _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &dst.any, dst.getOsSockLen()) catch return false;
+        return true;
+    }
+
     fn checkPto(self: *Server) void {
         const now_ms = compat.milliTimestamp();
         for (&self.conns) |*cslot| {
             const conn = if (cslot.*) |c| c else continue;
-            if (!conn.has_app_keys) continue;
             if (conn.draining) continue;
-            // Safety net: drain any flow-control-deferred application
-            // STREAM bytes whose MAX_DATA / MAX_STREAM_DATA arrived while
-            // we were not in `process1RttPacket` (e.g. the credit grew
-            // due to local recv-window advertising as our peer consumes
-            // — a tick boundary catches it without waiting for the next
-            // explicit credit-update frame).
-            self.drainPendingStreamSendsUntilStalled(conn);
+            if (conn.has_app_keys) {
+                self.drainPendingStreamSendsUntilStalled(conn);
+            }
 
             // Effective idle timeout used by branches 2 and 3: the smaller of
             // our 30s local default and the peer-advertised max_idle_timeout
@@ -5907,26 +6018,30 @@ pub const Server = struct {
                 }
             }
 
-            // Branch 1: PTO probe (RFC 9002 §6.2). Only when we have unACKed
-            // packets in flight and the smoothed-RTT-derived PTO deadline
-            // has passed since the last ACK we processed.
-            pto_block: {
-                if (conn.cc.getBytesInFlight() == 0) break :pto_block;
-                if (conn.last_ack_ms == 0) break :pto_block;
-                const pto_delay: i64 = @intCast(conn.rtt.pto_ms(conn.peer_max_ack_delay_ms, conn.pto_count));
-                const elapsed_since_ack: i64 = now_ms - conn.last_ack_ms;
-                const elapsed_since_last_probe: i64 = now_ms - conn.last_pto_ms;
+            // Branch 1: per-space PTO probes (RFC 9002 §6.2.3).
+            var pto_fired = false;
+            const pto_spaces = [_]recovery.PacketNumberSpace{ .initial, .handshake, .application };
+            for (pto_spaces) |space| {
+                const idx = @intFromEnum(space);
+                if (!conn.ld.inflightInSpace(space)) continue;
+                const ack_ms = conn.last_ack_ms_by_space[idx];
+                if (ack_ms == 0) continue;
+                const pto_delay: i64 = @intCast(conn.rtt.pto_ms(conn.peer_max_ack_delay_ms, conn.pto_count[idx]));
+                const elapsed_since_ack: i64 = now_ms - ack_ms;
+                const elapsed_since_last_probe: i64 = now_ms - conn.last_pto_ms[idx];
                 if (elapsed_since_ack > pto_delay and elapsed_since_last_probe > pto_delay) {
-                    const ping_frame = [_]u8{0x01};
-                    self.send1Rtt(conn, &ping_frame, conn.peer);
-                    conn.last_pto_ms = now_ms;
-                    conn.pto_count +|= 1;
-                    dbg("io: PTO probe sent pn={} pto_count={} pto_delay={}ms bif={}\n", .{
-                        conn.app_pn - 1, conn.pto_count, pto_delay, conn.cc.getBytesInFlight(),
-                    });
-                    continue;
+                    if (self.sendPtoProbeInSpace(conn, space, conn.peer)) {
+                        conn.last_pto_ms[idx] = now_ms;
+                        conn.pto_count[idx] +|= 1;
+                        dbg("io: PTO probe sent space={s} pto_count={} pto_delay={}ms bif={}\n", .{
+                            @tagName(space), conn.pto_count[idx], pto_delay, conn.cc.getBytesInFlight(),
+                        });
+                        pto_fired = true;
+                        break;
+                    }
                 }
             }
+            if (pto_fired) continue;
 
             // Branch 2: keepalive PING (RFC 9000 §10.1.2). When we have nothing
             // in flight to drive PTO but the peer is also quiet, we must elicit
@@ -5938,6 +6053,7 @@ pub const Server = struct {
             // effective idle timeout (min of local and peer) and triggers at
             // half that, leaving a full PTO worth of slack for the ACK to
             // arrive before the peer would timeout.
+            if (!conn.has_app_keys) continue;
             if (conn.last_ack_ms == 0) {
                 // No ACK ever seen — branch 2 requires one as a sanity baseline
                 // so it does not trip mid-handshake.
@@ -7938,6 +8054,7 @@ pub const Client = struct {
             .size = pkt_len,
             .ack_eliciting = true,
             .in_flight = true,
+            .space = .application,
         });
         if (tracked) self.conn.cc.onPacketSent(@intCast(pkt_len));
         return pn;
@@ -8200,6 +8317,7 @@ pub const Client = struct {
             .stream_offset = offset,
             .stream_data = buf,
             .stream_fin = fin,
+            .space = .application,
         });
         // Mirror Server.send1Rtt: only count toward bytes_in_flight when the
         // loss detector is tracking the packet.  Without this, checkPto
@@ -8300,6 +8418,7 @@ pub const Client = struct {
                 .stream_offset = offset,
                 .stream_data = rtx_buf,
                 .stream_fin = fin,
+                .space = .application,
             });
             if (recorded) {
                 self.conn.cc.onPacketSent(@intCast(pkt_len));
@@ -8360,14 +8479,61 @@ pub const Client = struct {
     /// quiet has no way to recover any tail packet that was dropped — the
     /// k_packet_threshold loss detector requires a *later* ACK to fire, and
     /// none arrives in an idle conversation.
+    fn sendClientPtoProbeInSpace(self: *Client, space: recovery.PacketNumberSpace) bool {
+        return switch (space) {
+            .application => self.sendOnePingFrame(),
+            .handshake => self.sendClientHandshakePtoProbe(),
+            .initial => self.sendClientInitialPtoProbe(),
+        };
+    }
+
+    fn sendClientHandshakePtoProbe(self: *Client) bool {
+        if (!self.conn.has_hs_keys) return false;
+        var send_buf: [256]u8 = undefined;
+        const ping = [_]u8{0x01};
+        const hs_pn_sent = self.conn.hs_pn;
+        const pkt_len = buildHandshakePacket(
+            &send_buf,
+            self.conn.remote_cid,
+            self.conn.local_cid,
+            &ping,
+            hs_pn_sent,
+            &self.conn.hs_client_km,
+            self.conn.quicVersion(),
+            self.conn.packet_cipher,
+        ) catch return false;
+        self.conn.hs_pn += 1;
+        recordAckElicitingSent(&self.conn, .handshake, hs_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
+        _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch return false;
+        return true;
+    }
+
+    fn sendClientInitialPtoProbe(self: *Client) bool {
+        const init_km = self.conn.init_keys orelse return false;
+        var send_buf: [256]u8 = undefined;
+        const ping = [_]u8{0x01};
+        const init_pn_sent = self.conn.init_pn;
+        const pkt_len = buildInitialPacket(
+            &send_buf,
+            self.conn.remote_cid,
+            self.conn.local_cid,
+            &.{},
+            &ping,
+            init_pn_sent,
+            &init_km.client,
+            self.conn.quicVersion(),
+        ) catch return false;
+        self.conn.init_pn += 1;
+        recordAckElicitingSent(&self.conn, .initial, init_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
+        _ = compat.sendto(self.sock, send_buf[0..pkt_len], 0, &self.conn.peer.any, self.conn.peer.getOsSockLen()) catch return false;
+        return true;
+    }
+
     fn checkPto(self: *Client) void {
-        if (self.conn.phase != .connected) return;
         if (self.conn.draining) return;
-        // Safety net: drain any flow-control-deferred application STREAM
-        // bytes (see Server.checkPto for the rationale).  Done before the
-        // PTO branches so the drained packets count toward bytes_in_flight
-        // when the loss detector evaluates them.
-        self.drainPendingStreamSendsUntilStalled();
+        if (self.conn.phase == .connected) {
+            self.drainPendingStreamSendsUntilStalled();
+        }
         // Need at least one prior ACK before either branch runs so the RTT
         // estimate is meaningful and we have evidence the peer is responsive.
         if (self.conn.last_ack_ms == 0) return;
@@ -8418,22 +8584,28 @@ pub const Client = struct {
             return;
         }
 
-        // Branch 1: PTO probe (RFC 9002 §6.2). Only when we have unACKed
-        // bytes in flight; otherwise there is nothing to recover.
-        if (self.conn.cc.getBytesInFlight() > 0) {
-            const pto_delay: i64 = @intCast(self.conn.rtt.pto_ms(self.conn.peer_max_ack_delay_ms, self.conn.pto_count));
-            const elapsed_since_last_probe: i64 = now_ms - self.conn.last_pto_ms;
-            if (elapsed_since_ack > pto_delay and elapsed_since_last_probe > pto_delay) {
-                if (self.sendOnePingFrame()) {
-                    self.conn.last_pto_ms = now_ms;
-                    self.conn.pto_count +|= 1;
-                    dbg("io: client PTO probe sent pto_count={} pto_delay={}ms bif={}\n", .{
-                        self.conn.pto_count, pto_delay, self.conn.cc.getBytesInFlight(),
+        const pto_spaces = [_]recovery.PacketNumberSpace{ .initial, .handshake, .application };
+        for (pto_spaces) |space| {
+            const idx = @intFromEnum(space);
+            if (!self.conn.ld.inflightInSpace(space)) continue;
+            const ack_ms = self.conn.last_ack_ms_by_space[idx];
+            if (ack_ms == 0) continue;
+            const pto_delay: i64 = @intCast(self.conn.rtt.pto_ms(self.conn.peer_max_ack_delay_ms, self.conn.pto_count[idx]));
+            const elapsed_since_space_ack: i64 = now_ms - ack_ms;
+            const elapsed_since_last_probe: i64 = now_ms - self.conn.last_pto_ms[idx];
+            if (elapsed_since_space_ack > pto_delay and elapsed_since_last_probe > pto_delay) {
+                if (self.sendClientPtoProbeInSpace(space)) {
+                    self.conn.last_pto_ms[idx] = now_ms;
+                    self.conn.pto_count[idx] +|= 1;
+                    dbg("io: client PTO probe sent space={s} pto_count={} pto_delay={}ms bif={}\n", .{
+                        @tagName(space), self.conn.pto_count[idx], pto_delay, self.conn.cc.getBytesInFlight(),
                     });
+                    return;
                 }
-                return;
             }
         }
+
+        if (self.conn.phase != .connected) return;
 
         // Branch 2: keepalive PING (RFC 9000 §10.1.2). Even when nothing is
         // in flight, send a PING every `max_idle_timeout / 2` so the peer's
@@ -8964,7 +9136,9 @@ pub const Client = struct {
             buildPaddingFrames(frame_buf[payload_len .. payload_len + add], add);
             payload_len += add;
         }
+        const init_pn_sent = self.conn.init_pn;
         self.conn.init_pn += 1;
+        recordAckElicitingSent(&self.conn, .initial, init_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
         self.initial_pkt_len = pkt_len;
 
         _ = try compat.sendto(self.sock, self.initial_pkt[0..pkt_len], 0, &server.any, server.getOsSockLen());
@@ -9339,8 +9513,40 @@ pub const Client = struct {
             }
             if (plaintext[fpos] == 0x02 or plaintext[fpos] == 0x03) {
                 const is_ecn = plaintext[fpos] == 0x03;
-                fpos += 1;
-                if (fpos > pt_len) break;
+                var ack_pos: usize = fpos + 1;
+                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch break;
+                ack_pos += lar_r.len;
+                const largest_ack = lar_r.value;
+                const del_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += del_r.len;
+                const ack_delay = del_r.value;
+                const cnt_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += cnt_r.len;
+                const fst_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
+                    continue;
+                };
+                const first_ack_range = fst_r.value;
+                var lost_buf: [32]recovery.SentPacket = undefined;
+                const now_ms: i64 = compat.milliTimestamp();
+                if (self.conn.ld.onAck(
+                    .handshake,
+                    largest_ack,
+                    first_ack_range,
+                    ack_delay,
+                    @intCast(now_ms),
+                    &self.conn.rtt,
+                    &lost_buf,
+                    self.allocator,
+                )) |_| {
+                    noteConnAckInSpace(&self.conn, .handshake, now_ms);
+                } else |_| {}
                 fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                 continue;
             }
@@ -9428,6 +9634,7 @@ pub const Client = struct {
                 self.conn.packet_cipher,
             ) catch return;
             self.conn.hs_pn += 1;
+            recordAckElicitingSent(&self.conn, .handshake, hs_pn_sent, pkt_len, @intCast(compat.milliTimestamp()));
             self.conn.qlog.packetSent(.handshake, hs_pn_sent, pkt_len);
 
             _ = compat.sendto(
@@ -9575,6 +9782,7 @@ pub const Client = struct {
 
                 var lost_buf: [32]recovery.SentPacket = undefined;
                 const ld_result = self.conn.ld.onAck(
+                    .application,
                     largest_ack,
                     first_ack_range,
                     ack_delay,
@@ -9659,8 +9867,7 @@ pub const Client = struct {
                 // ACK received — reset PTO backoff counter and record timestamp
                 // (RFC 9002 §6.2.1: PTO resets when an ACK is received).
                 // Mirrors the server-side bookkeeping at the matching ACK arm.
-                self.conn.last_ack_ms = compat.milliTimestamp();
-                self.conn.pto_count = 0;
+                noteConnAckInSpace(&self.conn, .application, compat.milliTimestamp());
                 pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
                 continue;
             }
@@ -11470,13 +11677,14 @@ test "client 1-RTT send: loss detector and CC bytes_in_flight stay coupled" {
         .size = pkt_len,
         .ack_eliciting = true,
         .in_flight = true,
+        .space = .application,
     });
     if (recorded) conn.cc.onPacketSent(@intCast(pkt_len));
     try std.testing.expect(recorded);
     try std.testing.expectEqual(@as(u64, @intCast(pkt_len)), conn.cc.getBytesInFlight());
 
     var lost_buf: [8]recovery.SentPacket = undefined;
-    const ld_result = try conn.ld.onAck(pn, 0, 0, 1000, &conn.rtt, &lost_buf, std.testing.allocator);
+    const ld_result = try conn.ld.onAck(.application, pn, 0, 0, 1000, &conn.rtt, &lost_buf, std.testing.allocator);
     if (ld_result.bytes_acked > 0) conn.cc.onAck(ld_result.bytes_acked, pn);
     try std.testing.expectEqual(@as(u64, 0), conn.cc.getBytesInFlight());
 }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -3763,8 +3763,48 @@ pub const Server = struct {
             }
             if (plaintext[pos] == 0x02 or plaintext[pos] == 0x03) {
                 const is_ecn = plaintext[pos] == 0x03;
+                var ack_pos: usize = pos + 1;
+                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += 1;
+                    pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += lar_r.len;
+                const largest_ack = lar_r.value;
+                const del_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += 1;
+                    pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += del_r.len;
+                const ack_delay = del_r.value;
+                const cnt_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += 1;
+                    pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += cnt_r.len;
+                const fst_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += 1;
+                    pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
+                    continue;
+                };
+                const first_ack_range = fst_r.value;
+                var lost_buf: [32]recovery.SentPacket = undefined;
+                const now_ms: i64 = compat.milliTimestamp();
+                if (conn.ld.onAck(
+                    .initial,
+                    largest_ack,
+                    first_ack_range,
+                    ack_delay,
+                    @intCast(now_ms),
+                    &conn.rtt,
+                    &lost_buf,
+                    self.allocator,
+                )) |_| {
+                    noteConnAckInSpace(conn, .initial, now_ms);
+                } else |_| {}
                 pos += 1;
-                if (pos > pt_len) break;
                 pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
                 continue;
             }
@@ -4554,21 +4594,28 @@ pub const Server = struct {
             } else if (plaintext[fpos] == 0x02 or plaintext[fpos] == 0x03) {
                 const is_ecn = plaintext[fpos] == 0x03;
                 var ack_pos: usize = fpos + 1;
-                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch break;
+                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += 1;
+                    fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
+                    continue;
+                };
                 ack_pos += lar_r.len;
                 const largest_ack = lar_r.value;
                 const del_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += 1;
                     fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                     continue;
                 };
                 ack_pos += del_r.len;
                 const ack_delay = del_r.value;
                 const cnt_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += 1;
                     fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                     continue;
                 };
                 ack_pos += cnt_r.len;
                 const fst_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += 1;
                     fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                     continue;
                 };
@@ -4587,6 +4634,7 @@ pub const Server = struct {
                 )) |_| {
                     noteConnAckInSpace(conn, .handshake, now_ms);
                 } else |_| {}
+                fpos += 1;
                 fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                 continue;
             } else {
@@ -9416,29 +9464,51 @@ pub const Client = struct {
                 pos += 1;
                 continue;
             }
-            if (ft == 0x02 or ft == 0x03) { // ACK — parse and skip
-                pos += 1; // type byte
-                const lar = varint.decode(plaintext[pos..]) catch break;
-                pos += lar.len;
-                const del = varint.decode(plaintext[pos..]) catch break;
-                pos += del.len;
-                const cnt = varint.decode(plaintext[pos..]) catch break;
-                pos += cnt.len;
-                const fst = varint.decode(plaintext[pos..]) catch break;
-                pos += fst.len;
-                var ri: u64 = 0;
-                while (ri < cnt.value) : (ri += 1) {
-                    const gp = varint.decode(plaintext[pos..]) catch break;
-                    pos += gp.len;
-                    const rl = varint.decode(plaintext[pos..]) catch break;
-                    pos += rl.len;
-                }
-                if (ft == 0x03) { // ECN counts (3 varints)
-                    inline for (0..3) |_| {
-                        const ec = varint.decode(plaintext[pos..]) catch break;
-                        pos += ec.len;
-                    }
-                }
+            if (ft == 0x02 or ft == 0x03) {
+                const is_ecn = ft == 0x03;
+                var ack_pos: usize = pos + 1;
+                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += 1;
+                    pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += lar_r.len;
+                const largest_ack = lar_r.value;
+                const del_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += 1;
+                    pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += del_r.len;
+                const ack_delay = del_r.value;
+                const cnt_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += 1;
+                    pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
+                    continue;
+                };
+                ack_pos += cnt_r.len;
+                const fst_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    pos += 1;
+                    pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
+                    continue;
+                };
+                const first_ack_range = fst_r.value;
+                var lost_buf: [32]recovery.SentPacket = undefined;
+                const now_ms: i64 = compat.milliTimestamp();
+                if (self.conn.ld.onAck(
+                    .initial,
+                    largest_ack,
+                    first_ack_range,
+                    ack_delay,
+                    @intCast(now_ms),
+                    &self.conn.rtt,
+                    &lost_buf,
+                    self.allocator,
+                )) |_| {
+                    noteConnAckInSpace(&self.conn, .initial, now_ms);
+                } else |_| {}
+                pos += 1;
+                pos += skipAckBody(plaintext[pos..pt_len], is_ecn);
                 continue;
             }
             if (ft != 0x06) break; // not a CRYPTO frame — stop
@@ -9514,21 +9584,28 @@ pub const Client = struct {
             if (plaintext[fpos] == 0x02 or plaintext[fpos] == 0x03) {
                 const is_ecn = plaintext[fpos] == 0x03;
                 var ack_pos: usize = fpos + 1;
-                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch break;
+                const lar_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += 1;
+                    fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
+                    continue;
+                };
                 ack_pos += lar_r.len;
                 const largest_ack = lar_r.value;
                 const del_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += 1;
                     fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                     continue;
                 };
                 ack_pos += del_r.len;
                 const ack_delay = del_r.value;
                 const cnt_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += 1;
                     fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                     continue;
                 };
                 ack_pos += cnt_r.len;
                 const fst_r = varint.decode(plaintext[ack_pos..pt_len]) catch {
+                    fpos += 1;
                     fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                     continue;
                 };
@@ -9547,6 +9624,7 @@ pub const Client = struct {
                 )) |_| {
                     noteConnAckInSpace(&self.conn, .handshake, now_ms);
                 } else |_| {}
+                fpos += 1;
                 fpos += skipAckBody(plaintext[fpos..pt_len], is_ecn);
                 continue;
             }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1237,6 +1237,20 @@ fn recordAckElicitingSent(
     });
 }
 
+/// RFC 9001 §4.9.1: Initial and Handshake PN spaces are abandoned once 1-RTT
+/// keys are available.  Drop any stale in-flight tracking so PTO does not probe
+/// discarded spaces during application data transfer.
+fn abandonEarlyPnSpaces(conn: *ConnState, allocator: std.mem.Allocator) void {
+    conn.ld.abandonSpace(.initial, allocator);
+    conn.ld.abandonSpace(.handshake, allocator);
+    conn.last_ack_ms_by_space[@intFromEnum(recovery.PacketNumberSpace.initial)] = 0;
+    conn.last_ack_ms_by_space[@intFromEnum(recovery.PacketNumberSpace.handshake)] = 0;
+    conn.pto_count[@intFromEnum(recovery.PacketNumberSpace.initial)] = 0;
+    conn.pto_count[@intFromEnum(recovery.PacketNumberSpace.handshake)] = 0;
+    conn.last_pto_ms[@intFromEnum(recovery.PacketNumberSpace.initial)] = 0;
+    conn.last_pto_ms[@intFromEnum(recovery.PacketNumberSpace.handshake)] = 0;
+}
+
 /// Quinn `poll_transmit` gates on cwnd, pacing, and tracked-packet capacity.
 /// `bytes` is the application payload size; we cap the pacer-credit check at
 /// one MSS because each call site ultimately emits at most one MTU-sized
@@ -4653,6 +4667,7 @@ pub const Server = struct {
 
         dbg("io: handshake complete for connection\n", .{});
         conn.phase = .connected;
+        abandonEarlyPnSpaces(conn, self.allocator);
         // Handshake complete → peer address is validated (RFC 9000 §8.1).
         conn.address_validated = true;
         conn.migration.trustActivePath();
@@ -6043,7 +6058,7 @@ pub const Server = struct {
             // The branch logs `log.warn` (not `dbg`) so the wedge is visible
             // in release builds — previously the fire was only observable
             // with `-Dverbose=true`, which masked the bug entirely.
-            if (conn.last_ack_ms != 0) {
+            if (conn.has_app_keys and conn.last_ack_ms != 0) {
                 const elapsed_since_ack_lost: i64 = now_ms - conn.last_ack_ms;
                 const lost_threshold_ms: i64 = @intCast(@max(idle_ms_u64 * 2, @as(u64, 60_000)));
                 const has_substantial_data_stuck =
@@ -6068,8 +6083,11 @@ pub const Server = struct {
 
             // Branch 1: per-space PTO probes (RFC 9002 §6.2.3).
             var pto_fired = false;
-            const pto_spaces = [_]recovery.PacketNumberSpace{ .initial, .handshake, .application };
-            for (pto_spaces) |space| {
+            const pto_space_list: []const recovery.PacketNumberSpace = if (conn.has_app_keys)
+                &[_]recovery.PacketNumberSpace{.application}
+            else
+                &[_]recovery.PacketNumberSpace{ .initial, .handshake };
+            for (pto_space_list) |space| {
                 const idx = @intFromEnum(space);
                 if (!conn.ld.inflightInSpace(space)) continue;
                 const ack_ms = conn.last_ack_ms_by_space[idx];
@@ -8617,7 +8635,9 @@ pub const Client = struct {
             self.conn.cc.getBytesInFlight() >= 1024 or
             self.conn.ld.sent_count >= recovery.LossDetector.max_tracked_packets / 4 or
             self.conn.pending_stream_sends.items.len > 0;
-        if (elapsed_since_ack >= lost_threshold_ms and has_substantial_data_stuck) {
+        if (self.conn.phase == .connected and
+            elapsed_since_ack >= lost_threshold_ms and has_substantial_data_stuck)
+        {
             log.warn("io: client declaring connection lost (no ACK for {}ms >= {}ms, bif={}, ld={}/{}, pending={}); marking draining", .{
                 elapsed_since_ack,
                 lost_threshold_ms,
@@ -8632,8 +8652,11 @@ pub const Client = struct {
             return;
         }
 
-        const pto_spaces = [_]recovery.PacketNumberSpace{ .initial, .handshake, .application };
-        for (pto_spaces) |space| {
+        const pto_space_list: []const recovery.PacketNumberSpace = if (self.conn.has_app_keys)
+            &[_]recovery.PacketNumberSpace{.application}
+        else
+            &[_]recovery.PacketNumberSpace{ .initial, .handshake };
+        for (pto_space_list) |space| {
             const idx = @intFromEnum(space);
             if (!self.conn.ld.inflightInSpace(space)) continue;
             const ack_ms = self.conn.last_ack_ms_by_space[idx];
@@ -9952,6 +9975,7 @@ pub const Client = struct {
             if (ft == 0x1e) { // HANDSHAKE_DONE
                 dbg("io: client received HANDSHAKE_DONE\n", .{});
                 self.conn.phase = .connected;
+                abandonEarlyPnSpaces(&self.conn, self.allocator);
                 if (self.config.keylog_path) |kpath| {
                     writeKeylog(kpath, self.tls.client_random, &self.tls.secrets);
                 }


### PR DESCRIPTION
## Summary
- Add `PacketNumberSpace` tagging on `SentPacket`; `onAck` filters by space with per-space `largest_acked` / `loss_time_ms`.
- Replace single `pto_count` / `last_pto_ms` with per-space arrays on `ConnState`; `checkPto` evaluates each space independently and sends probes in the matching PN space (Initial / Handshake / Application).
- Track Initial and Handshake sends in the loss detector; process Handshake-space ACK frames on server and client.

Closes #182.

## Test plan
- [x] `zig build test` — 245/245 pass locally
- [x] New unit test: per-space ACK isolation in `recovery.zig`
- [ ] CI interop matrix green