### PR TITLE
transport: implement NEW_TOKEN issuance and replay (#185)

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -37,6 +37,7 @@ pub const transport = struct {
     pub const endpoint = @import("transport/endpoint.zig");
     pub const flow_control = @import("transport/flow_control.zig");
     pub const stream_manager = @import("transport/stream_manager.zig");
+    pub const session_token = @import("transport/session_token.zig");
     pub const migration = @import("transport/migration.zig");
     pub const io = @import("transport/io.zig");
     pub const path_mtu = @import("transport/path_mtu.zig");
@@ -82,6 +83,7 @@ test {
     _ = @import("transport/endpoint.zig");
     _ = @import("transport/flow_control.zig");
     _ = @import("transport/stream_manager.zig");
+    _ = @import("transport/session_token.zig");
     _ = @import("transport/migration.zig");
     _ = @import("transport/raw_app_stream.zig");
     _ = @import("transport/io.zig");

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -43,6 +43,7 @@ const batch_io = @import("batch_io.zig");
 const path_mtu_mod = @import("path_mtu.zig");
 const migration_mod = @import("migration.zig");
 const raw_app_stream = @import("raw_app_stream.zig");
+const session_token_mod = @import("session_token.zig");
 const default_conn_path_mtu = path_mtu_mod.initFromConfig(null);
 
 /// Locally-initiate a key update after this many 1-RTT packets (RFC 9001 §6).
@@ -1757,6 +1758,8 @@ pub const ConnState = struct {
     // Retry token (set when server sends Retry; included in next Initial)
     retry_token: [64]u8 = [_]u8{0} ** 64,
     retry_token_len: usize = 0,
+    /// Server: whether a NEW_TOKEN frame was sent post-handshake (RFC 9000 §8.1).
+    new_token_sent: bool = false,
 
     // original_destination_connection_id (RFC 9000 §7.3): set on the server
     // when a valid Retry token is accepted.  Included in server transport params
@@ -2771,6 +2774,8 @@ pub const Server = struct {
     retry_secret_prev: [32]u8 = [_]u8{0} ** 32,
     retry_secret_prev_valid: bool = false,
     retry_secret_last_rotate_ms: i64 = 0,
+    /// Replay detection for NEW_TOKEN address-validation tokens (RFC 9000 §8.1.3).
+    token_replay_log: session_token_mod.ReplayLog = .{},
     /// (Removed: was a 50ms pacing gate. CC-based rate-limiting is now sufficient.)
     /// Pacing timestamp for http09RetransmitPendingFins: at most one burst per 50ms.
     http09_retransmit_last_ms: i64 = 0,
@@ -3677,14 +3682,34 @@ pub const Server = struct {
 
         // Retry mode: if enabled and no valid token, send Retry and drop.
         // An empty token means this is the first Initial (pre-Retry); a non-empty
-        // token must pass HMAC verification before the handshake proceeds.
+        // token must pass Retry HMAC or NEW_TOKEN verification before proceeding.
         var verified_odcid: ?[]const u8 = null;
+        var session_token_valid = false;
+        const prev_secret: ?*const [32]u8 = if (self.retry_secret_prev_valid) &self.retry_secret_prev else null;
         if (self.config.retry_enabled) {
             verified_odcid = self.verifyRetryToken(ip.token);
             if (verified_odcid == null) {
-                self.sendRetry(ip.dcid.slice(), ip.scid.slice(), src, pkt_version);
-                return;
+                if (ip.token.len > 0) {
+                    session_token_valid = session_token_mod.verifyAndRecord(
+                        &self.token_replay_log,
+                        ip.token,
+                        &self.retry_secret,
+                        prev_secret,
+                    );
+                }
+                if (!session_token_valid) {
+                    self.sendRetry(ip.dcid.slice(), ip.scid.slice(), src, pkt_version);
+                    return;
+                }
             }
+        } else if (ip.token.len > 0) {
+            session_token_valid = session_token_mod.verifyAndRecord(
+                &self.token_replay_log,
+                ip.token,
+                &self.retry_secret,
+                prev_secret,
+            );
+            // RFC 9000 §8.1.3: an invalid token is ignored; handshake continues.
         }
 
         // Find or create connection.
@@ -3724,8 +3749,8 @@ pub const Server = struct {
 
         // Anti-amplification (RFC 9000 §8.1): track received bytes.
         conn.migration.anti_amp.onRecv(buf.len);
-        // If Retry was accepted, the address is already validated.
-        if (verified_odcid != null) conn.address_validated = true;
+        // Retry or NEW_TOKEN accepted → address already validated.
+        if (verified_odcid != null or session_token_valid) conn.address_validated = true;
         self.tryFlushDeferredServerSend(conn, src);
 
         if (conn.init_keys == null) conn.deriveInitialKeys(ip.dcid);
@@ -4687,6 +4712,7 @@ pub const Server = struct {
         // HANDSHAKE_DONE so quinn sees stream credit before opening ~2000 streams.
         self.sendHandshakeAck(conn, src);
         self.sendHandshakeDone(conn, src);
+        self.sendNewToken(conn, src);
         self.send_batch.flush(self.sock);
 
         // Initiate a key update immediately after the handshake if enabled.
@@ -4827,6 +4853,18 @@ pub const Server = struct {
         }
 
         self.send1Rtt(conn, frames_buf[0..fp], src);
+    }
+
+    /// Issue one NEW_TOKEN frame after the handshake (RFC 9000 §8.1).
+    fn sendNewToken(self: *Server, conn: *ConnState, dst: compat.Address) void {
+        if (conn.new_token_sent or !conn.has_app_keys) return;
+        self.maybeRotateRetrySecret();
+        var token: [session_token_mod.token_len]u8 = undefined;
+        session_token_mod.mint(&token, &self.retry_secret);
+        var frame_buf: [64]u8 = undefined;
+        const frame_len = session_token_mod.serializeFrame(&token, &frame_buf) catch return;
+        self.send1Rtt(conn, frame_buf[0..frame_len], dst);
+        conn.new_token_sent = true;
     }
 
     fn process1RttPacket(self: *Server, buf: []const u8, src: compat.Address) void {
@@ -9984,6 +10022,15 @@ pub const Client = struct {
                 if (self.config.key_update) {
                     self.initiateClientKeyUpdate();
                 }
+                continue;
+            }
+            if (ft == 0x07) {
+                const r = transport_frames.NewToken.parse(plaintext[pos..pt_len]) catch return;
+                pos += r.consumed;
+                const tlen = @min(r.frame.token.len, self.conn.retry_token.len);
+                @memcpy(self.conn.retry_token[0..tlen], r.frame.token[0..tlen]);
+                self.conn.retry_token_len = tlen;
+                dbg("io: client stored NEW_TOKEN len={}\n", .{tlen});
                 continue;
             }
             if (ft == 0x06) {

--- a/src/transport/session_token.zig
+++ b/src/transport/session_token.zig
@@ -1,0 +1,145 @@
+//! NEW_TOKEN session tokens (RFC 9000 §8.1.3 / §19.7).
+//!
+//! Opaque address-validation tokens issued post-handshake, distinct from Retry
+//! tokens (which embed the original DCID).  Format:
+//!   [0]     magic 0xFF (Retry tokens use odcid_len ≤ 20, never 0xFF)
+//!   [1..8]  mint timestamp, ms since epoch, big-endian i64
+//!   [9..16] random nonce
+//!   [17..48] HMAC-SHA256(secret, "zquic-nt" || timestamp || nonce)
+
+const std = @import("std");
+const compat = @import("../compat.zig");
+const varint = @import("../varint.zig");
+
+pub const magic: u8 = 0xff;
+pub const token_len: usize = 49;
+pub const ttl_ms: i64 = 24 * 60 * 60 * 1000;
+const domain_label = "zquic-nt";
+
+pub const ReplayLog = struct {
+    const capacity: usize = 64;
+
+    fingerprints: [capacity][32]u8 = undefined,
+    count: usize = 0,
+
+    fn fingerprint(token: []const u8) [32]u8 {
+        var out: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(token, &out, .{});
+        return out;
+    }
+
+    pub fn contains(self: *const ReplayLog, token: []const u8) bool {
+        const fp = fingerprint(token);
+        const n = @min(self.count, capacity);
+        for (self.fingerprints[0..n]) |entry| {
+            if (std.crypto.timing_safe.eql([32]u8, entry, fp)) return true;
+        }
+        return false;
+    }
+
+    pub fn record(self: *ReplayLog, token: []const u8) void {
+        const fp = fingerprint(token);
+        if (self.count < capacity) {
+            self.fingerprints[self.count] = fp;
+            self.count += 1;
+        } else {
+            var i: usize = 1;
+            while (i < capacity) : (i += 1) {
+                self.fingerprints[i - 1] = self.fingerprints[i];
+            }
+            self.fingerprints[capacity - 1] = fp;
+        }
+    }
+};
+
+fn sessionHmac(key: *const [32]u8, ts_bytes: []const u8, nonce: []const u8) [32]u8 {
+    var hmac = std.crypto.auth.hmac.sha2.HmacSha256.init(key);
+    hmac.update(domain_label);
+    hmac.update(ts_bytes);
+    hmac.update(nonce);
+    var mac: [32]u8 = undefined;
+    hmac.final(&mac);
+    return mac;
+}
+
+/// Mint a NEW_TOKEN payload into `out` (exactly `token_len` bytes).
+pub fn mint(out: *[token_len]u8, secret: *const [32]u8) void {
+    out[0] = magic;
+    const ts_ms: i64 = @intCast(compat.milliTimestamp());
+    std.mem.writeInt(i64, out[1..][0..8], ts_ms, .big);
+    var nonce: [8]u8 = undefined;
+    compat.random.bytes(&nonce);
+    @memcpy(out[9..][0..8], &nonce);
+    const mac = sessionHmac(secret, out[1..][0..8], &nonce);
+    @memcpy(out[17..][0..32], &mac);
+}
+
+fn macValid(token: []const u8, secret: *const [32]u8) bool {
+    if (token.len != token_len or token[0] != magic) return false;
+    const ts_bytes = token[1..][0..8];
+    const nonce = token[9..][0..8];
+    const received_mac = token[17..][0..32];
+    const expected = sessionHmac(secret, ts_bytes, nonce);
+    var received: [32]u8 = undefined;
+    @memcpy(&received, received_mac);
+    return std.crypto.timing_safe.eql([32]u8, received, expected);
+}
+
+/// Validate token MAC, freshness, and replay log. Records on success.
+pub fn verifyAndRecord(
+    log: *ReplayLog,
+    token: []const u8,
+    secret: *const [32]u8,
+    prev_secret: ?*const [32]u8,
+) bool {
+    if (token.len != token_len or token[0] != magic) return false;
+    if (log.contains(token)) return false;
+
+    var ok = macValid(token, secret);
+    if (!ok) {
+        if (prev_secret) |prev| ok = macValid(token, prev);
+    }
+    if (!ok) return false;
+
+    const minted_ms = std.mem.readInt(i64, token[1..][0..8], .big);
+    const now_ms = compat.milliTimestamp();
+    const age_ms = now_ms - minted_ms;
+    if (age_ms < 0 or age_ms > ttl_ms) return false;
+
+    log.record(token);
+    return true;
+}
+
+/// Serialize a NEW_TOKEN frame (type 0x07) into `buf`.
+pub fn serializeFrame(token: []const u8, buf: []u8) !usize {
+    var w = varint.Writer.init(buf);
+    try w.writeVarint(0x07);
+    try w.writeVarint(token.len);
+    try w.writeBytes(token);
+    return w.pos;
+}
+
+test "session_token: mint and verify" {
+    const testing = std.testing;
+    var secret: [32]u8 = undefined;
+    @memset(&secret, 0x42);
+    var token: [token_len]u8 = undefined;
+    mint(&token, &secret);
+
+    var log: ReplayLog = .{};
+    try testing.expect(verifyAndRecord(&log, &token, &secret, null));
+    try testing.expect(log.contains(&token));
+    try testing.expect(!verifyAndRecord(&log, &token, &secret, null));
+}
+
+test "session_token: serialize frame" {
+    const testing = std.testing;
+    var secret: [32]u8 = undefined;
+    @memset(&secret, 0x11);
+    var token: [token_len]u8 = undefined;
+    mint(&token, &secret);
+    var buf: [64]u8 = undefined;
+    const n = try serializeFrame(&token, &buf);
+    try testing.expectEqual(@as(u8, 0x07), buf[0]);
+    try testing.expect(n > token_len);
+}


### PR DESCRIPTION
## Summary
- Add `session_token.zig` with HMAC-minted NEW_TOKEN payloads (distinct from Retry tokens via magic byte `0xFF`), 24h TTL, and a replay ring.
- Server: verify NEW_TOKEN on Initial (skips Retry when valid), issue one NEW_TOKEN frame after handshake completes.
- Client: store received NEW_TOKEN in `retry_token` for inclusion on the next connection's Initial.

Closes #185.

## Test plan
- [x] `zig fmt --check .`
- [x] `zig build test` (254 tests)
- [ ] CI interop (quic-interop-runner)