### PR TITLE
shadow: add -Dshadow=true build flag for Shadow simulator support (#216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zquic
 
-Pure-Zig QUIC (RFC 9000 / 9001 / 9002), TLS 1.3, HTTP/3, and QPACK. Current release: **[v1.6.10](https://github.com/ch4r10t33r/zquic/releases/tag/v1.6.10)**.
+Pure-Zig QUIC (RFC 9000 / 9001 / 9002), TLS 1.3, HTTP/3, and QPACK. Current release: **[v1.7.48](https://github.com/ch4r10t33r/zquic/releases/tag/v1.7.48)**.
 
 [![CI](https://github.com/ch4r10t33r/zquic/actions/workflows/ci.yml/badge.svg)](https://github.com/ch4r10t33r/zquic/actions/workflows/ci.yml)
 
@@ -20,9 +20,15 @@ Import as a package dependency (`build.zig.zon`):
 
 ```zig
 .zquic = .{
-    .url = "git+https://github.com/ch4r10t33r/zquic.git?ref=v1.6.10#3f8c8669758bbe57da72017b5db5fd30863e8369",
-    .hash = "zquic-1.6.10-2zRc1Il1EwC1WAXVszicLjgivbbHOM8b0yQgvdNYwEyb",
+    .url = "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.7.48.tar.gz",
+    .hash = "zquic-1.7.0-2zRc1PSAFgDCESpm-vZsUr4O02HM0dpzmVJSx5WXW6ES",
 },
+```
+
+Or fetch the latest tag automatically:
+
+```sh
+zig fetch --save "https://github.com/ch4r10t33r/zquic/archive/refs/tags/v1.7.48.tar.gz"
 ```
 
 See [CHANGELOG.md](CHANGELOG.md) for release notes. Tags publish Linux amd64 binaries via `.github/workflows/release.yml`.
@@ -44,7 +50,7 @@ All standard QUIC frame types, flow control, migration, key update, 0-RTT/resump
 
 **zquic ↔ zquic:** all 13 [quic-interop-runner](https://github.com/quic-interop/quic-interop-runner) cases pass on CI (`handshake`, `transfer`, `retry`, `chacha20`, `keyupdate`, `resumption`, `zerortt`, `http3`, `connectionmigration`, `multiplexing`, `v2`, `ecn`, `rebind-port`).
 
-**Cross-impl (quinn, etc.):** handshake and transfer smoke runs on every PR; the full matrix runs nightly via `.github/workflows/interop-cross-impl.yml`. Recent work (#162) fixed quinn→zquic HTTP/0.9 multiplexing under paced congestion control.
+**Cross-impl (quinn ↔ zquic):** per-commit CI runs the P0 subset (`handshake`, `transfer` in both directions plus `multiplexing(zquic→quinn)`); the full matrix runs nightly via `.github/workflows/interop-cross-impl.yml` and reclassifies the known capability gaps (HTTP/3, 0-RTT, session resumption, key update, Retry, ChaCha20, port rebinding, quinn-driven multiplexing) as `UNSUPPORTED` rather than failed — see `EXPECTED_UNSUPPORTED` in that workflow for the current list. Recent quinn-interop hardening: `transfer(cross-zquic-quinn)` flow-control regression (#201), per-PN-space loss detector with RFC 9001 §4.9 Initial/Handshake abandonment (#211), CONNECTION_CLOSE retransmission during draining (#194), stateless reset emission with rate-limit + 41-byte trigger floor (#206), NEW_TOKEN issuance + replay (#213).
 
 Local interop:
 
@@ -53,6 +59,23 @@ zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux-gnu
 docker build -t zquic:interop -f interop/Dockerfile.prebuilt .
 # then run quic-interop-runner against zquic:interop
 ```
+
+## Shadow simulator (`-Dshadow=true`)
+
+zquic builds for the [Shadow network simulator](https://shadow.github.io/), which gives deterministic, bit-exact replays of multi-peer scenarios — no NIC variance, no scheduler jitter. Shadow's shim intercepts at the libc layer via `LD_PRELOAD`, so the default pure-Zig Linux build (raw `std.os.linux.*` syscalls, no libc) is invisible to it; the `-Dshadow=true` flag fixes that:
+
+```sh
+zig build -Dtarget=x86_64-linux-gnu -Dshadow=true -Doptimize=ReleaseSafe
+file zig-out/bin/server   # → dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2
+```
+
+What changes under `-Dshadow=true`:
+
+- `link_libc = true` on Linux — dynamically linked against glibc so the Shadow shim can inject.
+- `compat.zig`'s `clock_gettime` and `getrandom` route through libc (gated on `!builtin.link_libc`) so Shadow's virtual clock + deterministic randomness apply.
+- `transport/batch_io.zig` disables the `sendmmsg(2)`/`recvmmsg(2)` batched path and falls back to per-message `sendto`/`recvfrom` (Shadow's shim doesn't virtualize the batched syscalls).
+
+See [docs/shadow.md](docs/shadow.md) for a minimal `shadow.yaml` and the known limitations. The default no-libc Linux build is unaffected.
 
 ## Embedder API
 
@@ -65,10 +88,14 @@ The stack is built for [quic-interop-runner](https://github.com/quic-interop/qui
 | External UDP loop | `Server.feedPacket`, `Client.feedPacket`, `processPendingWork` |
 | Pre-bound socket | `Server.initFromSocket`, `Client.initFromSocket` |
 | Heap-allocated client | `Client.initInPlace` (avoids stack-sized return copies in downstream callers) |
-| Open/send on streams | `rawAllocateNextLocal*Stream`, `sendRawStreamData` |
+| Open client-initiated streams | `rawAllocateNextLocalBidiStream` / `rawAllocateNextLocalUniStream` (emit `STREAMS_BLOCKED` on cap-hit, #188 / #205) |
+| Open server-initiated streams | `Server.openRawAppStream` (libp2p gossip-over-any-connection, #171) |
+| Send / FIN on streams | `sendRawStreamData` (now splits at packet-build time via `sent_in_buf` cursor, #199) |
 | In-memory TLS certs | `cert_pem` / `key_pem` / `client_cert_pem` / `client_key_pem` on config structs (#129) |
+| Congestion-control profile | `CcOptions.aggressive` opts into the libp2p-tuned 32·MSS IW / 10·MSS floor; default tracks RFC 9002 §7.2 / §7.6.3 (#195) |
+| Conn capacity | `MAX_CONNECTIONS = 256`, boxed (quinn-style slab) — heap cost scales with active conns, not the cap (#209) |
 
-Demo `Endpoint` / interop `Server` use small fixed connection arrays (`max_connections` 8 / `MAX_CONNECTIONS` 16) to stay stack-friendly in tests. Production embedders should heap-size their own connection tables via `initFromSocket` + `feedPacket`.
+Demo `Endpoint` uses a small fixed connection array (`max_connections` 8) to stay stack-friendly in tests. Production embedders should still heap-size their own connection tables via `initFromSocket` + `feedPacket` for unbounded scale.
 
 ## Layout
 
@@ -91,8 +118,17 @@ Varint encoding is re-exported from the shared [`zig-varint`](https://github.com
 
 ## Platform notes
 
-- **Linux:** statically linked release binaries; syscalls via `std.os.linux`, no OpenSSL/quictls.
-- **macOS:** links `libSystem` (required for supported syscalls and code signing); source remains pure Zig.
+- **Linux (default):** statically linked release binaries; syscalls via `std.os.linux`, no OpenSSL/quictls, no libc.
+- **Linux (`-Dshadow=true`):** dynamically linked against glibc with libc-mediated syscalls so the [Shadow simulator](#shadow-simulator--dshadowtrue)'s shim can inject. See [docs/shadow.md](docs/shadow.md).
+- **macOS:** links `libSystem` (Darwin has no stable syscall ABI); source remains pure Zig.
+
+## Open work
+
+A standing quinn-vs-zquic gap analysis tracks remaining capability deltas:
+
+- **Tracker:** [#138](https://github.com/ch4r10t33r/zquic/issues/138) (closed sub-issues linked from the comment thread).
+- **Open at v1.7.48:** RFC 9221 unreliable datagrams (#181), per-stream send buffer abstraction (#184), connection statistics expansion (#186), `ACK_FREQUENCY` extension (#187), stream priority API (#191), BBR congestion controller (#192).
+- **Shadow simulator support:** Phase 1 (build flag, syscall routing, batched-I/O fallback) tracked in #216 — Phase 2 (Docker image + CI matrix) is the next step.
 
 ## License
 

--- a/build.zig
+++ b/build.zig
@@ -4,21 +4,32 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const verbose = b.option(bool, "verbose", "Enable verbose debug output") orelse false;
+    // Shadow simulator (https://shadow.github.io) intercepts at the libc layer
+    // via LD_PRELOAD; it cannot inject into the default pure-Zig Linux build
+    // which uses raw `std.os.linux.*` syscalls and links no libc. When
+    // -Dshadow=true, force libc linkage on Linux so `compat.zig` routes time /
+    // random / network calls through libc, and disable the `sendmmsg(2)` /
+    // `recvmmsg(2)` batched-I/O path (Shadow's shim only handles single-syscall
+    // I/O). See `docs/shadow.md` and #216.
+    const shadow = b.option(bool, "shadow", "Build for the Shadow network simulator (forces libc on Linux, disables batched I/O)") orelse false;
 
     // src/compat.zig restores the std-library bits that 0.16 deleted by
     // dispatching directly to raw syscalls on Linux (no libc) and to libc on
     // Darwin (where there is no stable kernel ABI).  Apple platforms must
     // therefore link libc; Linux deliberately does not, keeping zquic a
-    // pure-Zig binary on that target.
+    // pure-Zig binary on that target. The `-Dshadow=true` build flag overrides
+    // the Linux branch to link libc (Shadow's shim requires it).
     const tag = target.result.os.tag;
     const needs_libc: bool = switch (tag) {
         .macos, .ios, .tvos, .watchos, .visionos, .driverkit => true,
+        .linux => shadow,
         else => false,
     };
 
     // Build-options module (verbose flag accessible as @import("build_options").verbose)
     const opts = b.addOptions();
     opts.addOption(bool, "verbose", verbose);
+    opts.addOption(bool, "shadow", shadow);
 
     // src/compat.zig calls libc directly (getaddrinfo, gettimeofday,
     // arc4random_buf/getrandom, …) for the std-library replacements that were

--- a/docs/shadow.md
+++ b/docs/shadow.md
@@ -1,0 +1,94 @@
+# Running zquic under the Shadow network simulator
+
+[Shadow](https://shadow.github.io/) is a discrete-event network simulator
+widely used by the Tor project and (increasingly) by QUIC implementations for
+**deterministic, repeatable** interop testing: bit-exact reproducibility of
+multi-peer scenarios, no NIC variance, no scheduler jitter, no host clock
+drift. Shadow can host hundreds–thousands of simulated peers on one box,
+which is useful for mesh-scale interop without a real cluster.
+
+## What changes vs. the default build
+
+Shadow's shim intercepts syscalls at the **libc layer** via `LD_PRELOAD`. The
+default zquic Linux build is pure-Zig — no libc, raw `std.os.linux.*`
+syscalls — which the shim cannot intercept. The `-Dshadow=true` build flag
+flips three knobs:
+
+1. **Forces `link_libc = true` on Linux** so the binary is dynamically linked
+   against glibc.
+2. **Routes `clock_gettime` / `getrandom` through libc** (via
+   `compat.zig`'s `!builtin.link_libc` gates) so Shadow's virtual clock and
+   deterministic randomness apply.
+3. **Disables the `sendmmsg(2)` / `recvmmsg(2)` batched-I/O path** in
+   `transport/batch_io.zig`; the per-message `sendto` / `recvfrom` fallback
+   is used instead, which Shadow's shim handles.
+
+## Build
+
+```sh
+zig build -Dtarget=x86_64-linux-gnu -Dshadow=true -Doptimize=ReleaseSafe
+```
+
+Use `-Dtarget=x86_64-linux-gnu` (system glibc) — Shadow's shim is not
+compatible with statically-linked musl binaries. Verify with `file`:
+
+```
+$ file zig-out/bin/server
+… ELF 64-bit LSB executable, x86-64, … dynamically linked,
+   interpreter /lib64/ld-linux-x86-64.so.2 …
+```
+
+The default (no `-Dshadow`) Linux build remains the fully-static
+no-libc binary — no behavior change for non-Shadow consumers.
+
+## Minimal Shadow simulation
+
+Two zquic peers on a 10 Mbps / 15 ms-RTT path:
+
+```yaml
+# shadow.yaml
+general:
+  stop_time: 60s
+
+network:
+  graph:
+    type: 1_gbit_switch
+
+hosts:
+  server:
+    network_node_id: 0
+    processes:
+      - path: ./zig-out/bin/server
+        args: --port 4443 --cert test/fixtures/quic_loopback/cert.pem --key test/fixtures/quic_loopback/key.pem
+        start_time: 1s
+
+  client:
+    network_node_id: 0
+    processes:
+      - path: ./zig-out/bin/client
+        args: server:4443
+        start_time: 5s
+```
+
+Run:
+
+```sh
+shadow shadow.yaml
+```
+
+## Known limitations
+
+- **Per-message I/O only**: the batched `sendmmsg`/`recvmmsg` path is
+  disabled under Shadow, so throughput inside the simulator is bounded by
+  per-packet syscall cost rather than NIC. This is the right trade-off
+  for interop / correctness testing; not a fit for performance studies.
+- **No `io_uring`**: zquic does not use it anyway.
+- **TLS RNG determinism**: with `-Dshadow=true`, `getrandom` goes through
+  libc and is virtualized by Shadow's shim. RNG output is therefore
+  deterministic across runs with the same Shadow seed — useful for
+  reproducing handshake-level bugs.
+
+## Status
+
+Phase 1: Build flag + syscall-routing changes (this commit). Phase 2 (out of
+scope here): bundled Shadow Docker image + CI matrix entry. Tracking: #216.

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -193,7 +193,11 @@ pub fn close(sock: posix.socket_t) void {
 // `getrandom(2)` on Linux and `getentropy(3)` elsewhere via libc.
 
 fn osRandomBytes(buf: []u8) void {
-    if (comptime builtin.os.tag == .linux) {
+    // Raw kernel `getrandom(2)` is used only on no-libc Linux (default zquic
+    // build). When libc is linked — Darwin, or Linux with `-Dshadow=true` —
+    // route through libc so the Shadow simulator's shim can intercept and
+    // produce deterministic randomness. See #216.
+    if (comptime builtin.os.tag == .linux and !builtin.link_libc) {
         // getrandom(2) is the kernel's CSPRNG; never blocks once seeded.
         // Raw syscall — no libc dependency.
         var off: usize = 0;
@@ -205,6 +209,20 @@ fn osRandomBytes(buf: []u8) void {
             } else if (e == .INTR) {
                 continue;
             } else {
+                @panic("getrandom failed");
+            }
+        }
+    } else if (comptime builtin.os.tag == .linux) {
+        // Linux with libc linked (Shadow build) — use libc `getrandom(3)`,
+        // which the Shadow shim intercepts.
+        var off: usize = 0;
+        while (off < buf.len) {
+            const n = std.c.getrandom(buf.ptr + off, buf.len - off, 0);
+            if (n > 0) {
+                off += @intCast(n);
+            } else {
+                const e = std.posix.errno(n);
+                if (e == .INTR) continue;
                 @panic("getrandom failed");
             }
         }
@@ -235,8 +253,12 @@ pub const random: std.Random = std.Random.init(&random_src, RandomSrc.fill);
 // stable syscall ABI).
 
 /// Returns the current wall-clock time in nanoseconds since the Unix epoch.
+///
+/// Linux without libc takes the raw `clock_gettime(2)` syscall. Linux with
+/// libc (Darwin, or `-Dshadow=true`) goes through libc — required so the
+/// Shadow simulator's shim can virtualize simulated time (#216).
 pub fn nanoTimestamp() i128 {
-    if (comptime builtin.os.tag == .linux) {
+    if (comptime builtin.os.tag == .linux and !builtin.link_libc) {
         var ts: std.os.linux.timespec = undefined;
         _ = std.os.linux.clock_gettime(.REALTIME, &ts);
         return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);

--- a/src/transport/batch_io.zig
+++ b/src/transport/batch_io.zig
@@ -21,7 +21,12 @@ const std = @import("std");
 const compat = @import("../compat.zig");
 const types = @import("../types.zig");
 const builtin = @import("builtin");
-const is_linux = builtin.os.tag == .linux;
+const build_options = @import("build_options");
+/// Use the Linux `sendmmsg(2)`/`recvmmsg(2)` batched path. Disabled under the
+/// Shadow build (#216) — the simulator's shim does not virtualize those calls,
+/// so the per-message `sendto`/`recvfrom` portable path is used instead and all
+/// I/O routes through Shadow's intercepted libc.
+const is_linux_batched = builtin.os.tag == .linux and !build_options.shadow;
 
 /// Platform-safe MSG_DONTWAIT constant (std.posix.MSG is void on some macOS builds).
 const MSG_DONTWAIT: u32 = if (@hasDecl(std.posix, "MSG") and @typeInfo(@TypeOf(std.posix.MSG)) == .@"struct")
@@ -68,7 +73,7 @@ pub const SendBatch = struct {
         self.count = 0;
         if (cnt == 0) return;
 
-        if (is_linux) {
+        if (is_linux_batched) {
             flushLinux(sock, self.entries[0..cnt]);
         } else {
             for (self.entries[0..cnt]) |*e| {
@@ -190,7 +195,7 @@ pub const RecvBatch = struct {
     /// blocking call (suitable after poll() indicates data is available).
     /// Returns the number of messages received.
     pub fn recv(self: *RecvBatch, sock: std.posix.socket_t, blocking_first: bool) usize {
-        if (is_linux) {
+        if (is_linux_batched) {
             return recvLinux(self, sock, blocking_first);
         } else {
             return recvPortable(self, sock, blocking_first);


### PR DESCRIPTION
## Summary

Phase 1 of #216 — Shadow network simulator support. Adds a `-Dshadow=true` build flag that makes the Linux build produce a dynamically-linked-against-glibc binary whose syscalls all flow through libc, where Shadow's LD_PRELOAD shim can intercept them.

### Three knobs flipped by `-Dshadow=true`

1. **`build.zig`**: forces `link_libc = true` on Linux. Non-Linux targets unchanged.
2. **`src/compat.zig`**: the two raw-syscall paths (`osRandomBytes`, `nanoTimestamp`) now gate on `!builtin.link_libc` instead of just `os.tag == .linux`. New Linux+libc arm of `osRandomBytes` calls `std.c.getrandom`. Darwin and Linux-no-libc behavior unchanged.
3. **`src/transport/batch_io.zig`**: renames `is_linux` → `is_linux_batched`, AND-ing with `!build_options.shadow`. Under `-Dshadow=true` the per-message `sendto`/`recvfrom` fallback is used; Shadow's shim does not virtualize `sendmmsg(2)`/`recvmmsg(2)`.

### Verification

```
$ zig build                                                # default no-libc Linux build: clean
$ zig build -Dshadow=true                                  # libc-linked: clean
$ zig build -Dtarget=x86_64-linux-gnu -Dshadow=true        # cross-compile + shadow
$ file zig-out/bin/server
… ELF 64-bit LSB executable, x86-64, dynamically linked,
  interpreter /lib64/ld-linux-x86-64.so.2 …                # Shadow-injectable
$ zig build test                                           # 256/256 pass
```

### Out of scope (Phase 2 in #216)

- Bundled Shadow Docker image for one-command interop.
- CI matrix entry running a Shadow subset nightly.
- `zig-libp2p` `-Dshadow=true` propagation through `build.zig.zon` (only needed once an embedder runs a libp2p workload under Shadow).

### Test plan

- [x] `zig build` (default) — pure-Zig, no-libc binary unchanged
- [x] `zig build -Dshadow=true` — clean
- [x] `zig build -Dtarget=x86_64-linux-gnu -Dshadow=true` — dynamically-linked ELF
- [x] `zig build test` — 256/256 pass
- [ ] Actual Shadow run (requires installing Shadow; pointer in `docs/shadow.md`)

Closes #216 (Phase 1).