### PR TITLE
transport: per-stream SendBuffer for partial STREAM retransmit (#184)

### DIFF
--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -164,6 +164,10 @@ pub const SentPacket = struct {
     has_stream_data: bool = false,
     stream_id: u64 = 0,
     stream_offset: u64 = 0,
+    /// Length of STREAM payload bytes when stored in a per-stream `SendBuffer`
+    /// (`stream_data == null`).  Enables partial retransmit without a heap copy
+    /// on the `SentPacket` (issue #184).
+    stream_byte_len: u32 = 0,
     /// Heap-owned plaintext bytes for the raw-application STREAM frame, kept
     /// so we can re-encrypt them under a fresh PN on loss.  `null` for the
     /// HTTP/0.9 and HTTP/3 paths — those rewind their own per-slot state from
@@ -179,6 +183,13 @@ pub const SentPacket = struct {
     stream_data: ?[]u8 = null,
     /// FIN flag accompanying `stream_data` (so retransmit preserves the bit).
     stream_fin: bool = false,
+};
+
+/// STREAM byte range ACKed via a packet-number ACK (issue #184).
+pub const StreamAck = struct {
+    stream_id: u64,
+    offset: u64,
+    len: u32,
 };
 
 /// Loss detection state for one packet number space.
@@ -294,6 +305,8 @@ pub const LossDetector = struct {
         /// ACK instead of once per lost packet — the recovery period bound
         /// is what matters, not the individual PNs.
         largest_lost_pn: ?u64,
+        /// Number of `StreamAck` entries written to `acked_stream_buf`.
+        acked_stream_count: usize = 0,
     };
 
     /// Process an ACK frame. Returns packets declared lost.
@@ -321,6 +334,8 @@ pub const LossDetector = struct {
         /// packets whose `stream_data` is non-null, ownership of that slice
         /// transfers to the caller (see `SentPacket.stream_data` docs).
         lost_buf: []SentPacket,
+        /// Caller-provided buffer for STREAM ranges ACKed in this PN space.
+        acked_stream_buf: []StreamAck,
         /// Allocator used to free `stream_data` for packets acked by this
         /// range.  Pass the same allocator that the producer used when
         /// attaching the data via `onPacketSent`.
@@ -367,6 +382,7 @@ pub const LossDetector = struct {
         // evaluate the persistent-congestion duration (RFC 9002 §7.6.1).
         var earliest_lost_eliciting_send_time: ?u64 = null;
         var latest_lost_eliciting_send_time: ?u64 = null;
+        var acked_stream_count: usize = 0;
 
         // Compute the time-threshold loss bound once per ACK (RFC 9002
         // §6.1.2).  A packet older than this is declared lost even if fewer
@@ -395,6 +411,15 @@ pub const LossDetector = struct {
                 if (self.sent[i].stream_data) |sd| {
                     _ = freeStreamDataChecked(allocator, sd, self.sent[i].pn, self.sent[i].stream_id);
                     self.sent[i].stream_data = null;
+                } else if (self.sent[i].has_stream_data and self.sent[i].stream_data == null) {
+                    if (acked_stream_count < acked_stream_buf.len) {
+                        acked_stream_buf[acked_stream_count] = .{
+                            .stream_id = self.sent[i].stream_id,
+                            .offset = self.sent[i].stream_offset,
+                            .len = self.sent[i].stream_byte_len,
+                        };
+                        acked_stream_count += 1;
+                    }
                 }
                 self.sent[i] = self.sent[self.sent_count - 1];
                 self.sent_count -= 1;
@@ -479,6 +504,7 @@ pub const LossDetector = struct {
             .lost_bytes = lost_bytes,
             .persistent_congestion = pc,
             .largest_lost_pn = largest_lost_pn,
+            .acked_stream_count = acked_stream_count,
         };
     }
 };
@@ -531,7 +557,7 @@ test "loss: packet threshold detection" {
     // Packets 0, 1, 2 are in a gap and should be detected as lost via
     // k_packet_threshold (5 >= 0+3, 1+3, 2+3).
     var lost_buf: [8]SentPacket = undefined;
-    const result = try ld.onAck(.application, 5, 0, 0, 200, &rtt, &lost_buf, testing.allocator);
+    const result = try ld.onAck(.application, 5, 0, 0, 200, &rtt, &lost_buf, &[_]StreamAck{}, testing.allocator);
     try testing.expect(result.lost_count >= 2);
 }
 
@@ -543,7 +569,7 @@ test "loss: rejects invalid first_ack_range > largest_acked" {
     // largest_acked=5, first_ack_range=10 → would underflow.
     try testing.expectError(
         error.FrameEncodingError,
-        ld.onAck(.application, 5, 10, 0, 200, &rtt, &lost_buf, testing.allocator),
+        ld.onAck(.application, 5, 10, 0, 200, &rtt, &lost_buf, &[_]StreamAck{}, testing.allocator),
     );
 }
 
@@ -563,7 +589,7 @@ test "loss: time-threshold declares old packet lost when gap < k_packet_threshol
     // Ack pn 1 at a time far enough past pn 0's send to trigger time-threshold.
     const now = 200 + loss_delay + 1;
     var lost_buf: [4]SentPacket = undefined;
-    const r = try ld.onAck(.application, 1, 0, 0, now, &rtt, &lost_buf, testing.allocator);
+    const r = try ld.onAck(.application, 1, 0, 0, now, &rtt, &lost_buf, &[_]StreamAck{}, testing.allocator);
     try testing.expectEqual(@as(usize, 1), r.lost_count);
     try testing.expectEqual(@as(u64, 0), lost_buf[0].pn);
     try testing.expect(r.largest_lost_pn != null);
@@ -596,7 +622,7 @@ test "loss: persistent congestion across spread-out losses" {
     // large enough that time-threshold also fires on 3 and 4.
     const now = t_last + 30 + rtt.loss_delay_ms() + 1;
     var lost_buf: [16]SentPacket = undefined;
-    const r = try ld.onAck(.application, 5, 0, 0, now, &rtt, &lost_buf, testing.allocator);
+    const r = try ld.onAck(.application, 5, 0, 0, now, &rtt, &lost_buf, &[_]StreamAck{}, testing.allocator);
     try testing.expect(r.lost_count >= 3);
     try testing.expect(r.persistent_congestion);
 }
@@ -625,7 +651,7 @@ test "loss: no persistent congestion when ack proves path is delivering" {
     // (largest_acked=4 ≥ 0+3) but pn 1 was acked inside the same ACK, so
     // even if a second loss were present, PC would not apply.
     var lost_buf: [8]SentPacket = undefined;
-    const r = try ld.onAck(.application, 4, 3, 0, t0 + pc_dur + 20, &rtt, &lost_buf, testing.allocator);
+    const r = try ld.onAck(.application, 4, 3, 0, t0 + pc_dur + 20, &rtt, &lost_buf, &[_]StreamAck{}, testing.allocator);
     try testing.expect(r.lost_count >= 1);
     try testing.expect(!r.persistent_congestion);
 }
@@ -690,10 +716,10 @@ test "loss: stream_data is freed on ack and transferred on loss" {
     var lost_buf: [8]SentPacket = undefined;
     // Ack pn 0 (frees buf0 internally), then ack pn 5 separately so pn 1
     // is declared lost via k_packet_threshold.
-    const r0 = try ld.onAck(.application, 0, 0, 0, 200, &rtt, &lost_buf, a);
+    const r0 = try ld.onAck(.application, 0, 0, 0, 200, &rtt, &lost_buf, &[_]StreamAck{}, a);
     try testing.expectEqual(@as(usize, 0), r0.lost_count);
 
-    const r1 = try ld.onAck(.application, 5, 0, 0, 200, &rtt, &lost_buf, a);
+    const r1 = try ld.onAck(.application, 5, 0, 0, 200, &rtt, &lost_buf, &[_]StreamAck{}, a);
     try testing.expect(r1.lost_count >= 1);
     // Find the lost descriptor that owns the heap slice.
     var saw_transfer = false;
@@ -794,7 +820,7 @@ test "loss: stream_data ownership survives adversarial send/ack/retransmit churn
         const largest = top -| rand.uintLessThan(u64, 3);
         const first_range = @min(range, largest);
 
-        const r = ld.onAck(.application, largest, first_range, 0, now, &rtt, &lost_buf, a) catch {
+        const r = ld.onAck(.application, largest, first_range, 0, now, &rtt, &lost_buf, &[_]StreamAck{}, a) catch {
             continue;
         };
 
@@ -813,7 +839,7 @@ test "loss: stream_data ownership survives adversarial send/ack/retransmit churn
         // the time-threshold loss path, exercising large single-ACK losses.
         if (iter % 4096 == 0 and ld.sent_count > 0) {
             now += 10_000;
-            const flush = ld.onAck(.application, next_pn -| 1, 0, 0, now, &rtt, &lost_buf, a) catch continue;
+            const flush = ld.onAck(.application, next_pn -| 1, 0, 0, now, &rtt, &lost_buf, &[_]StreamAck{}, a) catch continue;
             var fi: usize = 0;
             while (fi < flush.lost_count) : (fi += 1) {
                 if (lost_buf[fi].stream_data) |sbuf| a.free(sbuf);
@@ -834,7 +860,7 @@ test "loss: per-PN-space ACK only affects matching space" {
     _ = ld.onPacketSent(.{ .pn = 1, .send_time_ms = 196, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .application });
 
     var lost_buf: [8]SentPacket = undefined;
-    const r = try ld.onAck(.application, 1, 1, 0, 200, &rtt, &lost_buf, testing.allocator);
+    const r = try ld.onAck(.application, 1, 1, 0, 200, &rtt, &lost_buf, &[_]StreamAck{}, testing.allocator);
     try testing.expectEqual(@as(usize, 0), r.lost_count);
     try testing.expectEqual(@as(usize, 1), ld.sent_count);
     try testing.expectEqual(PacketNumberSpace.handshake, ld.sent[0].space);

--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -419,6 +419,16 @@ pub const LossDetector = struct {
                             .len = self.sent[i].stream_byte_len,
                         };
                         acked_stream_count += 1;
+                    } else {
+                        // Loud: silent overflow leaves `SendBuffer` ranges
+                        // un-pruned → CC stuck in recovery → transfer stalls
+                        // (the exact post-fix #219 interop symptom when the
+                        // cap was 64). Surface so future regressions are
+                        // obvious without re-bisecting.
+                        log.warn(
+                            "recovery: acked_stream_buf overflow (>{d} entries) — stream={d} offset={d} len={d} pruning skipped",
+                            .{ acked_stream_buf.len, self.sent[i].stream_id, self.sent[i].stream_offset, self.sent[i].stream_byte_len },
+                        );
                     }
                 }
                 self.sent[i] = self.sent[self.sent_count - 1];

--- a/src/root.zig
+++ b/src/root.zig
@@ -40,6 +40,7 @@ pub const transport = struct {
     pub const session_token = @import("transport/session_token.zig");
     pub const stats = @import("transport/stats.zig");
     pub const migration = @import("transport/migration.zig");
+    pub const send_buffer = @import("transport/send_buffer.zig");
     pub const io = @import("transport/io.zig");
     pub const path_mtu = @import("transport/path_mtu.zig");
 };
@@ -88,6 +89,7 @@ test {
     _ = @import("transport/stats.zig");
     _ = @import("transport/migration.zig");
     _ = @import("transport/raw_app_stream.zig");
+    _ = @import("transport/send_buffer.zig");
     _ = @import("transport/io.zig");
     _ = @import("transport/path_mtu.zig");
     _ = @import("http3/frame.zig");

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1109,7 +1109,16 @@ fn enqueuePendingStreamSend(
     const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
     if (data.len == 0 and !fin) return true;
     if (data.len > 0 and sbuf.coversRange(offset, data.len)) {
-        if (fin) sbuf.append(allocator, offset, &.{}, fin) catch return false;
+        // Bytes were recorded on the first enqueue — do not duplicate into
+        // queued_bytes.  Still record FIN if this retry carries it.
+        if (fin) {
+            const fa = offset + data.len;
+            if (sbuf.fin_at) |cur| {
+                sbuf.fin_at = @max(cur, fa);
+            } else {
+                sbuf.fin_at = fa;
+            }
+        }
         conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
         return true;
     }
@@ -3961,6 +3970,10 @@ pub const Server = struct {
             // Unknown or non-STREAM frame — stop parsing.
             break;
         }
+        if (conn.has_app_keys and conn.http09_pending_count > 0) {
+            self.drainHttp09Pending(conn);
+            self.flushSendBatch();
+        }
     }
 
     /// Retry token lifetime in milliseconds.  RFC 9000 §8.1.3 recommends
@@ -4705,6 +4718,16 @@ pub const Server = struct {
         conn.address_validated = true;
         conn.migration.trustActivePath();
         conn.captureHandshakeRtt();
+
+        // 0-RTT GETs are parsed in process0RttPacket before app keys exist and
+        // land in http09_pending.  Drain them now instead of waiting for the
+        // client's next datagram (zerortt would otherwise stall until a PING).
+        while (conn.http09_pending_count > 0) {
+            const before = conn.http09_pending_count;
+            self.drainHttp09Pending(conn);
+            if (conn.http09_pending_count == before) break;
+        }
+        self.flushSendBatch();
 
         const pending_n = conn.pending_1rtt_n;
         conn.pending_1rtt_n = 0;
@@ -8865,7 +8888,13 @@ pub const Client = struct {
             self.flushPendingStreamsBlocked();
             self.checkPto();
 
-            if (ready == 0) continue;
+            if (ready == 0) {
+                // Zerortt: up to 39 server responses can arrive during the
+                // handshake before downloadUrls runs; flush deferred ACKs on
+                // idle polls so the server is not stuck in a PTO/retransmit loop.
+                self.flushDeferredAck();
+                continue;
+            }
 
             // Drain a pending ICMP/socket error (e.g. port-unreachable when
             // the server is not yet bound) so the next poll() is not
@@ -8958,6 +8987,10 @@ pub const Client = struct {
                 if (self.early_km != null and self.zerortt_count < self.active_urls.len) {
                     self.send0RttRequests(server_addr) catch {};
                 }
+                // ACK responses that arrived during the handshake (0-RTT → 1-RTT
+                // burst) before downloadUrls blocks in its recv loop.
+                self.flushDeferredAck();
+                self.flushSendBatch();
                 // downloadUrls blocks with its own recv loop; extend the outer
                 // deadline so post-batch retransmits can still complete.
                 deadline = compat.milliTimestamp() + 120_000;
@@ -8973,6 +9006,7 @@ pub const Client = struct {
                 break;
             }
 
+            self.flushDeferredAck();
             deadline = compat.milliTimestamp() + 30_000; // extend while packets still arrive
         }
 
@@ -10864,6 +10898,9 @@ pub const Client = struct {
             self.h3_client_control_sent = true;
         }
 
+        self.flushDeferredAck();
+        self.flushSendBatch();
+
         // Process downloads in batches to stay within NS3 network simulator limits.
         // The NS3 DropTail queue is 25 packets; sending more than ~20 packets at
         // once causes queue overflow and packet drops.  Using BATCH_SIZE=20 keeps
@@ -11017,11 +11054,14 @@ pub const Client = struct {
                 const poll_timeout: i32 = @intCast(@min(200, @max(0, remaining)));
                 const ready = std.posix.poll(&fds, poll_timeout) catch 0;
                 if (ready == 0) {
-                    // Poll timed out — no incoming data.  Send a PING so the
-                    // server can see our current source port.  This is critical
-                    // for the rebind-port test: after a NAT rebind the server's
-                    // FIN retransmits go to the old (dead) port.  Without this
-                    // PING the server never learns the new port and exhausts all
+                    // Poll timed out — no incoming data.  Flush any deferred ACKs
+                    // so the peer can retire in-flight data (zerortt 0-RTT burst).
+                    self.flushDeferredAck();
+                    self.flushSendBatch();
+                    // Send a PING so the server can see our current source port.
+                    // This is critical for the rebind-port test: after a NAT rebind
+                    // the server's FIN retransmits go to the old (dead) port.  Without
+                    // this PING the server never learns the new port and exhausts all
                     // retransmits, stalling the download.
                     if (self.conn.has_app_keys) {
                         // PING (0x01) + PADDING (0x00 × 7) — minimum 4 bytes of
@@ -11066,6 +11106,7 @@ pub const Client = struct {
                 // This replaces N individual ACKs with a single packet, reducing
                 // the combined burst (ACK + next GET batch) to ≤ 21 packets.
                 self.flushDeferredAck();
+                self.flushSendBatch();
             }
 
             batch_start = batch_end;

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1108,6 +1108,11 @@ fn enqueuePendingStreamSend(
 ) bool {
     const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
     if (data.len == 0 and !fin) return true;
+    if (data.len > 0 and sbuf.coversRange(offset, data.len)) {
+        if (fin) sbuf.append(allocator, offset, &.{}, fin) catch return false;
+        conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
+        return true;
+    }
     const projected = streamSendQueuedBytes(conn) + data.len;
     if (projected > pending_stream_send_bytes_cap) return false;
     sbuf.append(allocator, offset, data, fin) catch return false;
@@ -1134,6 +1139,11 @@ fn enqueuePendingStreamSendOwned(
 ) bool {
     if (owned.len == 0) return true;
     const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
+    if (sbuf.coversRange(offset, owned.len)) {
+        allocator.free(owned);
+        conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
+        return true;
+    }
     if (streamSendQueuedBytes(conn) + owned.len > pending_stream_send_bytes_cap) return false;
     sbuf.append(allocator, offset, owned, fin) catch return false;
     allocator.free(owned);
@@ -5852,7 +5862,6 @@ pub const Server = struct {
             .has_length = true,
         };
         const old_offset = slot.stream_offset;
-        slot.stream_offset += @intCast(n);
         var frame_buf: [path_mtu_mod.max_app_stream_chunk_cap + 64]u8 = undefined;
         const frame_len = sf_out.serialize(&frame_buf) catch |err| {
             dbg("io: http09 stream_id={} serialize error at offset {}: {}\n", .{ slot.stream_id, old_offset, err });
@@ -5863,15 +5872,14 @@ pub const Server = struct {
         };
         dbg("io: http09 stream_id={} chunk: bytes={} offset={} fin={} frame_len={}\n", .{ slot.stream_id, n, old_offset, fin, frame_len });
         const fc_before = conn.fc_bytes_sent;
-        _ = self.sendRawStreamDataInner(conn, slot.stream_id, old_offset, file_buf[0..n], fin, null);
-        if (conn.fc_bytes_sent <= fc_before) {
-            // FC blocked (DATA_BLOCKED) or send failed — rewind and retry later.
-            slot.stream_offset -= @intCast(n);
-            slot.file.seekTo(slot.stream_offset) catch |err| {
-                dbg("io: http09 seekTo rewind failed stream_id={}: {}\n", .{ slot.stream_id, err });
-            };
+        const enqueued = self.sendRawStreamDataInner(conn, slot.stream_id, old_offset, file_buf[0..n], fin, null);
+        if (enqueued == 0) return;
+        if (fin and conn.fc_bytes_sent <= fc_before) {
+            // FIN chunk buffered but not on the wire yet — retry without advancing
+            // the file cursor (SendBuffer already holds these bytes).
             return;
         }
+        slot.stream_offset += @intCast(n);
         if (fin) {
             if (conn.http09_active_count > 0) conn.http09_active_count -= 1;
             slot.file.close();

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -46,6 +46,7 @@ const raw_app_stream = @import("raw_app_stream.zig");
 const connection_mod = @import("connection.zig");
 const stats_mod = @import("stats.zig");
 const session_token_mod = @import("session_token.zig");
+const send_buffer_mod = @import("send_buffer.zig");
 const default_conn_path_mtu = path_mtu_mod.initFromConfig(null);
 
 /// Locally-initiate a key update after this many 1-RTT packets (RFC 9001 §6).
@@ -1054,6 +1055,44 @@ const max_pending_stream_chunk: usize = MAX_DATAGRAM_SIZE - 64;
 /// steady-state per-conn send rate, so it only bounds post-stall catch-up bursts.
 const max_pending_drain_per_call: usize = 1024;
 
+fn streamSendQueuedBytes(conn: *const ConnState) usize {
+    var n: usize = 0;
+    for (&conn.stream_send_slots) |*slot| {
+        if (slot.active) n += slot.buf.byteLen();
+    }
+    return n;
+}
+
+fn streamSendHasWork(conn: *const ConnState) bool {
+    for (conn.stream_send_slots) |slot| {
+        if (!slot.active) continue;
+        if (slot.buf.hasWork()) return true;
+    }
+    return false;
+}
+
+fn applyStreamAcks(
+    conn: *ConnState,
+    allocator: std.mem.Allocator,
+    acks: []const recovery.StreamAck,
+) void {
+    for (acks) |a| {
+        if (send_buffer_mod.findStreamSendSlot(conn.stream_send_slots[0..], a.stream_id)) |buf| {
+            buf.onAck(allocator, a.offset, a.len);
+        }
+    }
+    conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
+}
+
+fn freeStreamSendSlots(conn: *ConnState, allocator: std.mem.Allocator) void {
+    for (&conn.stream_send_slots) |*slot| {
+        if (slot.active) {
+            slot.buf.deinit(allocator);
+            slot.* = .{};
+        }
+    }
+}
+
 /// Enqueue bytes that exceeded flow control.  Duplicates `data` onto the
 /// heap (caller's slice typically points into a transient frame buffer).
 /// Returns false when the per-connection caps are exhausted; callers must
@@ -1067,87 +1106,12 @@ fn enqueuePendingStreamSend(
     data: []const u8,
     fin: bool,
 ) bool {
-    // Empty (FIN-only) frames carry no retransmittable data and must never be
-    // queued as their own entry: `dupe(u8, &.{})` returns the allocator's
-    // zero-length sentinel slice (ptr 0xffff…, len 0), which the drain path
-    // would later hand to `allocator.free` and corrupt jemalloc's per-thread
-    // cache — a SIGSEGV in an unrelated later allocation.
-    // Split at packet-build time in `drainPendingStreamSends` (not here).
-    if (data.len == 0) {
-        // …but the half-close must still reach the peer even when this stream's
-        // payload is backpressured in the queue. A large response (libp2p
-        // reqresp blocks_by_range) saturates cwnd, so its trailing FIN arrives
-        // here with no room to send immediately; dropping it leaves the
-        // requester waiting on a stream-end that never comes (the response
-        // never "completes"). Ride the FIN out on the last queued frame for
-        // this stream instead of allocating a 0-byte entry.
-        if (fin) {
-            var i = conn.pending_stream_sends.items.len;
-            while (i > 0) {
-                i -= 1;
-                if (conn.pending_stream_sends.items[i].stream_id == stream_id) {
-                    conn.pending_stream_sends.items[i].fin = true;
-                    return true;
-                }
-            }
-            // No queued frame to carry the FIN: this stream's payload already
-            // went straight to the wire, leaving the queue empty for it. The
-            // half-close must still be delivered, so append a dedicated
-            // FIN-only entry that `drainPendingStreamSends` emits as a bare FIN
-            // once the congestion/pacer gate reopens. Its `data` is the empty
-            // slice (never duped or freed — that would hand the allocator its
-            // zero-length sentinel and corrupt the heap; `drainPendingStreamSends`
-            // and `freePendingStreamSends` both skip the free on len==0).
-            // Dropping the FIN here instead silently half-closed the stream and
-            // hung req/resp until timeout — the ~1-2% empty-FIN-on-blocked-gate
-            // flake on the req/resp-over-inbound reverse direction.
-            if (conn.pending_stream_sends.items.len >= pending_stream_send_cap) return false;
-            conn.pending_stream_sends.append(allocator, .{
-                .stream_id = stream_id,
-                .offset = offset,
-                .fin = true,
-                .data = &.{},
-            }) catch return false;
-        }
-        return true;
-    }
-    // Embedder may retry the same offset after a backpressure 0; treat as
-    // already accepted so we do not fill the queue with duplicate copies.
-    for (conn.pending_stream_sends.items) |e| {
-        if (e.stream_id == stream_id and e.offset == offset) return true;
-    }
-    // Coalesce contiguous tail bytes on the same stream (gossipsub /meshsub
-    // sends sequential 1200-byte chunks).  Without this, CC-blocked gossip
-    // creates one queue entry per chunk and hits the 1024-entry cap in ~30s
-    // even though total bytes stay under the 8 MiB byte cap.
-    if (conn.pending_stream_sends.items.len > 0) {
-        const last = &conn.pending_stream_sends.items[conn.pending_stream_sends.items.len - 1];
-        if (last.stream_id == stream_id and
-            last.offset +| (last.data.len - last.sent_in_buf) == offset and !last.fin)
-        {
-            if (conn.pending_stream_send_bytes +| data.len > pending_stream_send_bytes_cap) return false;
-            const new_len = last.data.len + data.len;
-            const grown = allocator.realloc(last.data, new_len) catch return false;
-            @memcpy(grown[last.data.len..][0..data.len], data);
-            last.data = grown;
-            if (fin) last.fin = true;
-            conn.pending_stream_send_bytes +|= data.len;
-            return true;
-        }
-    }
-    if (conn.pending_stream_sends.items.len >= pending_stream_send_cap) return false;
-    if (conn.pending_stream_send_bytes +| data.len > pending_stream_send_bytes_cap) return false;
-    const dup = allocator.dupe(u8, data) catch return false;
-    conn.pending_stream_sends.append(allocator, .{
-        .stream_id = stream_id,
-        .offset = offset,
-        .fin = fin,
-        .data = dup,
-    }) catch {
-        allocator.free(dup);
-        return false;
-    };
-    conn.pending_stream_send_bytes +|= data.len;
+    const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
+    if (data.len == 0 and !fin) return true;
+    const projected = streamSendQueuedBytes(conn) + data.len;
+    if (projected > pending_stream_send_bytes_cap) return false;
+    sbuf.append(allocator, offset, data, fin) catch return false;
+    conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
     return true;
 }
 
@@ -1168,65 +1132,12 @@ fn enqueuePendingStreamSendOwned(
     owned: []u8,
     fin: bool,
 ) bool {
-    // Empty (FIN-only) frames carry no retransmittable data; never queue them.
-    // Do NOT free `owned` — a zero-length slice is the allocator's sentinel,
-    // not a real allocation, and freeing it corrupts the heap.  (Post-v1.7.27
-    // the retransmit path never tracks empty stream_data, so this is defensive.)
     if (owned.len == 0) return true;
-    for (conn.pending_stream_sends.items) |e| {
-        if (e.stream_id == stream_id and e.offset == offset) {
-            allocator.free(owned);
-            return true;
-        }
-    }
-    if (conn.pending_stream_sends.items.len > 0) {
-        const last = &conn.pending_stream_sends.items[conn.pending_stream_sends.items.len - 1];
-        if (last.stream_id == stream_id and
-            last.offset +| (last.data.len - last.sent_in_buf) == offset and !last.fin)
-        {
-            // Defence-in-depth: if `owned` and `last.data` alias the same
-            // heap buffer, realloc would invalidate `owned`'s backing
-            // storage and the subsequent @memcpy would read freed memory.
-            // This should never happen (the caller's contract is that
-            // `owned` is freshly allocated and unique), but a stale-slice
-            // bug elsewhere could otherwise corrupt jemalloc's metadata
-            // and crash the process.  Skip the coalesce path on alias and
-            // fall through to the append path, which a few lines below
-            // detects the same alias via the for-loop dedup check above
-            // (in practice we never reach that because the for-loop
-            // already returns true for any duplicate).
-            if (owned.ptr != last.data.ptr) {
-                if (conn.pending_stream_send_bytes +| owned.len > pending_stream_send_bytes_cap) {
-                    return false; // caller owns `owned` on false (not consumed)
-                }
-                const new_len = last.data.len + owned.len;
-                const grown = allocator.realloc(last.data, new_len) catch {
-                    return false; // caller owns `owned`; last.data untouched
-                };
-                @memcpy(grown[last.data.len..][0..owned.len], owned);
-                allocator.free(owned);
-                last.data = grown;
-                if (fin) last.fin = true;
-                conn.pending_stream_send_bytes +|= owned.len;
-                return true;
-            }
-        }
-    }
-    if (conn.pending_stream_sends.items.len >= pending_stream_send_cap) {
-        return false; // caller owns `owned` on false (not consumed)
-    }
-    if (conn.pending_stream_send_bytes +| owned.len > pending_stream_send_bytes_cap) {
-        return false; // caller owns `owned` on false (not consumed)
-    }
-    conn.pending_stream_sends.append(allocator, .{
-        .stream_id = stream_id,
-        .offset = offset,
-        .fin = fin,
-        .data = owned,
-    }) catch {
-        return false; // caller owns `owned` on false (append failed, not stored)
-    };
-    conn.pending_stream_send_bytes +|= owned.len;
+    const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
+    if (streamSendQueuedBytes(conn) + owned.len > pending_stream_send_bytes_cap) return false;
+    sbuf.append(allocator, offset, owned, fin) catch return false;
+    allocator.free(owned);
+    conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
     return true;
 }
 
@@ -1288,6 +1199,136 @@ fn abandonEarlyPnSpaces(conn: *ConnState, allocator: std.mem.Allocator) void {
 /// (multi-KB coalesced gossip frames) could never accumulate enough pacing
 /// tokens and would wedge `drainPendingStreamSends`.  See `pacerUpdate` for
 /// the cwnd-scaled burst budget.
+fn streamSendActiveSlotCount(conn: *const ConnState) usize {
+    var n: usize = 0;
+    for (conn.stream_send_slots) |slot| {
+        if (slot.active) n += 1;
+    }
+    return n;
+}
+
+fn connAttachStreamToLastAppPacket(
+    conn: *ConnState,
+    stream_id: u64,
+    offset: u64,
+    byte_len: u32,
+    fin: bool,
+) void {
+    if (conn.ld.sent_count == 0) return;
+    const sent_pn = conn.app_pn -| 1;
+    const last = &conn.ld.sent[conn.ld.sent_count - 1];
+    if (last.pn != sent_pn or last.space != .application) return;
+    last.has_stream_data = byte_len > 0 or fin;
+    last.stream_id = stream_id;
+    last.stream_offset = offset;
+    last.stream_byte_len = byte_len;
+    last.stream_data = null;
+    last.stream_fin = fin;
+}
+
+fn emitStreamPollServer(
+    self: *Server,
+    conn: *ConnState,
+    stream_id: u64,
+    poll: send_buffer_mod.PollResult,
+) bool {
+    const chunk_len = poll.data.len;
+    if (!poll.retransmit) {
+        const stream_limit = conn.peerStreamSendLimit(stream_id, true);
+        if (stream_limit > 0 and poll.offset +| chunk_len > stream_limit) return false;
+        const projected: u64 = conn.fc_bytes_sent +| chunk_len;
+        if (projected > conn.fc_send_max) return false;
+    }
+    const pace_bytes: u64 = @intCast(if (chunk_len > 0) chunk_len else 1);
+    if (!connCanTransmitAppData(conn, compat.milliTimestamp(), pace_bytes)) return false;
+
+    const sf = stream_frame_mod.StreamFrame{
+        .stream_id = stream_id,
+        .offset = poll.offset,
+        .data = poll.data,
+        .fin = poll.fin,
+        .has_length = true,
+    };
+    var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+    const flen = sf.serialize(&frame_buf) catch return false;
+    const pn_before = conn.app_pn;
+    self.send1Rtt(conn, frame_buf[0..flen], conn.peer);
+    if (conn.app_pn == pn_before) return false;
+
+    if (!poll.retransmit and chunk_len > 0) conn.fc_bytes_sent +|= chunk_len;
+    if (send_buffer_mod.findStreamSendSlot(conn.stream_send_slots[0..], stream_id)) |sbuf| {
+        sbuf.onSent(poll.offset, chunk_len);
+    }
+    connAttachStreamToLastAppPacket(conn, stream_id, poll.offset, @intCast(chunk_len), poll.fin);
+    conn.pacerConsume(pace_bytes);
+    return true;
+}
+
+fn emitStreamPollClient(
+    self: *Client,
+    stream_id: u64,
+    poll: send_buffer_mod.PollResult,
+) bool {
+    const chunk_len = poll.data.len;
+    if (!poll.retransmit) {
+        const stream_limit = self.conn.peerStreamSendLimit(stream_id, false);
+        if (stream_limit > 0 and poll.offset +| chunk_len > stream_limit) return false;
+        const projected: u64 = self.conn.fc_bytes_sent +| chunk_len;
+        if (projected > self.conn.fc_send_max) return false;
+    }
+    const pace_bytes: u64 = @intCast(if (chunk_len > 0) chunk_len else 1);
+    if (!connCanTransmitAppData(&self.conn, compat.milliTimestamp(), pace_bytes)) return false;
+    if (!self.conn.ld.hasCapacity()) return false;
+
+    const sf = stream_frame_mod.StreamFrame{
+        .stream_id = stream_id,
+        .offset = poll.offset,
+        .data = poll.data,
+        .fin = poll.fin,
+        .has_length = true,
+    };
+    var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+    const flen = sf.serialize(&frame_buf) catch return false;
+    var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
+    const pkt_len = build1RttPacketFull(
+        &send_buf,
+        self.conn.remote_cid,
+        frame_buf[0..flen],
+        self.conn.app_pn,
+        &self.conn.app_client_km,
+        self.conn.key_phase_bit,
+        self.conn.packet_cipher,
+        self.conn.peer_grease_quic_bit,
+    ) catch return false;
+    const pn = self.conn.app_pn;
+    self.conn.app_pn += 1;
+    self.batchSend(send_buf[0..pkt_len]);
+    if (!poll.retransmit and chunk_len > 0) self.conn.fc_bytes_sent +|= chunk_len;
+    if (send_buffer_mod.findStreamSendSlot(self.conn.stream_send_slots[0..], stream_id)) |sbuf| {
+        sbuf.onSent(poll.offset, chunk_len);
+    }
+    self.conn.note1RttSent();
+    const recorded = self.conn.ld.onPacketSent(.{
+        .pn = pn,
+        .send_time_ms = @intCast(compat.milliTimestamp()),
+        .size = pkt_len,
+        .ack_eliciting = true,
+        .in_flight = true,
+        .has_stream_data = chunk_len > 0 or poll.fin,
+        .stream_id = stream_id,
+        .stream_offset = poll.offset,
+        .stream_byte_len = @intCast(chunk_len),
+        .stream_data = null,
+        .stream_fin = poll.fin,
+        .space = .application,
+    });
+    if (recorded) {
+        self.conn.cc.onPacketSent(@intCast(pkt_len));
+        self.conn.pacerConsume(pace_bytes);
+    }
+    return recorded;
+}
+
 fn connCanTransmitAppData(conn: *ConnState, now_ms: i64, bytes: u64) bool {
     conn.pacerUpdate(now_ms);
     const pace_bytes = @min(bytes, congestion.mss);
@@ -1295,11 +1336,11 @@ fn connCanTransmitAppData(conn: *ConnState, now_ms: i64, bytes: u64) bool {
 }
 
 fn maybeLogPendingStreamStall(conn: *ConnState, side: []const u8) void {
-    if (conn.pending_stream_sends.items.len == 0) return;
+    if (!streamSendHasWork(conn)) return;
     const now_ms = compat.milliTimestamp();
     if (now_ms - conn.pending_stream_stall_warn_ms < 5000) return;
     conn.pacerUpdate(now_ms);
-    const head_bytes: u64 = @intCast(conn.pending_stream_sends.items[0].data.len);
+    const head_bytes: u64 = @intCast(conn.pending_stream_send_bytes);
     const pace_bytes = @min(head_bytes, congestion.mss);
     const block = connTransmitBlock(conn, pace_bytes) orelse return;
     conn.pending_stream_stall_warn_ms = now_ms;
@@ -1310,10 +1351,10 @@ fn maybeLogPendingStreamStall(conn: *ConnState, side: []const u8) void {
     // (cong_events climbing) from ACK-clock starvation (acked flat) from
     // local-send-drop spurious loss (local_send_drops climbing).
     log.info(
-        "io: {s} pending-stream-send drain stalled: {} entries, {} bytes, blocked_by={s}, cc_bif={}, cwnd={}, ld={}/{}, fc_sent={} fc_max={}",
+        "io: {s} pending-stream-send drain stalled: {} streams, {} bytes, blocked_by={s}, cc_bif={}, cwnd={}, ld={}/{}, fc_sent={} fc_max={}",
         .{
             side,
-            conn.pending_stream_sends.items.len,
+            streamSendActiveSlotCount(conn),
             conn.pending_stream_send_bytes,
             @tagName(block),
             conn.cc.getBytesInFlight(),
@@ -1358,6 +1399,7 @@ fn freePendingStreamSends(conn: *ConnState, allocator: std.mem.Allocator) void {
     }
     conn.pending_stream_sends.deinit(allocator);
     conn.pending_stream_sends = .empty;
+    freeStreamSendSlots(conn, allocator);
     conn.pending_stream_send_bytes = 0;
 }
 
@@ -1366,11 +1408,11 @@ fn warnPendingStreamSendQueueFull(conn: *ConnState, stream_id: u64, side: []cons
     if (now - conn.pending_stream_send_queue_full_warn_ms < 5000) return;
     conn.pending_stream_send_queue_full_warn_ms = now;
     const peer_lim = conn.peerStreamSendLimit(stream_id, std.mem.eql(u8, side, "server"));
-    log.warn("io: {s} pending-stream-send queue full ({} entries, {} bytes) on stream_id={}; backpressure. CC: cwnd={} ssthresh={} state={s} bif={} cong_events={} acked={} srtt_ms={} min_rtt_ms={} latest_rtt_ms={} fc_sent={} fc_max={} stream_lim={}\n", .{
-        side,                          conn.pending_stream_sends.items.len, conn.pending_stream_send_bytes, stream_id,
-        conn.cc.getCwnd(),             conn.cc.getSsthresh(),               @tagName(conn.cc.getState()),   conn.cc.getBytesInFlight(),
-        conn.cc.getCongestionEvents(), conn.cc.getTotalBytesAcked(),        conn.rtt.srtt_ms,               conn.rtt.min_rtt_ms,
-        conn.rtt.latest_rtt_ms,        conn.fc_bytes_sent,                  conn.fc_send_max,               peer_lim,
+    log.warn("io: {s} pending-stream-send queue full ({} streams, {} bytes) on stream_id={}; backpressure. CC: cwnd={} ssthresh={} state={s} bif={} cong_events={} acked={} srtt_ms={} min_rtt_ms={} latest_rtt_ms={} fc_sent={} fc_max={} stream_lim={}\n", .{
+        side,                          streamSendActiveSlotCount(conn), conn.pending_stream_send_bytes, stream_id,
+        conn.cc.getCwnd(),             conn.cc.getSsthresh(),           @tagName(conn.cc.getState()),   conn.cc.getBytesInFlight(),
+        conn.cc.getCongestionEvents(), conn.cc.getTotalBytesAcked(),    conn.rtt.srtt_ms,               conn.rtt.min_rtt_ms,
+        conn.rtt.latest_rtt_ms,        conn.fc_bytes_sent,              conn.fc_send_max,               peer_lim,
     });
 }
 
@@ -1785,6 +1827,10 @@ pub const ConnState = struct {
 
     /// Opaque application STREAM receive buffers (server: peer → us).
     raw_app_streams: [64]RawAppStreamSlot = [_]RawAppStreamSlot{.{}} ** 64,
+
+    /// Per-stream send buffers for raw-app egress (issue #184).
+    stream_send_slots: [send_buffer_mod.stream_send_slot_max]send_buffer_mod.StreamSendSlot =
+        [_]send_buffer_mod.StreamSendSlot{.{}} ** send_buffer_mod.stream_send_slot_max,
 
     /// 1-RTT frames received while waiting for client Finished (reordering).
     pending_1rtt: [pending_1rtt_cap]Pending1RttPayload = [_]Pending1RttPayload{.{}} ** pending_1rtt_cap,
@@ -3177,166 +3223,58 @@ pub const Server = struct {
             if (owned_buf) |b| self.allocator.free(b);
             return 0;
         }
-        // Connection-level send-credit gate (RFC 9000 §4.1 / §19.9).  Without
-        // this, zquic can send STREAM payload past the peer's advertised
-        // MAX_DATA budget; the peer would then close with FLOW_CONTROL_ERROR
-        // (0x03).  Only the *original* byte range counts toward the
-        // cumulative limit; retransmits (owned_buf set) re-emit bytes
-        // already charged.
-        const is_fresh = owned_buf == null;
-        if (is_fresh) {
+        if (owned_buf) |buf| {
+            if (!enqueuePendingStreamSendOwned(conn, self.allocator, stream_id, offset, buf, fin)) {
+                self.allocator.free(buf);
+                return 0;
+            }
+            self.drainPendingStreamSends(conn);
+            return data.len;
+        }
+        self.drainPendingStreamSendsUntilStalled(conn);
+        const stream_limit = conn.peerStreamSendLimit(stream_id, true);
+        const exceeds_stream = stream_limit > 0 and offset +| data.len > stream_limit;
+        const projected: u64 = conn.fc_bytes_sent +| data.len;
+        const exceeds_conn = projected > conn.fc_send_max;
+        if (exceeds_stream or exceeds_conn) {
+            if (exceeds_stream) {
+                dbg("io: server per-stream gate stream_id={} end={} limit={} — enqueueing pending + STREAM_DATA_BLOCKED\n", .{
+                    stream_id, offset + data.len, stream_limit,
+                });
+                var blk_buf: [24]u8 = undefined;
+                blk_buf[0] = 0x15; // STREAM_DATA_BLOCKED
+                const sid_enc = varint.encode(blk_buf[1..], stream_id) catch return 0;
+                const lim_enc = varint.encode(blk_buf[1 + sid_enc.len ..], stream_limit) catch return 0;
+                self.send1Rtt(conn, blk_buf[0 .. 1 + sid_enc.len + lim_enc.len], conn.peer);
+            }
+            if (exceeds_conn) {
+                dbg("io: server send-credit gate stream_id={} bytes={} fc_bytes_sent={} fc_send_max={} — enqueueing pending + DATA_BLOCKED\n", .{
+                    stream_id, data.len, conn.fc_bytes_sent, conn.fc_send_max,
+                });
+                var blk_buf: [16]u8 = undefined;
+                blk_buf[0] = 0x14;
+                const enc = varint.encode(blk_buf[1..], conn.fc_send_max) catch return 0;
+                self.send1Rtt(conn, blk_buf[0 .. 1 + enc.len], conn.peer);
+            }
+            return self.serverEnqueueFreshStream(conn, stream_id, offset, data, fin);
+        }
+        const now_ms = compat.milliTimestamp();
+        const pace_bytes: u64 = @intCast(data.len);
+        if (!connCanTransmitAppData(conn, now_ms, pace_bytes)) {
             self.drainPendingStreamSendsUntilStalled(conn);
-            // Per-stream send-credit gate (RFC 9000 §4.1, §19.13). Compares
-            // the highest end-offset on this stream against the peer's
-            // advertised limit — initial §18.2 value, raised by any
-            // MAX_STREAM_DATA (0x11) frames the peer has sent since.
-            const stream_limit = conn.peerStreamSendLimit(stream_id, true);
-            const exceeds_stream = stream_limit > 0 and offset +| data.len > stream_limit;
-            const projected: u64 = conn.fc_bytes_sent +| data.len;
-            const exceeds_conn = projected > conn.fc_send_max;
-            if (exceeds_stream or exceeds_conn) {
-                if (exceeds_stream) {
-                    dbg("io: server per-stream gate stream_id={} end={} limit={} — enqueueing pending + STREAM_DATA_BLOCKED\n", .{
-                        stream_id, offset + data.len, stream_limit,
-                    });
-                    var blk_buf: [24]u8 = undefined;
-                    blk_buf[0] = 0x15; // STREAM_DATA_BLOCKED
-                    const sid_enc = varint.encode(blk_buf[1..], stream_id) catch return 0;
-                    const lim_enc = varint.encode(blk_buf[1 + sid_enc.len ..], stream_limit) catch return 0;
-                    self.send1Rtt(conn, blk_buf[0 .. 1 + sid_enc.len + lim_enc.len], conn.peer);
-                }
-                if (exceeds_conn) {
-                    dbg("io: server send-credit gate stream_id={} bytes={} fc_bytes_sent={} fc_send_max={} — enqueueing pending + DATA_BLOCKED\n", .{
-                        stream_id, data.len, conn.fc_bytes_sent, conn.fc_send_max,
-                    });
-                    var blk_buf: [16]u8 = undefined;
-                    blk_buf[0] = 0x14;
-                    const enc = varint.encode(blk_buf[1..], conn.fc_send_max) catch return 0;
-                    self.send1Rtt(conn, blk_buf[0 .. 1 + enc.len], conn.peer);
-                }
-                // Queue the bytes so they go on the wire once the peer
-                // raises MAX_STREAM_DATA / MAX_DATA.  Returns 0 if the
-                // pending queue is full so the embedder retries instead
-                // of advancing its send_offset and punching a hole.
+            if (!connCanTransmitAppData(conn, compat.milliTimestamp(), pace_bytes)) {
                 return self.serverEnqueueFreshStream(conn, stream_id, offset, data, fin);
             }
-            // Congestion + pacer + loss-detector gate (quinn `poll_transmit`).
-            const now_ms = compat.milliTimestamp();
-            const pace_bytes: u64 = @intCast(data.len);
-            if (!connCanTransmitAppData(conn, now_ms, pace_bytes)) {
-                self.drainPendingStreamSendsUntilStalled(conn);
-                if (!connCanTransmitAppData(conn, compat.milliTimestamp(), pace_bytes)) {
-                    return self.serverEnqueueFreshStream(conn, stream_id, offset, data, fin);
-                }
-            }
-        } else if (owned_buf) |buf| {
-            const now_ms = compat.milliTimestamp();
-            if (!connCanTransmitAppData(conn, now_ms, @intCast(buf.len))) {
-                if (!enqueuePendingStreamSendOwned(conn, self.allocator, stream_id, offset, buf, fin)) {
-                    self.allocator.free(buf);
-                }
-                return data.len;
-            }
         }
-        const sf = stream_frame_mod.StreamFrame{
-            .stream_id = stream_id,
-            .offset = offset,
-            .data = data,
-            .fin = fin,
-            .has_length = true,
-        };
-        var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const flen = sf.serialize(&frame_buf) catch {
-            // Frame too big for one datagram (or some other serialize
-            // failure).  Re-queue as fresh send so a future drain pass
-            // can split it (see drainPendingStreamSends slicing).
-            if (owned_buf) |b| {
-                if (!enqueuePendingStreamSendOwned(conn, self.allocator, stream_id, offset, b, fin)) {
-                    self.allocator.free(b);
-                }
-                return data.len;
-            }
-            return self.serverEnqueueFreshStream(conn, stream_id, offset, data, fin);
-        };
-        const pn_before = conn.app_pn;
-        self.send1Rtt(conn, frame_buf[0..flen], conn.peer);
-        // If send1Rtt actually emitted a packet, app_pn advanced.  Attach the
-        // retransmit buffer to the LD entry it just appended so the loss
-        // detector can replay this STREAM frame under a fresh PN on loss.
-        // `send1Rtt` only fails silently for `draining` — in that case
-        // app_pn does not move.  Treat as "not on wire": re-queue fresh
-        // bytes so the caller doesn't advance its offset, or free the
-        // owned retransmit buf if this was a replay path.
-        if (conn.app_pn == pn_before) {
-            if (owned_buf) |b| {
-                if (!enqueuePendingStreamSendOwned(conn, self.allocator, stream_id, offset, b, fin)) {
-                    self.allocator.free(b);
-                }
-                return data.len;
-            }
-            return self.serverEnqueueFreshStream(conn, stream_id, offset, data, fin);
+        if (!enqueuePendingStreamSend(conn, self.allocator, stream_id, offset, data, fin)) {
+            warnPendingStreamSendQueueFull(conn, stream_id, "server");
+            return 0;
         }
-        // Fresh STREAM bytes went on the wire — charge flow control even when
-        // the loss detector is full and we cannot attach a retransmit buffer.
-        if (is_fresh) conn.fc_bytes_sent +|= data.len;
-        if (conn.ld.sent_count == 0) {
-            if (owned_buf) |b| self.allocator.free(b);
-            if (is_fresh) conn.pacerConsume(@intCast(data.len));
-            return data.len;
-        }
-        const sent_pn = conn.app_pn - 1;
-        const last = &conn.ld.sent[conn.ld.sent_count - 1];
-        if (last.pn != sent_pn) {
-            if (owned_buf) |b| self.allocator.free(b);
-            if (is_fresh) conn.pacerConsume(@intCast(data.len));
-            return data.len;
-        }
-        // Zero-length STREAM frames (FIN-only stream closes) have nothing to
-        // retransmit.  `dupe(u8, &.{})` returns the allocator's zero-length
-        // sentinel slice (ptr 0xffff…, len 0); attaching and freeing it on
-        // ack/loss hands jemalloc a bogus pointer and segfaults.  (The prior
-        // `edata_list_inactive_remove` SIGSEGV referenced below was the same
-        // bug: two empty dupes share the sentinel ptr, so the alias guard
-        // skipped the free and left the sentinel attached to crash later in
-        // `onAck`.)  Carry such packets with no retransmit buffer.
-        const buf: ?[]u8 = if (owned_buf) |b| b else if (data.len == 0) null else (self.allocator.dupe(u8, data) catch {
-            // First send: copy the embedder-supplied data onto the heap so we
-            // own it until the carrying packet is acked (the embedder's slice
-            // typically points into a transient frame buffer).
-            if (is_fresh) conn.pacerConsume(@intCast(data.len));
-            return data.len;
-        });
-        if (buf) |b| {
-            // Defence-in-depth: free any pre-existing data so we don't leak if
-            // some unrelated path already attached one.  Guard against the
-            // alias case where `old.ptr == b.ptr` — without this, the retx
-            // path that passes the same slice as both `data` and `owned_buf`
-            // could free `b` and then immediately store the same dangling
-            // pointer, corrupting jemalloc's slab metadata once the buffer's
-            // slot is reused.
-            if (last.stream_data) |old| {
-                if (old.ptr != b.ptr) self.allocator.free(old);
-            }
-            last.has_stream_data = true;
-            last.stream_id = stream_id;
-            last.stream_offset = offset;
-            last.stream_data = b;
-            last.stream_fin = fin;
-        } else if (fin) {
-            // FIN-only frame (empty data): no retransmit buffer, but mark the
-            // packet so the loss arm re-sends the bare FIN if it is lost (the
-            // raw-app retransmit loop gates on `has_stream_data`).
-            last.has_stream_data = true;
-            last.stream_id = stream_id;
-            last.stream_offset = offset;
-            last.stream_data = null;
-            last.stream_fin = true;
-        }
-        if (is_fresh) conn.pacerConsume(@intCast(data.len));
+        self.drainPendingStreamSends(conn);
         return data.len;
     }
 
-    /// Try to put queued raw STREAM bytes (`pending_stream_sends`) on the
+    /// Try to put queued raw STREAM bytes (per-stream `SendBuffer`) on the
     /// wire, honoring the same per-stream + connection-level flow-control
     /// gates as the initial submission.  Called whenever the peer raises
     /// MAX_DATA / MAX_STREAM_DATA, and on every `checkPto` tick as a
@@ -3346,98 +3284,25 @@ pub const Server = struct {
     /// `sendRawStreamDataInner`.
     fn drainPendingStreamSends(self: *Server, conn: *ConnState) void {
         if (conn.draining or conn.phase != .connected or !conn.has_app_keys) return;
-        if (conn.pending_stream_sends.items.len == 0) return;
-        var i: usize = 0;
+        if (!streamSendHasWork(conn)) return;
         var drained: usize = 0;
-        while (i < conn.pending_stream_sends.items.len) {
-            if (drained >= max_pending_drain_per_call) return; // fairness bound
-            const p = &conn.pending_stream_sends.items[i];
-            const unsent = p.data.len - p.sent_in_buf;
-            const chunk_len = @min(unsent, max_pending_stream_chunk);
-            const stream_limit = conn.peerStreamSendLimit(p.stream_id, true);
-            if (stream_limit > 0 and p.offset +| chunk_len > stream_limit) {
-                i += 1;
-                continue;
+        for (&conn.stream_send_slots) |*slot| {
+            if (!slot.active) continue;
+            while (drained < max_pending_drain_per_call) {
+                const poll = slot.buf.pollTransmit(max_pending_stream_chunk) orelse break;
+                if (!emitStreamPollServer(self, conn, slot.stream_id, poll)) {
+                    maybeLogPendingStreamStall(conn, "server");
+                    conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
+                    return;
+                }
+                drained += 1;
             }
-            const projected: u64 = conn.fc_bytes_sent +| chunk_len;
-            if (projected > conn.fc_send_max) {
-                i += 1;
-                continue;
-            }
-            const pace_bytes: u64 = @intCast(chunk_len);
-            if (!connCanTransmitAppData(conn, compat.milliTimestamp(), pace_bytes)) {
-                maybeLogPendingStreamStall(conn, "server");
+            if (drained >= max_pending_drain_per_call) {
+                conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
                 return;
             }
-            const stream_id = p.stream_id;
-            const offset = p.offset;
-            const fin = p.fin and p.sent_in_buf + chunk_len == p.data.len;
-            const chunk = p.data[p.sent_in_buf .. p.sent_in_buf + chunk_len];
-            const sf = stream_frame_mod.StreamFrame{
-                .stream_id = stream_id,
-                .offset = offset,
-                .data = chunk,
-                .fin = fin,
-                .has_length = true,
-            };
-            var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-            const flen = sf.serialize(&frame_buf) catch {
-                i += 1;
-                continue;
-            };
-            const pn_before = conn.app_pn;
-            self.send1Rtt(conn, frame_buf[0..flen], conn.peer);
-            if (conn.app_pn == pn_before) return;
-            conn.fc_bytes_sent +|= chunk_len;
-            drained += 1;
-            if (conn.ld.sent_count == 0) {
-                p.sent_in_buf += chunk_len;
-                p.offset += chunk_len;
-                conn.pending_stream_send_bytes -|= chunk_len;
-                if (p.sent_in_buf == p.data.len) {
-                    const buf = p.data;
-                    _ = conn.pending_stream_sends.orderedRemove(i);
-                    if (buf.len > 0) self.allocator.free(buf);
-                } else {
-                    i += 1;
-                }
-                continue;
-            }
-            const sent_pn = conn.app_pn - 1;
-            const last = &conn.ld.sent[conn.ld.sent_count - 1];
-            if (last.pn != sent_pn) {
-                i += 1;
-                continue;
-            }
-            // FIN-only entries (chunk_len == 0) carry no retransmittable bytes.
-            // Never dupe an empty chunk: that yields the allocator's zero-length
-            // sentinel slice, which freeing on ack/loss corrupts the heap. Track
-            // with no stream_data; a lost bare FIN is re-emitted by the FIN-only
-            // loss-recovery arm.
-            const rtx_buf: ?[]u8 = if (chunk_len == 0) null else (self.allocator.dupe(u8, chunk) catch {
-                i += 1;
-                continue;
-            });
-            if (last.stream_data) |old| {
-                if (rtx_buf == null or old.ptr != rtx_buf.?.ptr) self.allocator.free(old);
-            }
-            last.has_stream_data = rtx_buf != null;
-            last.stream_id = stream_id;
-            last.stream_offset = offset;
-            last.stream_data = rtx_buf;
-            last.stream_fin = fin;
-            conn.pacerConsume(@intCast(chunk_len));
-            p.sent_in_buf += chunk_len;
-            p.offset += chunk_len;
-            conn.pending_stream_send_bytes -|= chunk_len;
-            if (p.sent_in_buf == p.data.len) {
-                const buf = p.data;
-                _ = conn.pending_stream_sends.orderedRemove(i);
-                if (buf.len > 0) self.allocator.free(buf);
-            } else {
-                i += 1;
-            }
         }
+        conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
     }
 
     pub fn deinit(self: *Server) void {
@@ -3970,6 +3835,7 @@ pub const Server = struct {
                     @intCast(now_ms),
                     &conn.rtt,
                     &lost_buf,
+                    &[_]recovery.StreamAck{},
                     self.allocator,
                 )) |_| {
                     noteConnAckInSpace(conn, .initial, now_ms);
@@ -4800,6 +4666,7 @@ pub const Server = struct {
                     @intCast(now_ms),
                     &conn.rtt,
                     &lost_buf,
+                    &[_]recovery.StreamAck{},
                     self.allocator,
                 )) |_| {
                     noteConnAckInSpace(conn, .handshake, now_ms);
@@ -5326,6 +5193,7 @@ pub const Server = struct {
                 // Pass first_ack_range so the loss detector can correctly
                 // distinguish acked packets from those in gaps.
                 var lost_buf: [32]recovery.SentPacket = undefined;
+                var acked_stream_buf: [64]recovery.StreamAck = undefined;
                 const ld_result = conn.ld.onAck(
                     .application,
                     largest_ack,
@@ -5334,6 +5202,7 @@ pub const Server = struct {
                     @intCast(compat.milliTimestamp()),
                     &conn.rtt,
                     &lost_buf,
+                    acked_stream_buf[0..],
                     self.allocator,
                 ) catch {
                     // Malformed ACK (e.g. first_ack_range > largest_acked) —
@@ -5348,6 +5217,7 @@ pub const Server = struct {
                 if (ld_result.bytes_acked > 0) {
                     conn.cc.onAck(ld_result.bytes_acked, largest_ack);
                 }
+                applyStreamAcks(conn, self.allocator, acked_stream_buf[0..ld_result.acked_stream_count]);
                 conn.noteLossFromAck(ld_result.lost_count, ld_result.lost_bytes);
                 if (conn.plpmtu.probe_pn) |probe_pn| {
                     if (largest_ack >= probe_pn) {
@@ -5481,11 +5351,14 @@ pub const Server = struct {
                             break;
                         }
                         // raw_application_streams: zquic is the data source.
-                        // The lost packet carries a heap-owned plaintext copy
-                        // of the STREAM payload in `lp.stream_data`; re-send
-                        // it via `sendRawStreamDataInner` so the bytes get a
-                        // fresh PN and the new SentPacket adopts the buffer.
-                        if (lp.stream_data) |buf| {
+                        // Per-stream `SendBuffer` holds plaintext; mark the lost
+                        // range and drain narrow retransmits (issue #184).
+                        if (lp.stream_byte_len > 0 and lp.stream_data == null) {
+                            if (send_buffer_mod.findStreamSendSlot(conn.stream_send_slots[0..], lp.stream_id)) |sbuf| {
+                                sbuf.onLoss(self.allocator, lp.stream_offset, lp.stream_byte_len) catch {};
+                            }
+                            self.drainPendingStreamSends(conn);
+                        } else if (lp.stream_data) |buf| {
                             // Retransmissions are subject to the congestion
                             // window (RFC 9002 §6.2.4 / §7).  When cwnd has room
                             // resend immediately; otherwise queue the frame so
@@ -6238,7 +6111,7 @@ pub const Server = struct {
                 const has_substantial_data_stuck =
                     conn.cc.getBytesInFlight() >= 1024 or
                     conn.ld.sent_count >= recovery.LossDetector.max_tracked_packets / 4 or
-                    conn.pending_stream_sends.items.len > 0;
+                    streamSendHasWork(conn);
                 if (elapsed_since_ack_lost >= lost_threshold_ms and has_substantial_data_stuck) {
                     log.warn("io: server declaring connection lost (no ACK for {}ms >= {}ms, bif={}, ld={}/{}, pending={}); sent={} acked={} lost={} cong_events={} cwnd={} ssthresh={} srtt_ms={} marking draining", .{
                         elapsed_since_ack_lost,
@@ -6246,7 +6119,7 @@ pub const Server = struct {
                         conn.cc.getBytesInFlight(),
                         conn.ld.sent_count,
                         recovery.LossDetector.max_tracked_packets,
-                        conn.pending_stream_sends.items.len,
+                        streamSendActiveSlotCount(conn),
                         conn.app_pn,
                         conn.cc.getTotalBytesAcked(),
                         conn.ld.total_declared_lost,
@@ -7826,6 +7699,7 @@ pub fn rawAppStreamFullyReceived(conn: *ConnState, stream_id: u64) bool {
 /// on that stream from being reassembled, so prefer to gate on
 /// `rawAppStreamFinReceived`.
 pub fn releaseRawAppStream(conn: *ConnState, stream_id: u64, allocator: std.mem.Allocator) bool {
+    send_buffer_mod.releaseStreamSendSlot(conn.stream_send_slots[0..], allocator, stream_id);
     for (&conn.raw_app_streams) |*slot| {
         if (slot.active and slot.stream_id == stream_id) {
             slot.deinit(allocator);
@@ -8451,286 +8325,84 @@ pub const Client = struct {
             if (owned_buf) |b| self.allocator.free(b);
             return 0;
         }
-        // Connection-level send-credit gate (RFC 9000 §4.1 / §19.9).  Mirror
-        // of Server.sendRawStreamDataInner.  Retransmits (owned_buf set)
-        // bypass the gate because their byte range was already charged on
-        // the original send.
-        const is_fresh = owned_buf == null;
-        if (is_fresh) {
+        if (owned_buf) |buf| {
+            if (!enqueuePendingStreamSendOwned(&self.conn, self.allocator, stream_id, offset, buf, fin)) {
+                self.allocator.free(buf);
+                return 0;
+            }
+            self.drainPendingStreamSends();
+            return data.len;
+        }
+        self.drainPendingStreamSendsUntilStalled();
+        const stream_limit = self.conn.peerStreamSendLimit(stream_id, false);
+        const exceeds_stream = stream_limit > 0 and offset +| data.len > stream_limit;
+        const projected: u64 = self.conn.fc_bytes_sent +| data.len;
+        const exceeds_conn = projected > self.conn.fc_send_max;
+        if (exceeds_stream or exceeds_conn) {
+            if (exceeds_stream) {
+                dbg("io: client per-stream gate stream_id={} end={} limit={} — enqueueing pending + STREAM_DATA_BLOCKED\n", .{
+                    stream_id, offset + data.len, stream_limit,
+                });
+                var blk_buf: [24]u8 = undefined;
+                blk_buf[0] = 0x15; // STREAM_DATA_BLOCKED
+                const sid_enc = varint.encode(blk_buf[1..], stream_id) catch return 0;
+                const lim_enc = varint.encode(blk_buf[1 + sid_enc.len ..], stream_limit) catch return 0;
+                const blk_frame = blk_buf[0 .. 1 + sid_enc.len + lim_enc.len];
+                _ = self.sendClient1Rtt(blk_frame);
+            }
+            if (exceeds_conn) {
+                dbg("io: client send-credit gate stream_id={} bytes={} fc_bytes_sent={} fc_send_max={} — enqueueing pending + DATA_BLOCKED\n", .{
+                    stream_id, data.len, self.conn.fc_bytes_sent, self.conn.fc_send_max,
+                });
+                var blk_buf: [16]u8 = undefined;
+                blk_buf[0] = 0x14;
+                const enc = varint.encode(blk_buf[1..], self.conn.fc_send_max) catch return 0;
+                _ = self.sendClient1Rtt(blk_buf[0 .. 1 + enc.len]);
+            }
+            return self.clientEnqueueFreshStream(stream_id, offset, data, fin);
+        }
+        const now_ms = compat.milliTimestamp();
+        const pace_bytes: u64 = @intCast(data.len);
+        if (!connCanTransmitAppData(&self.conn, now_ms, pace_bytes)) {
             self.drainPendingStreamSendsUntilStalled();
-            // Per-stream + connection-level send-credit gates (RFC 9000
-            // §4.1, §19.9, §19.13).  Mirrors the server-side gate.  On
-            // failure we enqueue the bytes instead of silently dropping
-            // them — see Server.sendRawStreamDataInner for the rationale
-            // and the original-bug analysis in
-            // CHANGELOG.md (entry for v1.7.0 "buffer flow-control-blocked
-            // raw stream sends").
-            const stream_limit = self.conn.peerStreamSendLimit(stream_id, false);
-            const exceeds_stream = stream_limit > 0 and offset +| data.len > stream_limit;
-            const projected: u64 = self.conn.fc_bytes_sent +| data.len;
-            const exceeds_conn = projected > self.conn.fc_send_max;
-            if (exceeds_stream or exceeds_conn) {
-                if (exceeds_stream) {
-                    dbg("io: client per-stream gate stream_id={} end={} limit={} — enqueueing pending + STREAM_DATA_BLOCKED\n", .{
-                        stream_id, offset + data.len, stream_limit,
-                    });
-                    var blk_buf: [24]u8 = undefined;
-                    blk_buf[0] = 0x15; // STREAM_DATA_BLOCKED
-                    const sid_enc = varint.encode(blk_buf[1..], stream_id) catch return 0;
-                    const lim_enc = varint.encode(blk_buf[1 + sid_enc.len ..], stream_limit) catch return 0;
-                    const blk_frame = blk_buf[0 .. 1 + sid_enc.len + lim_enc.len];
-                    _ = self.sendClient1Rtt(blk_frame);
-                }
-                if (exceeds_conn) {
-                    dbg("io: client send-credit gate stream_id={} bytes={} fc_bytes_sent={} fc_send_max={} — enqueueing pending + DATA_BLOCKED\n", .{
-                        stream_id, data.len, self.conn.fc_bytes_sent, self.conn.fc_send_max,
-                    });
-                    var blk_buf: [16]u8 = undefined;
-                    blk_buf[0] = 0x14;
-                    const enc = varint.encode(blk_buf[1..], self.conn.fc_send_max) catch return 0;
-                    _ = self.sendClient1Rtt(blk_buf[0 .. 1 + enc.len]);
-                }
+            if (!connCanTransmitAppData(&self.conn, compat.milliTimestamp(), pace_bytes)) {
                 return self.clientEnqueueFreshStream(stream_id, offset, data, fin);
             }
-            // Congestion + pacer + loss-detector gate (quinn `poll_transmit`).
-            const now_ms = compat.milliTimestamp();
-            const pace_bytes: u64 = @intCast(data.len);
-            if (!connCanTransmitAppData(&self.conn, now_ms, pace_bytes)) {
-                self.drainPendingStreamSendsUntilStalled();
-                if (!connCanTransmitAppData(&self.conn, compat.milliTimestamp(), pace_bytes)) {
-                    return self.clientEnqueueFreshStream(stream_id, offset, data, fin);
-                }
-            }
-        } else if (owned_buf) |buf| {
-            if (!connCanTransmitAppData(&self.conn, compat.milliTimestamp(), @intCast(buf.len))) {
-                if (!enqueuePendingStreamSendOwned(&self.conn, self.allocator, stream_id, offset, buf, fin)) {
-                    self.allocator.free(buf);
-                }
-                return data.len;
-            }
         }
-        return self.clientSendRawStreamFrame(stream_id, offset, data, fin, owned_buf);
-    }
-
-    /// Build and send one STREAM frame on 1-RTT (shared by fresh send and
-    /// after CC drain retry).  Returns bytes accepted on success.
-    fn clientSendRawStreamFrame(
-        self: *Client,
-        stream_id: u64,
-        offset: u64,
-        data: []const u8,
-        fin: bool,
-        owned_buf: ?[]u8,
-    ) usize {
-        const is_fresh = owned_buf == null;
-        if (!connCanTransmitAppData(&self.conn, compat.milliTimestamp(), @intCast(data.len))) {
-            if (is_fresh) return self.clientEnqueueFreshStream(stream_id, offset, data, fin);
-            if (owned_buf) |buf| {
-                if (!enqueuePendingStreamSendOwned(&self.conn, self.allocator, stream_id, offset, buf, fin)) {
-                    self.allocator.free(buf);
-                }
-                return data.len;
-            }
+        if (!enqueuePendingStreamSend(&self.conn, self.allocator, stream_id, offset, data, fin)) {
+            warnPendingStreamSendQueueFull(&self.conn, stream_id, "client");
             return 0;
         }
-        const sf = stream_frame_mod.StreamFrame{
-            .stream_id = stream_id,
-            .offset = offset,
-            .data = data,
-            .fin = fin,
-            .has_length = true,
-        };
-        var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const flen = sf.serialize(&frame_buf) catch {
-            if (owned_buf) |b| self.allocator.free(b);
-            return 0;
-        };
-        var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-        const pkt_len = build1RttPacketFull(
-            &send_buf,
-            self.conn.remote_cid,
-            frame_buf[0..flen],
-            self.conn.app_pn,
-            &self.conn.app_client_km,
-            self.conn.key_phase_bit,
-            self.conn.packet_cipher,
-            self.conn.peer_grease_quic_bit,
-        ) catch {
-            if (owned_buf) |b| self.allocator.free(b);
-            return 0;
-        };
-        if (!self.conn.ld.hasCapacity()) {
-            if (is_fresh) return self.clientEnqueueFreshStream(stream_id, offset, data, fin);
-            if (owned_buf) |buf| {
-                if (!enqueuePendingStreamSendOwned(&self.conn, self.allocator, stream_id, offset, buf, fin)) {
-                    self.allocator.free(buf);
-                }
-                return data.len;
-            }
-            return 0;
-        }
-        const pn = self.conn.app_pn;
-        self.conn.app_pn += 1;
-        // Batched send (sendmmsg at the next flush); the datagram is copied into
-        // the batch so `send_buf` may be reused immediately. Loss recovery still
-        // tracks the packet for retransmit exactly as the immediate-send path did.
-        self.batchSend(send_buf[0..pkt_len]);
-        // Charge fresh-send bytes against the connection-level limit.
-        if (is_fresh) self.conn.fc_bytes_sent +|= data.len;
-
-        // Track for retransmit.  See Server.sendRawStreamDataInner for the
-        // ownership-transfer protocol; the Client mirrors it.
-        //
-        // Zero-length STREAM frames (FIN-only — every libp2p stream close sends
-        // `sendRawStreamData(.., &[_]u8{}, true)`) have nothing to retransmit.
-        // `dupe(u8, &.{})` returns the allocator's zero-length sentinel slice
-        // (ptr 0xffff…, len 0); tracking it and freeing it on ack/loss hands
-        // jemalloc a bogus pointer and segfaults (`arena_dalloc_large`).  Carry
-        // such packets with no retransmit buffer instead.
-        const buf: ?[]u8 = if (owned_buf) |b| b else if (data.len == 0) null else (self.allocator.dupe(u8, data) catch return 0);
-        self.conn.note1RttSent();
-        const recorded = self.conn.ld.onPacketSent(.{
-            .pn = pn,
-            .send_time_ms = @intCast(compat.milliTimestamp()),
-            .size = pkt_len,
-            .ack_eliciting = true,
-            .in_flight = true,
-            .has_stream_data = buf != null,
-            .stream_id = stream_id,
-            .stream_offset = offset,
-            .stream_data = buf,
-            .stream_fin = fin,
-            .space = .application,
-        });
-        // Mirror Server.send1Rtt: only count toward bytes_in_flight when the
-        // loss detector is tracking the packet.  Without this, checkPto
-        // branch 1 (cc.getBytesInFlight() > 0) never fires, tail losses on
-        // the outbound client path are not PTO-probed, and quinn peers wedge
-        // on undelivered gossip STREAM frames.
-        if (recorded) {
-            self.conn.cc.onPacketSent(@intCast(pkt_len));
-            if (is_fresh) self.conn.pacerConsume(@intCast(pkt_len));
-        }
-        if (!recorded) {
-            // LD full — caller's data has already gone on the wire; we just
-            // can't retransmit it on loss.  Free the buffer to avoid the leak.
-            if (buf) |b| self.allocator.free(b);
-        }
+        self.drainPendingStreamSends();
         return data.len;
     }
 
-    /// Try to put queued raw STREAM bytes (`pending_stream_sends`) on the
+    /// Try to put queued raw STREAM bytes (per-stream `SendBuffer`) on the
     /// wire, honoring the same per-stream + connection-level flow-control
     /// gates as the initial submission.  Mirrors
     /// `Server.drainPendingStreamSends`; see that function for the
     /// design notes.
     fn drainPendingStreamSends(self: *Client) void {
         if (self.conn.draining or self.conn.phase != .connected or !self.conn.has_app_keys) return;
-        if (self.conn.pending_stream_sends.items.len == 0) return;
-        var i: usize = 0;
+        if (!streamSendHasWork(&self.conn)) return;
         var drained: usize = 0;
-        while (i < self.conn.pending_stream_sends.items.len) {
-            if (drained >= max_pending_drain_per_call) return; // fairness bound
-            const p = &self.conn.pending_stream_sends.items[i];
-            const unsent = p.data.len - p.sent_in_buf;
-            const chunk_len = @min(unsent, max_pending_stream_chunk);
-            const stream_limit = self.conn.peerStreamSendLimit(p.stream_id, false);
-            if (stream_limit > 0 and p.offset +| chunk_len > stream_limit) {
-                i += 1;
-                continue;
+        for (&self.conn.stream_send_slots) |*slot| {
+            if (!slot.active) continue;
+            while (drained < max_pending_drain_per_call) {
+                const poll = slot.buf.pollTransmit(max_pending_stream_chunk) orelse break;
+                if (!emitStreamPollClient(self, slot.stream_id, poll)) {
+                    maybeLogPendingStreamStall(&self.conn, "client");
+                    self.conn.pending_stream_send_bytes = streamSendQueuedBytes(&self.conn);
+                    return;
+                }
+                drained += 1;
             }
-            const projected: u64 = self.conn.fc_bytes_sent +| chunk_len;
-            if (projected > self.conn.fc_send_max) {
-                i += 1;
-                continue;
-            }
-            const pace_bytes: u64 = @intCast(chunk_len);
-            if (!connCanTransmitAppData(&self.conn, compat.milliTimestamp(), pace_bytes)) {
-                maybeLogPendingStreamStall(&self.conn, "client");
+            if (drained >= max_pending_drain_per_call) {
+                self.conn.pending_stream_send_bytes = streamSendQueuedBytes(&self.conn);
                 return;
-            }
-            const stream_id = p.stream_id;
-            const offset = p.offset;
-            const fin = p.fin and p.sent_in_buf + chunk_len == p.data.len;
-            const chunk = p.data[p.sent_in_buf .. p.sent_in_buf + chunk_len];
-            const sf = stream_frame_mod.StreamFrame{
-                .stream_id = stream_id,
-                .offset = offset,
-                .data = chunk,
-                .fin = fin,
-                .has_length = true,
-            };
-            var frame_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-            const flen = sf.serialize(&frame_buf) catch {
-                i += 1;
-                continue;
-            };
-            if (!self.conn.ld.hasCapacity()) {
-                maybeLogPendingStreamStall(&self.conn, "client");
-                return;
-            }
-            var send_buf: [MAX_DATAGRAM_SIZE]u8 = undefined;
-            const pkt_len = build1RttPacketFull(
-                &send_buf,
-                self.conn.remote_cid,
-                frame_buf[0..flen],
-                self.conn.app_pn,
-                &self.conn.app_client_km,
-                self.conn.key_phase_bit,
-                self.conn.packet_cipher,
-                self.conn.peer_grease_quic_bit,
-            ) catch {
-                i += 1;
-                continue;
-            };
-            const pn = self.conn.app_pn;
-            self.conn.app_pn += 1;
-            // Batched 1-RTT send (sendmmsg at the next flush). This is the
-            // deferred-stream / retransmit drain — the hottest client send path
-            // when forwarding gossip under backpressure.
-            self.batchSend(send_buf[0..pkt_len]);
-            self.conn.fc_bytes_sent +|= chunk_len;
-            self.conn.note1RttSent();
-            drained += 1;
-            // FIN-only entries (chunk_len == 0) carry no retransmittable bytes.
-            // Never dupe an empty chunk: `dupe(u8, &.{})` returns the
-            // allocator's zero-length sentinel slice, which freeing on ack/loss
-            // corrupts the heap. Track with no stream_data; a lost bare FIN is
-            // re-emitted by the FIN-only loss-recovery arm.
-            const rtx_buf: ?[]u8 = if (chunk_len == 0) null else (self.allocator.dupe(u8, chunk) catch {
-                i += 1;
-                continue;
-            });
-            const recorded = self.conn.ld.onPacketSent(.{
-                .pn = pn,
-                .send_time_ms = @intCast(compat.milliTimestamp()),
-                .size = pkt_len,
-                .ack_eliciting = true,
-                .in_flight = true,
-                .has_stream_data = rtx_buf != null,
-                .stream_id = stream_id,
-                .stream_offset = offset,
-                .stream_data = rtx_buf,
-                .stream_fin = fin,
-                .space = .application,
-            });
-            if (recorded) {
-                self.conn.cc.onPacketSent(@intCast(pkt_len));
-                self.conn.pacerConsume(@intCast(pkt_len));
-            } else if (rtx_buf) |b| {
-                self.allocator.free(b);
-            }
-            p.sent_in_buf += chunk_len;
-            p.offset += chunk_len;
-            self.conn.pending_stream_send_bytes -|= chunk_len;
-            if (p.sent_in_buf == p.data.len) {
-                const buf = p.data;
-                _ = self.conn.pending_stream_sends.orderedRemove(i);
-                if (buf.len > 0) self.allocator.free(buf);
-            } else {
-                i += 1;
             }
         }
+        self.conn.pending_stream_send_bytes = streamSendQueuedBytes(&self.conn);
     }
 
     /// RFC 8899: probe a larger UDP payload when PLPMTUD state allows it.
@@ -8862,7 +8534,7 @@ pub const Client = struct {
         const has_substantial_data_stuck =
             self.conn.cc.getBytesInFlight() >= 1024 or
             self.conn.ld.sent_count >= recovery.LossDetector.max_tracked_packets / 4 or
-            self.conn.pending_stream_sends.items.len > 0;
+            streamSendHasWork(&self.conn);
         if (self.conn.phase == .connected and
             elapsed_since_ack >= lost_threshold_ms and has_substantial_data_stuck)
         {
@@ -8872,7 +8544,7 @@ pub const Client = struct {
                 self.conn.cc.getBytesInFlight(),
                 self.conn.ld.sent_count,
                 recovery.LossDetector.max_tracked_packets,
-                self.conn.pending_stream_sends.items.len,
+                streamSendActiveSlotCount(&self.conn),
                 self.conn.app_pn,
                 self.conn.cc.getTotalBytesAcked(),
                 self.conn.ld.total_declared_lost,
@@ -8967,6 +8639,7 @@ pub const Client = struct {
 
     /// Mirror of the connection-level `releaseRawAppStream`.
     pub fn releaseRawAppStream(self: *Client, stream_id: u64) bool {
+        send_buffer_mod.releaseStreamSendSlot(self.conn.stream_send_slots[0..], self.allocator, stream_id);
         for (&self.raw_app_recv) |*slot| {
             if (slot.active and slot.stream_id == stream_id) {
                 slot.deinit(self.allocator);
@@ -9769,6 +9442,7 @@ pub const Client = struct {
                     @intCast(now_ms),
                     &self.conn.rtt,
                     &lost_buf,
+                    &[_]recovery.StreamAck{},
                     self.allocator,
                 )) |_| {
                     noteConnAckInSpace(&self.conn, .initial, now_ms);
@@ -9886,6 +9560,7 @@ pub const Client = struct {
                     @intCast(now_ms),
                     &self.conn.rtt,
                     &lost_buf,
+                    &[_]recovery.StreamAck{},
                     self.allocator,
                 )) |_| {
                     noteConnAckInSpace(&self.conn, .handshake, now_ms);
@@ -10127,6 +9802,7 @@ pub const Client = struct {
                 const first_ack_range = fst_r.value;
 
                 var lost_buf: [32]recovery.SentPacket = undefined;
+                var acked_stream_buf: [64]recovery.StreamAck = undefined;
                 const ld_result = self.conn.ld.onAck(
                     .application,
                     largest_ack,
@@ -10135,12 +9811,14 @@ pub const Client = struct {
                     @intCast(compat.milliTimestamp()),
                     &self.conn.rtt,
                     &lost_buf,
+                    acked_stream_buf[0..],
                     self.allocator,
                 ) catch {
                     pos += skipAckBody(plaintext[pos..pt_len], ft == 0x03);
                     continue;
                 };
                 if (ld_result.bytes_acked > 0) self.conn.cc.onAck(ld_result.bytes_acked, largest_ack);
+                applyStreamAcks(&self.conn, self.allocator, acked_stream_buf[0..ld_result.acked_stream_count]);
                 self.conn.noteLossFromAck(ld_result.lost_count, ld_result.lost_bytes);
                 if (self.conn.plpmtu.probe_pn) |probe_pn| {
                     if (largest_ack >= probe_pn) {
@@ -10185,7 +9863,12 @@ pub const Client = struct {
                             self.conn.syncPathMtuFields();
                         }
                     }
-                    if (lp.stream_data) |sbuf| {
+                    if (lp.stream_byte_len > 0 and lp.stream_data == null) {
+                        if (send_buffer_mod.findStreamSendSlot(self.conn.stream_send_slots[0..], lp.stream_id)) |sbuf| {
+                            sbuf.onLoss(self.allocator, lp.stream_offset, lp.stream_byte_len) catch {};
+                        }
+                        self.drainPendingStreamSends();
+                    } else if (lp.stream_data) |sbuf| {
                         const rtx_bytes: u64 = @intCast(sbuf.len);
                         if (connCanTransmitAppData(&self.conn, compat.milliTimestamp(), rtx_bytes)) {
                             _ = self.sendRawStreamDataInner(lp.stream_id, lp.stream_offset, sbuf, lp.stream_fin, sbuf);
@@ -11774,51 +11457,40 @@ test "seedLocalRecvWindows: libp2p preset" {
 test "pending stream send: contiguous enqueues coalesce on same stream" {
     var conn = makeConnForStreamTest();
     defer freePendingStreamSends(&conn, std.testing.allocator);
-    // Sequential gossipsub chunks on one stream append to the tail entry
-    // instead of consuming one slot per chunk.
     try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, 0, "aaaa", false));
     try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, 4, "bbbb", false));
     try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, 8, "cccc", true));
-    try std.testing.expectEqual(@as(usize, 1), conn.pending_stream_sends.items.len);
+    const sbuf = send_buffer_mod.findStreamSendSlot(conn.stream_send_slots[0..], 4).?;
+    try std.testing.expectEqual(@as(usize, 1), sbuf.segments.items.len);
     try std.testing.expectEqual(@as(usize, 12), conn.pending_stream_send_bytes);
-    try std.testing.expectEqual(@as(u64, 0), conn.pending_stream_sends.items[0].offset);
-    try std.testing.expectEqualSlices(u8, "aaaabbbbcccc", conn.pending_stream_sends.items[0].data);
-    try std.testing.expect(conn.pending_stream_sends.items[0].fin);
+    try std.testing.expectEqual(@as(u64, 0), sbuf.segments.items[0].offset);
+    try std.testing.expectEqualSlices(u8, "aaaabbbbcccc", sbuf.segments.items[0].data);
+    try std.testing.expect(sbuf.fin_at != null);
 }
 
 test "pending stream send: FIN-only frame rides out on the last queued frame" {
     var conn = makeConnForStreamTest();
     defer freePendingStreamSends(&conn, std.testing.allocator);
-    // A large response's payload is backpressured in the queue; the trailing
-    // half-close (0-byte FIN) must attach to the last queued frame for that
-    // stream rather than be dropped — otherwise the peer never sees the FIN
-    // and the response never completes (gap-offsets prevent coalescing).
     try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, 0, "aaaa", false));
     try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, 100, "bbbb", false));
-    try std.testing.expectEqual(@as(usize, 2), conn.pending_stream_sends.items.len);
-    try std.testing.expect(!conn.pending_stream_sends.items[1].fin);
+    const sbuf = send_buffer_mod.findStreamSendSlot(conn.stream_send_slots[0..], 4).?;
+    try std.testing.expectEqual(@as(usize, 2), sbuf.segments.items.len);
+    try std.testing.expect(sbuf.fin_at == null);
 
-    // FIN-only at the end offset: no new entry, FIN set on the last frame.
     try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, 104, &.{}, true));
-    try std.testing.expectEqual(@as(usize, 2), conn.pending_stream_sends.items.len);
-    try std.testing.expect(conn.pending_stream_sends.items[1].fin);
-    try std.testing.expect(!conn.pending_stream_sends.items[0].fin);
+    try std.testing.expectEqual(@as(usize, 2), sbuf.segments.items.len);
+    try std.testing.expectEqual(@as(?u64, 104), sbuf.fin_at);
+    try std.testing.expect(sbuf.segments.items[0].offset == 0);
 }
 
-test "pending stream send: cap rejects past per-conn entry budget" {
+test "pending stream send: cap rejects past per-stream slot budget" {
     var conn = makeConnForStreamTest();
     defer freePendingStreamSends(&conn, std.testing.allocator);
-    // Fill to the per-conn entry cap with tiny payloads so we hit the
-    // entry-count limit (not the byte limit).  Use gaps in offset so
-    // coalescing does not collapse the entries.
     var i: usize = 0;
-    while (i < pending_stream_send_cap) : (i += 1) {
-        try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, @intCast(i * 2), "x", false));
+    while (i < send_buffer_mod.stream_send_slot_max) : (i += 1) {
+        try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, @intCast(i * 4), 0, "x", false));
     }
-    // One more must fail; the caller is expected to mark the conn
-    // draining so the embedder reconnects (silently dropping would
-    // corrupt the stream offset).
-    try std.testing.expect(!enqueuePendingStreamSend(&conn, std.testing.allocator, 4, @intCast(i * 2), "x", false));
+    try std.testing.expect(!enqueuePendingStreamSend(&conn, std.testing.allocator, @intCast(i * 4), 0, "x", false));
 }
 
 test "pending stream send (owned): false return leaves `owned` to the caller (no double-free)" {
@@ -11833,32 +11505,29 @@ test "pending stream send (owned): false return leaves `owned` to the caller (no
     var conn = makeConnForStreamTest();
     defer freePendingStreamSends(&conn, a);
 
-    // Fill to the per-conn entry cap so the next owned-enqueue hits the
-    // queue-full false path.
+    // Fill all per-stream send slots so the next enqueue hits the slot cap.
     var i: usize = 0;
-    while (i < pending_stream_send_cap) : (i += 1) {
-        try std.testing.expect(enqueuePendingStreamSend(&conn, a, 4, @intCast(i * 2), "x", false));
+    while (i < send_buffer_mod.stream_send_slot_max) : (i += 1) {
+        try std.testing.expect(enqueuePendingStreamSend(&conn, a, @intCast(i * 4), 0, "x", false));
     }
 
-    // Exercise the OWNED variant on the full queue exactly as the callers do.
     const owned = try a.dupe(u8, "retransmit-me");
-    const queued = enqueuePendingStreamSendOwned(&conn, a, 4, 10_000_000, owned, false);
+    const queued = enqueuePendingStreamSendOwned(&conn, a, @intCast(i * 4), 0, owned, false);
     try std.testing.expect(!queued); // full → false
     if (!queued) a.free(owned); // single, correct free — NOT a double-free
 }
 
-test "pending stream send: oversized write stored as single entry (split at drain)" {
+test "pending stream send: oversized write stored as single segment (split at drain)" {
     var conn = makeConnForStreamTest();
     defer freePendingStreamSends(&conn, std.testing.allocator);
-    // Large writes are kept as one queue entry; `drainPendingStreamSends`
-    // slices at packet-build time instead of fanning out on enqueue.
     const big = try std.testing.allocator.alloc(u8, max_pending_stream_chunk * 4 + 100);
     defer std.testing.allocator.free(big);
     @memset(big, 0xaa);
     try std.testing.expect(enqueuePendingStreamSend(&conn, std.testing.allocator, 4, 0, big, true));
-    try std.testing.expectEqual(@as(usize, 1), conn.pending_stream_sends.items.len);
-    try std.testing.expectEqual(@as(usize, big.len), conn.pending_stream_sends.items[0].data.len);
-    try std.testing.expect(conn.pending_stream_sends.items[0].fin);
+    const sbuf = send_buffer_mod.findStreamSendSlot(conn.stream_send_slots[0..], 4).?;
+    try std.testing.expectEqual(@as(usize, 1), sbuf.segments.items.len);
+    try std.testing.expectEqual(@as(usize, big.len), sbuf.segments.items[0].data.len);
+    try std.testing.expect(sbuf.fin_at != null);
 }
 
 test "AppAckTracker: adjacent ranges coalesce and serialize without integer overflow" {
@@ -12043,7 +11712,7 @@ test "client 1-RTT send: loss detector and CC bytes_in_flight stay coupled" {
     try std.testing.expectEqual(@as(u64, @intCast(pkt_len)), conn.cc.getBytesInFlight());
 
     var lost_buf: [8]recovery.SentPacket = undefined;
-    const ld_result = try conn.ld.onAck(.application, pn, 0, 0, 1000, &conn.rtt, &lost_buf, std.testing.allocator);
+    const ld_result = try conn.ld.onAck(.application, pn, 0, 0, 1000, &conn.rtt, &lost_buf, &[_]recovery.StreamAck{}, std.testing.allocator);
     if (ld_result.bytes_acked > 0) conn.cc.onAck(ld_result.bytes_acked, pn);
     try std.testing.expectEqual(@as(u64, 0), conn.cc.getBytesInFlight());
 }
@@ -12615,7 +12284,7 @@ test "raw-app server-initiated bidi: CLIENT separate empty-FIN survives a pacer-
     // 3. Submit the SEPARATE empty FIN while the pacer is drained — this is the
     //    flake window. The data frame already went on the wire, so
     //    `pending_stream_sends` is empty for this stream.
-    try std.testing.expectEqual(@as(usize, 0), lb.client.conn.pending_stream_sends.items.len);
+    try std.testing.expect(!streamSendHasWork(&lb.client.conn));
     lb.client.conn.pacing_tokens = 0;
     lb.client.conn.pacing_last_ms = compat.milliTimestamp();
     _ = lb.client.sendRawStreamData(sid, response.len, &[_]u8{}, true);

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -11779,6 +11779,15 @@ const RawDrop = struct {
     /// Only drop datagrams at least this large, so we target a STREAM-bearing
     /// data packet rather than a bare ACK.
     min_len: usize = 0,
+    /// When non-zero, drop the Nth eligible datagram (counting only those that
+    /// pass `min_len`).  Lets a test simulate periodic loss across a long
+    /// transfer (e.g. interop's NS3 1% drop pattern) without burning up
+    /// `remaining` on consecutive packets.
+    drop_every: usize = 0,
+    /// Total drops performed so far (test diagnostic).
+    drops_done: usize = 0,
+    /// Internal counter for `drop_every`.
+    seen: usize = 0,
 };
 
 /// Drive one pump iteration of the in-process loopback: wait briefly for I/O,
@@ -11802,9 +11811,19 @@ fn rawPumpOnce(server: *Server, client: *Client, server_addr: compat.Address, dr
 
     while (rawSockReadable(client.sock)) {
         const n = compat.recvfrom(client.sock, &buf, 0, null, null) catch break;
-        if (drop.remaining > 0 and n >= drop.min_len) {
-            drop.remaining -= 1;
-            continue;
+        if (n >= drop.min_len) {
+            if (drop.remaining > 0) {
+                drop.remaining -= 1;
+                drop.drops_done += 1;
+                continue;
+            }
+            if (drop.drop_every > 0) {
+                drop.seen += 1;
+                if (drop.seen % drop.drop_every == 0) {
+                    drop.drops_done += 1;
+                    continue;
+                }
+            }
         }
         client.feedPacket(buf[0..n]);
     }

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1150,6 +1150,14 @@ fn enqueuePendingStreamSendOwned(
     const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
     if (sbuf.coversRange(offset, owned.len)) {
         allocator.free(owned);
+        if (fin) {
+            const fa = offset + owned.len;
+            if (sbuf.fin_at) |cur| {
+                sbuf.fin_at = @max(cur, fa);
+            } else {
+                sbuf.fin_at = fa;
+            }
+        }
         conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
         return true;
     }
@@ -5427,6 +5435,7 @@ pub const Server = struct {
                         }
                     }
                 }
+                send_buffer_mod.releaseIdleStreamSendSlots(conn.stream_send_slots[0..], self.allocator);
                 // ACK received — reset PTO backoff counter and record timestamp
                 // (RFC 9002 §6.2.1: PTO resets when an ACK is received).
                 noteConnAckInSpace(conn, .application, compat.milliTimestamp());
@@ -8947,6 +8956,13 @@ pub const Client = struct {
             }
             self.processPacket(recv_buf[0..n]);
 
+            // Send the next 0-RTT batch once the link has drained (batch 2 is
+            // normally triggered from processInitialPacket; this covers the case
+            // where the server Initial is delayed or already processed).
+            if (self.early_km != null and self.zerortt_count < self.active_urls.len) {
+                self.send0RttRequests(server_addr) catch {};
+            }
+
             // Connection migration: after the handshake, rebind to a new local
             // UDP port.  Sending any 1-RTT packet from the new address causes
             // the server to detect the address change and send a PATH_CHALLENGE;
@@ -9950,6 +9966,7 @@ pub const Client = struct {
                         _ = self.sendRawStreamDataInner(lp.stream_id, lp.stream_offset, &[_]u8{}, true, null);
                     }
                 }
+                send_buffer_mod.releaseIdleStreamSendSlots(self.conn.stream_send_slots[0..], self.allocator);
                 // ACK received — reset PTO backoff counter and record timestamp
                 // (RFC 9002 §6.2.1: PTO resets when an ACK is received).
                 // Mirrors the server-side bookkeeping at the matching ACK arm.
@@ -10900,6 +10917,42 @@ pub const Client = struct {
 
         self.flushDeferredAck();
         self.flushSendBatch();
+
+        // All GETs were already sent as 0-RTT — only wait for responses.
+        if (self.zerortt_count >= self.active_urls.len and self.active_urls.len > 0) {
+            const dl_deadline = compat.milliTimestamp() + 120_000;
+            var dl_iter: u32 = 0;
+            while (self.streams_done < self.active_urls.len) {
+                dl_iter += 1;
+                const now = compat.milliTimestamp();
+                const remaining = dl_deadline - now;
+                if (remaining <= 0) {
+                    dbg("io: downloadUrls 0-RTT-only DEADLINE streams_done={}/{}\n", .{ self.streams_done, self.active_urls.len });
+                    break;
+                }
+                if (dl_iter % 100 == 0) {
+                    dbg("io: downloadUrls 0-RTT-only iter {} streams_done={}/{}\n", .{ dl_iter, self.streams_done, self.active_urls.len });
+                }
+                var fds = [1]std.posix.pollfd{.{ .fd = self.sock, .events = std.posix.POLL.IN, .revents = 0 }};
+                const poll_timeout: i32 = @intCast(@min(200, @max(0, remaining)));
+                const ready = std.posix.poll(&fds, poll_timeout) catch 0;
+                if (ready == 0) {
+                    self.flushDeferredAck();
+                    self.flushSendBatch();
+                    continue;
+                }
+                if (fds[0].revents & std.posix.POLL.IN == 0) continue;
+                var rb = batch_io.RecvBatch{};
+                const n_recv = rb.recv(self.sock, true);
+                for (rb.entries[0..n_recv]) |*e| {
+                    self.processPacket(e.buf[0..e.len]);
+                }
+                self.flushDeferredAck();
+                self.flushSendBatch();
+            }
+            dbg("io: downloadUrls done streams_done={}/{}\n", .{ self.streams_done, self.active_urls.len });
+            return;
+        }
 
         // Process downloads in batches to stay within NS3 network simulator limits.
         // The NS3 DropTail queue is 25 packets; sending more than ~20 packets at

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -229,26 +229,26 @@ const AppAckTracker = struct {
         if (pn > self.largest) self.largest = pn;
         if (self.range_count > 0) {
             for (self.ranges[0..self.range_count]) |*r| {
-                if (pn >= r[0] and pn <= r[1]) return self.range_count >= 48;
+                if (pn >= r[0] and pn <= r[1]) return self.range_count >= 16;
                 if (pn + 1 == r[0]) {
                     r[0] = pn;
-                    return self.range_count >= 48;
+                    return self.range_count >= 16;
                 }
                 if (pn == r[1] + 1) {
                     r[1] = pn;
-                    return self.range_count >= 48;
+                    return self.range_count >= 16;
                 }
             }
         }
         if (self.range_count == 0) {
             self.ranges[0] = .{ pn, pn };
             self.range_count = 1;
-            return self.range_count >= 48;
+            return self.range_count >= 16;
         }
         if (self.range_count < self.ranges.len) {
             self.ranges[self.range_count] = .{ pn, pn };
             self.range_count += 1;
-            return self.range_count >= 48;
+            return self.range_count >= 16;
         }
         return true;
     }
@@ -5241,7 +5241,7 @@ pub const Server = struct {
                 // SendBuffer.onAck never pruned those ranges → drain re-emitted
                 // bytes that the peer already had → CC stuck in recovery,
                 // transfer timed out at 168 s on the post-fix interop run.
-                var acked_stream_buf: [1024]recovery.StreamAck = undefined;
+                var acked_stream_buf: [2048]recovery.StreamAck = undefined;
                 const ld_result = conn.ld.onAck(
                     .application,
                     largest_ack,
@@ -9874,7 +9874,7 @@ pub const Client = struct {
                 // SendBuffer.onAck never pruned those ranges → drain re-emitted
                 // bytes that the peer already had → CC stuck in recovery,
                 // transfer timed out at 168 s on the post-fix interop run.
-                var acked_stream_buf: [1024]recovery.StreamAck = undefined;
+                var acked_stream_buf: [2048]recovery.StreamAck = undefined;
                 const ld_result = self.conn.ld.onAck(
                     .application,
                     largest_ack,
@@ -10226,11 +10226,11 @@ pub const Client = struct {
             return;
         }
 
-        // Defer ACK until after the recv drain loop in downloadUrls.
-        if (self.app_ack.observe(decompressed_pn)) {
-            self.flushDeferredAck();
-            _ = self.app_ack.observe(decompressed_pn);
-        }
+        // Flush ACKs promptly so the server's CC window opens during 0-RTT
+        // response bursts (zerortt / multiplexing); deferring until 48 PNs
+        // stalled the peer when fewer than 48 responses were in flight.
+        _ = self.app_ack.observe(decompressed_pn);
+        self.flushDeferredAck();
     }
 
     /// Send a CONNECTION_CLOSE frame (QUIC layer, type 0x1c) and enter draining.

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -5193,7 +5193,14 @@ pub const Server = struct {
                 // Pass first_ack_range so the loss detector can correctly
                 // distinguish acked packets from those in gaps.
                 var lost_buf: [32]recovery.SentPacket = undefined;
-                var acked_stream_buf: [64]recovery.StreamAck = undefined;
+                // 1024 covers the realistic per-ACK stream-range count for
+                // multi-MB transfers (bulk file download ~hundreds of packets
+                // in flight; tail-drop ACKs can confirm many at once). The
+                // previous 64-entry cap silently dropped overflow entries →
+                // SendBuffer.onAck never pruned those ranges → drain re-emitted
+                // bytes that the peer already had → CC stuck in recovery,
+                // transfer timed out at 168 s on the post-fix interop run.
+                var acked_stream_buf: [1024]recovery.StreamAck = undefined;
                 const ld_result = conn.ld.onAck(
                     .application,
                     largest_ack,
@@ -9802,7 +9809,14 @@ pub const Client = struct {
                 const first_ack_range = fst_r.value;
 
                 var lost_buf: [32]recovery.SentPacket = undefined;
-                var acked_stream_buf: [64]recovery.StreamAck = undefined;
+                // 1024 covers the realistic per-ACK stream-range count for
+                // multi-MB transfers (bulk file download ~hundreds of packets
+                // in flight; tail-drop ACKs can confirm many at once). The
+                // previous 64-entry cap silently dropped overflow entries →
+                // SendBuffer.onAck never pruned those ranges → drain re-emitted
+                // bytes that the peer already had → CC stuck in recovery,
+                // transfer timed out at 168 s on the post-fix interop run.
+                var acked_stream_buf: [1024]recovery.StreamAck = undefined;
                 const ld_result = self.conn.ld.onAck(
                     .application,
                     largest_ack,

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -150,7 +150,14 @@ pub const SendBuffer = struct {
                     @memcpy(grown[last.data.len..][0..data.len], data);
                     last.data = grown;
                     self.queued_bytes += data.len;
-                    if (fin) self.fin_at = offset + data.len;
+                    if (fin) {
+                        const fa = offset + data.len;
+                        if (self.fin_at) |cur| {
+                            self.fin_at = @max(cur, fa);
+                        } else {
+                            self.fin_at = fa;
+                        }
+                    }
                     return;
                 }
             }
@@ -302,6 +309,19 @@ pub const SendBuffer = struct {
         return false;
     }
 
+    /// True when all enqueued bytes are sent and contiguously ACKed (safe to
+    /// drop the per-stream slot).  Stricter than `hasWork`: sent-but-unacked
+    /// data with a leading gap must not be released before loss recovery runs.
+    pub fn isSendComplete(self: *const SendBuffer) bool {
+        if (self.lost.items.len > 0) return false;
+        for (self.segments.items) |seg| {
+            if (seg.sent < seg.data.len) return false;
+            if (contiguousAckedEnd(seg.acked_ranges.items) < seg.data.len) return false;
+        }
+        if (self.fin_at != null and !self.fin_sent) return false;
+        return true;
+    }
+
     /// Next range to put on the wire (lost ranges first, then unsent tail).
     pub fn pollTransmit(self: *SendBuffer, max_len: usize) ?PollResult {
         if (max_len == 0) return null;
@@ -426,6 +446,19 @@ pub fn releaseStreamSendSlot(slots: []StreamSendSlot, allocator: std.mem.Allocat
             slot.buf.deinit(allocator);
             slot.* = .{};
             return;
+        }
+    }
+}
+
+/// Free per-stream send slots whose `SendBuffer` has no unsent or unacked work.
+/// HTTP/0.9 immediate responses (multiplexing / zerortt) only need a slot until
+/// the peer ACKs; without this the 64-slot table is exhausted after ~64 streams.
+pub fn releaseIdleStreamSendSlots(slots: []StreamSendSlot, allocator: std.mem.Allocator) void {
+    for (slots) |*slot| {
+        if (!slot.active) continue;
+        if (slot.buf.isSendComplete()) {
+            slot.buf.deinit(allocator);
+            slot.* = .{};
         }
     }
 }
@@ -574,4 +607,21 @@ test "send_buffer: non-contiguous ack retains gap for retransmit (#221)" {
     buf.onAck(testing.allocator, 0, 1436);
     try testing.expectEqual(@as(usize, 0), buf.segments.items.len);
     try testing.expectEqual(@as(usize, 0), buf.queued_bytes);
+}
+
+test "send_buffer: releaseIdleStreamSendSlots frees acked slots" {
+    const testing = std.testing;
+    var slots: [stream_send_slot_max]StreamSendSlot = [_]StreamSendSlot{.{}} ** stream_send_slot_max;
+
+    const s0 = getOrCreateStreamSendSlot(&slots, 0) orelse return error.TestUnexpectedNull;
+    try s0.append(testing.allocator, 0, "ok", true);
+    const p = s0.pollTransmit(2).?;
+    s0.onSent(p.offset, p.data.len);
+    s0.onAck(testing.allocator, 0, 2);
+    s0.onAck(testing.allocator, 2, 0);
+    try testing.expect(s0.isSendComplete());
+
+    releaseIdleStreamSendSlots(&slots, testing.allocator);
+    try testing.expect(!slots[0].active);
+    try testing.expect(getOrCreateStreamSendSlot(&slots, 4) != null);
 }

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -232,8 +232,11 @@ pub const SendBuffer = struct {
     /// Mark `[offset, offset+len)` as ACKed by the peer.
     pub fn onAck(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) void {
         if (len == 0) {
-            if (self.fin_at == offset) self.fin_sent = false;
-            self.fin_at = null;
+            if (self.fin_at) |fa| {
+                if (offset != fa) return;
+                self.fin_sent = false;
+                self.fin_at = null;
+            }
             return;
         }
         const end = offset + len;
@@ -452,7 +455,7 @@ pub fn releaseStreamSendSlot(slots: []StreamSendSlot, allocator: std.mem.Allocat
 
 /// Free per-stream send slots whose `SendBuffer` has no unsent or unacked work.
 /// HTTP/0.9 immediate responses (multiplexing / zerortt) only need a slot until
-/// the peer ACKs; without this the 64-slot table is exhausted after ~64 streams.
+/// the peer ACKs; without this the slot table is exhausted after ~slot_max streams.
 pub fn releaseIdleStreamSendSlots(slots: []StreamSendSlot, allocator: std.mem.Allocator) void {
     for (slots) |*slot| {
         if (!slot.active) continue;
@@ -624,4 +627,17 @@ test "send_buffer: releaseIdleStreamSendSlots frees acked slots" {
     releaseIdleStreamSendSlots(&slots, testing.allocator);
     try testing.expect(!slots[0].active);
     try testing.expect(getOrCreateStreamSendSlot(&slots, 4) != null);
+}
+
+test "send_buffer: onAck len=0 at wrong offset does not clear fin_at" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 0, "data", true);
+    const p = buf.pollTransmit(4).?;
+    buf.onSent(p.offset, p.data.len);
+    try testing.expectEqual(@as(?u64, 4), buf.fin_at);
+    buf.onAck(testing.allocator, 0, 0);
+    try testing.expectEqual(@as(?u64, 4), buf.fin_at);
 }

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -159,7 +159,22 @@ pub const SendBuffer = struct {
             self.queued_bytes += data.len;
         }
         if (fin) {
-            self.fin_at = if (data.len > 0) offset + data.len else offset;
+            const fa: u64 = if (data.len > 0) offset + data.len else blk: {
+                var end = offset;
+                for (self.segments.items) |seg| {
+                    const seg_end = seg.offset + seg.data.len;
+                    if (offset >= seg.offset and offset < seg_end) {
+                        end = seg_end;
+                        break;
+                    }
+                }
+                break :blk end;
+            };
+            if (self.fin_at) |cur| {
+                self.fin_at = @max(cur, fa);
+            } else {
+                self.fin_at = fa;
+            }
         }
     }
 
@@ -494,6 +509,21 @@ test "send_buffer: overlapping onLoss calls coalesce (regression for infinite-re
     try buf.onLoss(testing.allocator, 6, 2);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
     try testing.expectEqual(@as(usize, 8), buf.lost.items[0].len);
+}
+
+test "send_buffer: duplicate fin enqueue does not clobber fin_at (#221)" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    var data: [32]u8 = undefined;
+    @memset(&data, 0xAB);
+    try buf.append(testing.allocator, 0, &data, true);
+    try testing.expectEqual(@as(?u64, 32), buf.fin_at);
+
+    // coversRange retry must not reset fin_at to offset 0.
+    try buf.append(testing.allocator, 0, &.{}, true);
+    try testing.expectEqual(@as(?u64, 32), buf.fin_at);
 }
 
 test "send_buffer: coversRange skips duplicate enqueue" {

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -119,6 +119,18 @@ pub const SendBuffer = struct {
         return self.queued_bytes;
     }
 
+    /// True when `[offset, offset+len)` is already held in a segment (embedder
+    /// retry after backpressure must not duplicate into `queued_bytes`).
+    pub fn coversRange(self: *const SendBuffer, offset: u64, len: usize) bool {
+        if (len == 0) return false;
+        const end = offset + len;
+        for (self.segments.items) |seg| {
+            const seg_end = seg.offset + seg.data.len;
+            if (offset >= seg.offset and end <= seg_end) return true;
+        }
+        return false;
+    }
+
     /// Append `data` at `offset`.  Coalesces with the tail segment when contiguous.
     pub fn append(
         self: *SendBuffer,
@@ -482,6 +494,17 @@ test "send_buffer: overlapping onLoss calls coalesce (regression for infinite-re
     try buf.onLoss(testing.allocator, 6, 2);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
     try testing.expectEqual(@as(usize, 8), buf.lost.items[0].len);
+}
+
+test "send_buffer: coversRange skips duplicate enqueue" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 0, "hello", false);
+    try testing.expect(buf.coversRange(0, 5));
+    try testing.expect(!buf.coversRange(0, 6));
+    try testing.expect(!buf.coversRange(5, 1));
 }
 
 test "send_buffer: non-contiguous ack retains gap for retransmit (#221)" {

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -321,7 +321,7 @@ pub const SendBuffer = struct {
     }
 };
 
-pub const stream_send_slot_max: usize = 64;
+pub const stream_send_slot_max: usize = 512;
 
 pub const StreamSendSlot = struct {
     active: bool = false,

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -1,0 +1,376 @@
+//! Per-stream send buffer (quinn `SendBuffer`-style, RFC 9000 §2).
+//!
+//! Holds unacked application bytes in offset-ordered segments.  Supports
+//! partial-frame retransmit: a lost 4 KiB STREAM frame can be re-emitted as
+//! narrower slices via `pollTransmit(max_len)` without pushing that work to
+//! the embedder.
+
+const std = @import("std");
+
+pub const Range = struct {
+    offset: u64,
+    len: usize,
+};
+
+const Segment = struct {
+    offset: u64,
+    data: []u8,
+    /// Bytes from the start of this segment that have been put on the wire and
+    /// are not yet ACKed (includes in-flight and lost ranges).
+    sent: usize = 0,
+    /// Bytes from the start of this segment that the peer has ACKed.
+    acked: usize = 0,
+};
+
+pub const PollResult = struct {
+    offset: u64,
+    data: []const u8,
+    fin: bool,
+    /// True when this slice comes from a lost range (retransmit).
+    retransmit: bool = false,
+};
+
+pub const SendBuffer = struct {
+    segments: std.ArrayList(Segment) = .empty,
+    lost: std.ArrayList(Range) = .empty,
+    /// Stream end offset when FIN was queued (exclusive).
+    fin_at: ?u64 = null,
+    fin_sent: bool = false,
+    queued_bytes: usize = 0,
+
+    pub fn deinit(self: *SendBuffer, allocator: std.mem.Allocator) void {
+        for (self.segments.items) |seg| allocator.free(seg.data);
+        self.segments.deinit(allocator);
+        self.lost.deinit(allocator);
+        self.* = .{};
+    }
+
+    pub fn byteLen(self: *const SendBuffer) usize {
+        return self.queued_bytes;
+    }
+
+    /// Append `data` at `offset`.  Coalesces with the tail segment when contiguous.
+    pub fn append(
+        self: *SendBuffer,
+        allocator: std.mem.Allocator,
+        offset: u64,
+        data: []const u8,
+        fin: bool,
+    ) !void {
+        if (data.len == 0 and !fin) return;
+        if (data.len > 0) {
+            if (self.segments.items.len > 0) {
+                const last = &self.segments.items[self.segments.items.len - 1];
+                const tail_end = last.offset + last.data.len;
+                if (tail_end == offset) {
+                    const new_len = last.data.len + data.len;
+                    const grown = try allocator.realloc(last.data, new_len);
+                    @memcpy(grown[last.data.len..][0..data.len], data);
+                    last.data = grown;
+                    self.queued_bytes += data.len;
+                    if (fin) self.fin_at = offset + data.len;
+                    return;
+                }
+            }
+            const dup = try allocator.dupe(u8, data);
+            try self.segments.append(allocator, .{ .offset = offset, .data = dup });
+            self.queued_bytes += data.len;
+        }
+        if (fin) {
+            self.fin_at = if (data.len > 0) offset + data.len else offset;
+        }
+    }
+
+    fn pruneAcked(self: *SendBuffer, allocator: std.mem.Allocator) void {
+        while (self.segments.items.len > 0) {
+            const seg = &self.segments.items[0];
+            if (seg.acked < seg.data.len) break;
+            allocator.free(seg.data);
+            _ = self.segments.orderedRemove(0);
+        }
+        var i: usize = 0;
+        while (i < self.lost.items.len) {
+            const r = self.lost.items[i];
+            if (self.segments.items.len == 0) break;
+            const head = self.segments.items[0];
+            if (r.offset + r.len <= head.offset + head.acked) {
+                _ = self.lost.orderedRemove(i);
+                continue;
+            }
+            i += 1;
+        }
+    }
+
+    fn mergeLost(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) !void {
+        if (len == 0) return;
+        const end = offset + len;
+        var i: usize = 0;
+        while (i < self.lost.items.len) {
+            const r = &self.lost.items[i];
+            const r_end = r.offset + r.len;
+            if (end < r.offset or offset > r_end) {
+                i += 1;
+                continue;
+            }
+            const new_off = @min(offset, r.offset);
+            const new_end = @max(end, r_end);
+            r.offset = new_off;
+            r.len = @intCast(new_end - new_off);
+            try self.mergeLost(allocator, offset, len);
+            return;
+        }
+        try self.lost.append(allocator, .{ .offset = offset, .len = len });
+    }
+
+    /// Mark `[offset, offset+len)` as ACKed by the peer.
+    pub fn onAck(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) void {
+        if (len == 0) {
+            if (self.fin_at == offset) self.fin_sent = false;
+            self.fin_at = null;
+            return;
+        }
+        const end = offset + len;
+        var i: usize = 0;
+        while (i < self.lost.items.len) {
+            const r = self.lost.items[i];
+            if (r.offset >= end or r.offset + r.len <= offset) {
+                i += 1;
+                continue;
+            }
+            if (r.offset >= offset and r.offset + r.len <= end) {
+                _ = self.lost.orderedRemove(i);
+                continue;
+            }
+            i += 1;
+        }
+        for (self.segments.items) |*seg| {
+            const seg_end = seg.offset + seg.data.len;
+            if (end <= seg.offset or offset >= seg_end) continue;
+            const rel_end: usize = @intCast(@min(end, seg_end) - seg.offset);
+            if (rel_end > seg.acked) {
+                const delta = rel_end - seg.acked;
+                seg.acked = rel_end;
+                self.queued_bytes -|= delta;
+            }
+            if (rel_end > seg.sent) seg.sent = rel_end;
+        }
+        self.pruneAcked(allocator);
+    }
+
+    /// Mark `[offset, offset+len)` as lost — eligible for `pollTransmit`.
+    pub fn onLoss(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) !void {
+        if (len == 0) return;
+        try self.mergeLost(allocator, offset, len);
+        for (self.segments.items) |*seg| {
+            const seg_end = seg.offset + seg.data.len;
+            if (offset >= seg_end or offset + len <= seg.offset) continue;
+            const rel_start: usize = @intCast(@max(offset, seg.offset) - seg.offset);
+            if (rel_start < seg.sent) seg.sent = rel_start;
+        }
+    }
+
+    fn sliceFromSegment(seg: *const Segment, off: u64, max_len: usize) ?PollResult {
+        if (off < seg.offset or off >= seg.offset + seg.data.len) return null;
+        const rel: usize = @intCast(off - seg.offset);
+        const avail = seg.data.len - rel;
+        const n = @min(avail, max_len);
+        const fin = if (seg.offset + seg.data.len == off + n)
+            false // FIN handled separately via fin_at
+        else
+            false;
+        return .{ .offset = off, .data = seg.data[rel .. rel + n], .fin = fin };
+    }
+
+    /// Next range to put on the wire (lost ranges first, then unsent tail).
+    pub fn hasWork(self: *const SendBuffer) bool {
+        if (self.lost.items.len > 0) return true;
+        for (self.segments.items) |seg| {
+            if (seg.sent < seg.data.len) return true;
+        }
+        if (self.fin_at != null and !self.fin_sent) return true;
+        return false;
+    }
+
+    /// Next range to put on the wire (lost ranges first, then unsent tail).
+    pub fn pollTransmit(self: *SendBuffer, max_len: usize) ?PollResult {
+        if (max_len == 0) return null;
+
+        if (self.lost.items.len > 0) {
+            std.mem.sort(Range, self.lost.items, {}, struct {
+                fn less(_: void, a: Range, b: Range) bool {
+                    return a.offset < b.offset;
+                }
+            }.less);
+            const r = self.lost.items[0];
+            const n = @min(r.len, max_len);
+            for (self.segments.items) |*seg| {
+                if (r.offset >= seg.offset and r.offset < seg.offset + seg.data.len) {
+                    const res = sliceFromSegment(seg, r.offset, n) orelse continue;
+                    const fin = self.fin_at == r.offset + n;
+                    return .{ .offset = res.offset, .data = res.data, .fin = fin, .retransmit = true };
+                }
+            }
+            return null;
+        }
+
+        for (self.segments.items) |*seg| {
+            const unsent_off = seg.offset + seg.sent;
+            if (seg.sent >= seg.data.len) continue;
+            const n = @min(seg.data.len - seg.sent, max_len);
+            const fin = self.fin_at == unsent_off + n;
+            return .{
+                .offset = unsent_off,
+                .data = seg.data[seg.sent .. seg.sent + n],
+                .fin = fin,
+                .retransmit = false,
+            };
+        }
+
+        if (self.fin_at) |fa| {
+            for (self.segments.items) |*seg| {
+                if (seg.offset + seg.data.len == fa and seg.sent == seg.data.len) {
+                    if (!self.fin_sent) {
+                        return .{ .offset = fa, .data = &.{}, .fin = true, .retransmit = false };
+                    }
+                    break;
+                }
+            }
+            if (self.segments.items.len == 0 and !self.fin_sent) {
+                return .{ .offset = fa, .data = &.{}, .fin = true, .retransmit = false };
+            }
+        }
+        return null;
+    }
+
+    /// Record that `poll` bytes were sent on the wire (awaiting ACK).
+    pub fn onSent(self: *SendBuffer, offset: u64, len: usize) void {
+        if (len == 0) {
+            if (self.fin_at == offset) self.fin_sent = true;
+            return;
+        }
+        for (self.segments.items) |*seg| {
+            const seg_end = seg.offset + seg.data.len;
+            if (offset >= seg_end or offset + len <= seg.offset) continue;
+            const rel_end: usize = @intCast(offset + len - seg.offset);
+            if (rel_end > seg.sent) seg.sent = rel_end;
+        }
+        if (self.lost.items.len > 0) {
+            const end = offset + len;
+            var r = &self.lost.items[0];
+            if (r.offset == offset) {
+                if (len >= r.len) {
+                    _ = self.lost.orderedRemove(0);
+                } else {
+                    r.offset += len;
+                    r.len -= len;
+                }
+            } else if (offset < r.offset and end > r.offset) {
+                const overlap = end - r.offset;
+                if (overlap >= r.len) {
+                    _ = self.lost.orderedRemove(0);
+                } else {
+                    r.offset += overlap;
+                    r.len -= overlap;
+                }
+            }
+        }
+    }
+};
+
+pub const stream_send_slot_max: usize = 64;
+
+pub const StreamSendSlot = struct {
+    active: bool = false,
+    stream_id: u64 = 0,
+    buf: SendBuffer = .{},
+};
+
+pub fn findStreamSendSlot(slots: []StreamSendSlot, stream_id: u64) ?*SendBuffer {
+    for (slots) |*slot| {
+        if (slot.active and slot.stream_id == stream_id) return &slot.buf;
+    }
+    return null;
+}
+
+pub fn getOrCreateStreamSendSlot(
+    slots: []StreamSendSlot,
+    stream_id: u64,
+) ?*SendBuffer {
+    if (findStreamSendSlot(slots, stream_id)) |buf| return buf;
+    for (slots) |*slot| {
+        if (!slot.active) {
+            slot.* = .{ .active = true, .stream_id = stream_id, .buf = .{} };
+            return &slot.buf;
+        }
+    }
+    return null;
+}
+
+pub fn releaseStreamSendSlot(slots: []StreamSendSlot, allocator: std.mem.Allocator, stream_id: u64) void {
+    for (slots) |*slot| {
+        if (slot.active and slot.stream_id == stream_id) {
+            slot.buf.deinit(allocator);
+            slot.* = .{};
+            return;
+        }
+    }
+}
+
+test "send_buffer: append coalesce and poll" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 0, "hello", false);
+    try buf.append(testing.allocator, 5, " world", false);
+    const p1 = buf.pollTransmit(8).?;
+    try testing.expectEqual(@as(u64, 0), p1.offset);
+    try testing.expectEqualSlices(u8, "hello wo", p1.data);
+    buf.onSent(p1.offset, p1.data.len);
+
+    const p2 = buf.pollTransmit(8).?;
+    try testing.expectEqual(@as(u64, 8), p2.offset);
+    try testing.expectEqualSlices(u8, "rld", p2.data);
+}
+
+test "send_buffer: partial loss retransmit" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 0, "abcdefghij", false);
+    const p = buf.pollTransmit(10).?;
+    buf.onSent(p.offset, p.data.len);
+    try buf.onLoss(testing.allocator, 2, 4);
+    const rtx = buf.pollTransmit(2).?;
+    try testing.expectEqual(@as(u64, 2), rtx.offset);
+    try testing.expectEqualSlices(u8, "cd", rtx.data);
+    buf.onSent(rtx.offset, rtx.data.len);
+    const rtx2 = buf.pollTransmit(10).?;
+    try testing.expectEqual(@as(u64, 4), rtx2.offset);
+    try testing.expectEqualSlices(u8, "ef", rtx2.data);
+}
+
+test "send_buffer: ack frees head" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 0, "abc", false);
+    const p = buf.pollTransmit(3).?;
+    buf.onSent(p.offset, p.data.len);
+    buf.onAck(testing.allocator, 0, 3);
+    try testing.expectEqual(@as(usize, 0), buf.segments.items.len);
+    try testing.expectEqual(@as(usize, 0), buf.queued_bytes);
+}
+
+test "send_buffer: fin only" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 100, &.{}, true);
+    const p = buf.pollTransmit(64).?;
+    try testing.expect(p.fin);
+    try testing.expectEqual(@as(u64, 100), p.offset);
+}

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -88,11 +88,20 @@ pub const SendBuffer = struct {
             allocator.free(seg.data);
             _ = self.segments.orderedRemove(0);
         }
+        // Drop lost ranges that no longer have a backing segment.  When ALL
+        // segments are pruned (entire stream fully acked), every remaining
+        // lost range is orphaned and `pollTransmit` will return null
+        // forever for it — `hasWork()` stays true → drain stalls in an
+        // infinite no-op loop.  The previous loop's `if (.. == 0) break`
+        // exited without clearing those orphans; clear them explicitly.
+        if (self.segments.items.len == 0) {
+            self.lost.clearRetainingCapacity();
+            return;
+        }
+        const head = self.segments.items[0];
         var i: usize = 0;
         while (i < self.lost.items.len) {
             const r = self.lost.items[i];
-            if (self.segments.items.len == 0) break;
-            const head = self.segments.items[0];
             if (r.offset + r.len <= head.offset + head.acked) {
                 _ = self.lost.orderedRemove(i);
                 continue;
@@ -166,10 +175,25 @@ pub const SendBuffer = struct {
     /// Mark `[offset, offset+len)` as lost — eligible for `pollTransmit`.
     pub fn onLoss(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) !void {
         if (len == 0) return;
+        // If no segment backs any byte of this range — typically a spurious
+        // loss declared after every byte was acked + the segment pruned —
+        // don't create a phantom lost range that `pollTransmit` will never be
+        // able to serve.  Without this gate, `hasWork()` returns true forever
+        // for the orphan and the drain spins.
+        const end = offset + len;
+        var has_backing = false;
+        for (self.segments.items) |seg| {
+            const seg_end = seg.offset + seg.data.len;
+            if (end > seg.offset and offset < seg_end) {
+                has_backing = true;
+                break;
+            }
+        }
+        if (!has_backing) return;
         try self.mergeLost(allocator, offset, len);
         for (self.segments.items) |*seg| {
             const seg_end = seg.offset + seg.data.len;
-            if (offset >= seg_end or offset + len <= seg.offset) continue;
+            if (offset >= seg_end or end <= seg.offset) continue;
             const rel_start: usize = @intCast(@max(offset, seg.offset) - seg.offset);
             if (rel_start < seg.sent) seg.sent = rel_start;
         }
@@ -259,6 +283,20 @@ pub const SendBuffer = struct {
             if (offset >= seg_end or offset + len <= seg.offset) continue;
             const rel_end: usize = @intCast(offset + len - seg.offset);
             if (rel_end > seg.sent) seg.sent = rel_end;
+        }
+        // Data + FIN piggyback: `pollTransmit` attaches `fin=true` to the last
+        // unsent data frame when it ends exactly at `fin_at`.  Without marking
+        // `fin_sent` here, `hasWork()` keeps returning true → drain emits an
+        // EXTRA empty-FIN frame at the same offset.  If the data frame is then
+        // lost but the empty-FIN reaches the peer, the peer ACKs the empty FIN
+        // → `onAck(fin_at, 0)` clears `fin_at` → the data retransmit's lost-
+        // branch sees `fin_at == null` and re-emits the data without FIN.
+        // Receiver still has the empty FIN sitting in out-of-order and never
+        // delivers the (still missing) tail data.  Net effect: a permanent
+        // stall at the very end of large transfers (the post-rebase #219
+        // interop `transfer` / `zerortt` symptom).
+        if (self.fin_at) |fa| {
+            if (offset + len >= fa) self.fin_sent = true;
         }
         if (self.lost.items.len > 0) {
             const end = offset + len;

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -12,14 +12,20 @@ pub const Range = struct {
     len: usize,
 };
 
+/// Byte range relative to the start of a segment's `data` buffer.
+const RelRange = struct {
+    off: usize,
+    len: usize,
+};
+
 const Segment = struct {
     offset: u64,
     data: []u8,
     /// Bytes from the start of this segment that have been put on the wire and
     /// are not yet ACKed (includes in-flight and lost ranges).
     sent: usize = 0,
-    /// Bytes from the start of this segment that the peer has ACKed.
-    acked: usize = 0,
+    /// Non-overlapping ACKed ranges relative to `offset` (quinn-style).
+    acked_ranges: std.ArrayList(RelRange) = .empty,
 };
 
 pub const PollResult = struct {
@@ -30,6 +36,67 @@ pub const PollResult = struct {
     retransmit: bool = false,
 };
 
+fn totalAckedBytes(ranges: []const RelRange) usize {
+    var sum: usize = 0;
+    for (ranges) |r| sum += r.len;
+    return sum;
+}
+
+/// Contiguous ACK prefix from the segment start (0).  Zero when the first
+/// acked range does not begin at 0 — gaps before it are still in flight.
+fn contiguousAckedEnd(ranges: []const RelRange) usize {
+    if (ranges.len == 0 or ranges[0].off != 0) return 0;
+    return ranges[0].len;
+}
+
+fn mergeAckedRange(
+    ranges: *std.ArrayList(RelRange),
+    allocator: std.mem.Allocator,
+    off: usize,
+    len: usize,
+) !usize {
+    if (len == 0) return 0;
+    const old_total = totalAckedBytes(ranges.items);
+    const end = off + len;
+
+    var new_off = off;
+    var new_end = end;
+    var i: usize = 0;
+    while (i < ranges.items.len) {
+        const r = ranges.items[i];
+        const r_end = r.off + r.len;
+        if (new_end <= r.off or new_off >= r_end) {
+            i += 1;
+            continue;
+        }
+        new_off = @min(new_off, r.off);
+        new_end = @max(new_end, r_end);
+        _ = ranges.orderedRemove(i);
+    }
+    try ranges.append(allocator, .{ .off = new_off, .len = new_end - new_off });
+
+    std.mem.sort(RelRange, ranges.items, {}, struct {
+        fn less(_: void, a: RelRange, b: RelRange) bool {
+            return a.off < b.off;
+        }
+    }.less);
+
+    i = 0;
+    while (i + 1 < ranges.items.len) {
+        const a = &ranges.items[i];
+        const b = &ranges.items[i + 1];
+        if (a.off + a.len >= b.off) {
+            const merged_end = @max(a.off + a.len, b.off + b.len);
+            a.len = merged_end - a.off;
+            _ = ranges.orderedRemove(i + 1);
+            continue;
+        }
+        i += 1;
+    }
+
+    return totalAckedBytes(ranges.items) - old_total;
+}
+
 pub const SendBuffer = struct {
     segments: std.ArrayList(Segment) = .empty,
     lost: std.ArrayList(Range) = .empty,
@@ -39,7 +106,10 @@ pub const SendBuffer = struct {
     queued_bytes: usize = 0,
 
     pub fn deinit(self: *SendBuffer, allocator: std.mem.Allocator) void {
-        for (self.segments.items) |seg| allocator.free(seg.data);
+        for (self.segments.items) |*seg| {
+            seg.acked_ranges.deinit(allocator);
+            allocator.free(seg.data);
+        }
         self.segments.deinit(allocator);
         self.lost.deinit(allocator);
         self.* = .{};
@@ -84,25 +154,21 @@ pub const SendBuffer = struct {
     fn pruneAcked(self: *SendBuffer, allocator: std.mem.Allocator) void {
         while (self.segments.items.len > 0) {
             const seg = &self.segments.items[0];
-            if (seg.acked < seg.data.len) break;
+            if (contiguousAckedEnd(seg.acked_ranges.items) < seg.data.len) break;
+            seg.acked_ranges.deinit(allocator);
             allocator.free(seg.data);
             _ = self.segments.orderedRemove(0);
         }
-        // Drop lost ranges that no longer have a backing segment.  When ALL
-        // segments are pruned (entire stream fully acked), every remaining
-        // lost range is orphaned and `pollTransmit` will return null
-        // forever for it — `hasWork()` stays true → drain stalls in an
-        // infinite no-op loop.  The previous loop's `if (.. == 0) break`
-        // exited without clearing those orphans; clear them explicitly.
         if (self.segments.items.len == 0) {
             self.lost.clearRetainingCapacity();
             return;
         }
         const head = self.segments.items[0];
+        const head_cont = contiguousAckedEnd(head.acked_ranges.items);
         var i: usize = 0;
         while (i < self.lost.items.len) {
             const r = self.lost.items[i];
-            if (r.offset + r.len <= head.offset + head.acked) {
+            if (r.offset + r.len <= head.offset + head_cont) {
                 _ = self.lost.orderedRemove(i);
                 continue;
             }
@@ -112,13 +178,6 @@ pub const SendBuffer = struct {
 
     fn mergeLost(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) !void {
         if (len == 0) return;
-        // Walk once, absorbing every overlapping / adjacent range into a single
-        // accumulator. The previous version recursed with the ORIGINAL
-        // (offset, len) after each merge — since the merged range still overlaps
-        // with those args, the recursion never terminated (release builds TCO'd
-        // it into a CPU spin, which is exactly the symptom the post-rebase
-        // interop hit: transfer stalled with `pending_stream_sends` drained but
-        // CC stuck in recovery and bif > cwnd).
         var new_off = offset;
         var new_end = offset + len;
         var i: usize = 0;
@@ -132,7 +191,6 @@ pub const SendBuffer = struct {
             new_off = @min(new_off, r.offset);
             new_end = @max(new_end, r_end);
             _ = self.lost.orderedRemove(i);
-            // Don't increment i — the shifted-down entry takes this slot.
         }
         try self.lost.append(allocator, .{ .offset = new_off, .len = @intCast(new_end - new_off) });
     }
@@ -161,12 +219,13 @@ pub const SendBuffer = struct {
         for (self.segments.items) |*seg| {
             const seg_end = seg.offset + seg.data.len;
             if (end <= seg.offset or offset >= seg_end) continue;
-            const rel_end: usize = @intCast(@min(end, seg_end) - seg.offset);
-            if (rel_end > seg.acked) {
-                const delta = rel_end - seg.acked;
-                seg.acked = rel_end;
-                self.queued_bytes -|= delta;
-            }
+            const ix_start = @max(offset, seg.offset);
+            const ix_end = @min(end, seg_end);
+            const rel_off: usize = @intCast(ix_start - seg.offset);
+            const rel_len: usize = @intCast(ix_end - ix_start);
+            const delta = mergeAckedRange(&seg.acked_ranges, allocator, rel_off, rel_len) catch continue;
+            self.queued_bytes -|= delta;
+            const rel_end = rel_off + rel_len;
             if (rel_end > seg.sent) seg.sent = rel_end;
         }
         self.pruneAcked(allocator);
@@ -175,11 +234,6 @@ pub const SendBuffer = struct {
     /// Mark `[offset, offset+len)` as lost — eligible for `pollTransmit`.
     pub fn onLoss(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) !void {
         if (len == 0) return;
-        // If no segment backs any byte of this range — typically a spurious
-        // loss declared after every byte was acked + the segment pruned —
-        // don't create a phantom lost range that `pollTransmit` will never be
-        // able to serve.  Without this gate, `hasWork()` returns true forever
-        // for the orphan and the drain spins.
         const end = offset + len;
         var has_backing = false;
         for (self.segments.items) |seg| {
@@ -284,17 +338,6 @@ pub const SendBuffer = struct {
             const rel_end: usize = @intCast(offset + len - seg.offset);
             if (rel_end > seg.sent) seg.sent = rel_end;
         }
-        // Data + FIN piggyback: `pollTransmit` attaches `fin=true` to the last
-        // unsent data frame when it ends exactly at `fin_at`.  Without marking
-        // `fin_sent` here, `hasWork()` keeps returning true → drain emits an
-        // EXTRA empty-FIN frame at the same offset.  If the data frame is then
-        // lost but the empty-FIN reaches the peer, the peer ACKs the empty FIN
-        // → `onAck(fin_at, 0)` clears `fin_at` → the data retransmit's lost-
-        // branch sees `fin_at == null` and re-emits the data without FIN.
-        // Receiver still has the empty FIN sitting in out-of-order and never
-        // delivers the (still missing) tail data.  Net effect: a permanent
-        // stall at the very end of large transfers (the post-rebase #219
-        // interop `transfer` / `zerortt` symptom).
         if (self.fin_at) |fa| {
             if (offset + len >= fa) self.fin_sent = true;
         }
@@ -428,19 +471,54 @@ test "send_buffer: overlapping onLoss calls coalesce (regression for infinite-re
     _ = buf.pollTransmit(10);
     buf.onSent(0, 10);
 
-    // First lost range; alone, append-only path is exercised.
     try buf.onLoss(testing.allocator, 0, 4);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
 
-    // Second lost range overlapping the first — previously triggered
-    // mergeLost's terminal-recurse-with-original-args spin.
     try buf.onLoss(testing.allocator, 2, 4);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
     try testing.expectEqual(@as(u64, 0), buf.lost.items[0].offset);
     try testing.expectEqual(@as(usize, 6), buf.lost.items[0].len);
 
-    // Third lost range adjacent to the merged range — also merges.
     try buf.onLoss(testing.allocator, 6, 2);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
     try testing.expectEqual(@as(usize, 8), buf.lost.items[0].len);
+}
+
+test "send_buffer: non-contiguous ack retains gap for retransmit (#221)" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    var data: [1632]u8 = undefined;
+    for (&data, 0..) |*b, i| b.* = @intCast(i % 256);
+
+    try buf.append(testing.allocator, 0, &data, false);
+    try testing.expectEqual(@as(usize, 1632), buf.queued_bytes);
+
+    const p1 = buf.pollTransmit(1436).?;
+    try testing.expectEqual(@as(u64, 0), p1.offset);
+    try testing.expectEqual(@as(usize, 1436), p1.data.len);
+    buf.onSent(p1.offset, p1.data.len);
+
+    const p2 = buf.pollTransmit(196).?;
+    try testing.expectEqual(@as(u64, 1436), p2.offset);
+    try testing.expectEqual(@as(usize, 196), p2.data.len);
+    buf.onSent(p2.offset, p2.data.len);
+
+    // ACK only the tail packet — must not treat the leading gap as acked.
+    buf.onAck(testing.allocator, 1436, 196);
+    try testing.expectEqual(@as(usize, 1), buf.segments.items.len);
+    try testing.expectEqual(@as(usize, 1436), buf.queued_bytes);
+    try testing.expectEqual(@as(usize, 0), contiguousAckedEnd(buf.segments.items[0].acked_ranges.items));
+
+    try buf.onLoss(testing.allocator, 0, 1436);
+    const rtx = buf.pollTransmit(1436).?;
+    try testing.expectEqual(@as(u64, 0), rtx.offset);
+    try testing.expectEqual(@as(usize, 1436), rtx.data.len);
+    try testing.expectEqualSlices(u8, data[0..1436], rtx.data);
+
+    buf.onSent(rtx.offset, rtx.data.len);
+    buf.onAck(testing.allocator, 0, 1436);
+    try testing.expectEqual(@as(usize, 0), buf.segments.items.len);
+    try testing.expectEqual(@as(usize, 0), buf.queued_bytes);
 }

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -103,23 +103,29 @@ pub const SendBuffer = struct {
 
     fn mergeLost(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) !void {
         if (len == 0) return;
-        const end = offset + len;
+        // Walk once, absorbing every overlapping / adjacent range into a single
+        // accumulator. The previous version recursed with the ORIGINAL
+        // (offset, len) after each merge — since the merged range still overlaps
+        // with those args, the recursion never terminated (release builds TCO'd
+        // it into a CPU spin, which is exactly the symptom the post-rebase
+        // interop hit: transfer stalled with `pending_stream_sends` drained but
+        // CC stuck in recovery and bif > cwnd).
+        var new_off = offset;
+        var new_end = offset + len;
         var i: usize = 0;
         while (i < self.lost.items.len) {
-            const r = &self.lost.items[i];
+            const r = self.lost.items[i];
             const r_end = r.offset + r.len;
-            if (end < r.offset or offset > r_end) {
+            if (new_end < r.offset or new_off > r_end) {
                 i += 1;
                 continue;
             }
-            const new_off = @min(offset, r.offset);
-            const new_end = @max(end, r_end);
-            r.offset = new_off;
-            r.len = @intCast(new_end - new_off);
-            try self.mergeLost(allocator, offset, len);
-            return;
+            new_off = @min(new_off, r.offset);
+            new_end = @max(new_end, r_end);
+            _ = self.lost.orderedRemove(i);
+            // Don't increment i — the shifted-down entry takes this slot.
         }
-        try self.lost.append(allocator, .{ .offset = offset, .len = len });
+        try self.lost.append(allocator, .{ .offset = new_off, .len = @intCast(new_end - new_off) });
     }
 
     /// Mark `[offset, offset+len)` as ACKed by the peer.
@@ -373,4 +379,30 @@ test "send_buffer: fin only" {
     const p = buf.pollTransmit(64).?;
     try testing.expect(p.fin);
     try testing.expectEqual(@as(u64, 100), p.offset);
+}
+
+test "send_buffer: overlapping onLoss calls coalesce (regression for infinite-recurse mergeLost)" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 0, "abcdefghij", false);
+    _ = buf.pollTransmit(10);
+    buf.onSent(0, 10);
+
+    // First lost range; alone, append-only path is exercised.
+    try buf.onLoss(testing.allocator, 0, 4);
+    try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
+
+    // Second lost range overlapping the first — previously triggered
+    // mergeLost's terminal-recurse-with-original-args spin.
+    try buf.onLoss(testing.allocator, 2, 4);
+    try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
+    try testing.expectEqual(@as(u64, 0), buf.lost.items[0].offset);
+    try testing.expectEqual(@as(usize, 6), buf.lost.items[0].len);
+
+    // Third lost range adjacent to the merged range — also merges.
+    try buf.onLoss(testing.allocator, 6, 2);
+    try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
+    try testing.expectEqual(@as(usize, 8), buf.lost.items[0].len);
 }


### PR DESCRIPTION
## Summary

- Adds `SendBuffer` per raw-app stream (offset-ordered segments, lost-range tracking, `pollTransmit(max_len)`) — quinn `SendBuffer`-style partial retransmit without embedder range tracking ([#184](https://github.com/ch4r10t33r/zquic/issues/184)).
- Loss detector records `stream_byte_len` on `SentPacket` when payload lives in the per-stream buffer (`stream_data == null`); ACKs surface `StreamAck` entries that prune acked ranges in-place.
- Raw-app send/drain paths enqueue into `SendBuffer` and emit via shared poll helpers; loss calls `onLoss` + drain instead of replaying whole heap chunks. Send slots are released with `releaseRawAppStream`.

## Test plan

- [x] `zig fmt --check .`
- [x] `zig build test --summary all` (261/261)
- [ ] CI interop (quinn/zquic transfer)