### PR TITLE
send_buffer: track acked ranges instead of watermark (#221)

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1109,7 +1109,16 @@ fn enqueuePendingStreamSend(
     const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
     if (data.len == 0 and !fin) return true;
     if (data.len > 0 and sbuf.coversRange(offset, data.len)) {
-        if (fin) sbuf.append(allocator, offset, &.{}, fin) catch return false;
+        // Bytes were recorded on the first enqueue — do not duplicate into
+        // queued_bytes.  Still record FIN if this retry carries it.
+        if (fin) {
+            const fa = offset + data.len;
+            if (sbuf.fin_at) |cur| {
+                sbuf.fin_at = @max(cur, fa);
+            } else {
+                sbuf.fin_at = fa;
+            }
+        }
         conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
         return true;
     }
@@ -3961,6 +3970,10 @@ pub const Server = struct {
             // Unknown or non-STREAM frame — stop parsing.
             break;
         }
+        if (conn.has_app_keys and conn.http09_pending_count > 0) {
+            self.drainHttp09Pending(conn);
+            self.flushSendBatch();
+        }
     }
 
     /// Retry token lifetime in milliseconds.  RFC 9000 §8.1.3 recommends
@@ -4705,6 +4718,16 @@ pub const Server = struct {
         conn.address_validated = true;
         conn.migration.trustActivePath();
         conn.captureHandshakeRtt();
+
+        // 0-RTT GETs are parsed in process0RttPacket before app keys exist and
+        // land in http09_pending.  Drain them now instead of waiting for the
+        // client's next datagram (zerortt would otherwise stall until a PING).
+        while (conn.http09_pending_count > 0) {
+            const before = conn.http09_pending_count;
+            self.drainHttp09Pending(conn);
+            if (conn.http09_pending_count == before) break;
+        }
+        self.flushSendBatch();
 
         const pending_n = conn.pending_1rtt_n;
         conn.pending_1rtt_n = 0;
@@ -8865,7 +8888,13 @@ pub const Client = struct {
             self.flushPendingStreamsBlocked();
             self.checkPto();
 
-            if (ready == 0) continue;
+            if (ready == 0) {
+                // Zerortt: up to 39 server responses can arrive during the
+                // handshake before downloadUrls runs; flush deferred ACKs on
+                // idle polls so the server is not stuck in a PTO/retransmit loop.
+                self.flushDeferredAck();
+                continue;
+            }
 
             // Drain a pending ICMP/socket error (e.g. port-unreachable when
             // the server is not yet bound) so the next poll() is not
@@ -8958,6 +8987,10 @@ pub const Client = struct {
                 if (self.early_km != null and self.zerortt_count < self.active_urls.len) {
                     self.send0RttRequests(server_addr) catch {};
                 }
+                // ACK responses that arrived during the handshake (0-RTT → 1-RTT
+                // burst) before downloadUrls blocks in its recv loop.
+                self.flushDeferredAck();
+                self.flushSendBatch();
                 // downloadUrls blocks with its own recv loop; extend the outer
                 // deadline so post-batch retransmits can still complete.
                 deadline = compat.milliTimestamp() + 120_000;
@@ -8973,6 +9006,7 @@ pub const Client = struct {
                 break;
             }
 
+            self.flushDeferredAck();
             deadline = compat.milliTimestamp() + 30_000; // extend while packets still arrive
         }
 
@@ -10864,6 +10898,9 @@ pub const Client = struct {
             self.h3_client_control_sent = true;
         }
 
+        self.flushDeferredAck();
+        self.flushSendBatch();
+
         // Process downloads in batches to stay within NS3 network simulator limits.
         // The NS3 DropTail queue is 25 packets; sending more than ~20 packets at
         // once causes queue overflow and packet drops.  Using BATCH_SIZE=20 keeps
@@ -11017,11 +11054,14 @@ pub const Client = struct {
                 const poll_timeout: i32 = @intCast(@min(200, @max(0, remaining)));
                 const ready = std.posix.poll(&fds, poll_timeout) catch 0;
                 if (ready == 0) {
-                    // Poll timed out — no incoming data.  Send a PING so the
-                    // server can see our current source port.  This is critical
-                    // for the rebind-port test: after a NAT rebind the server's
-                    // FIN retransmits go to the old (dead) port.  Without this
-                    // PING the server never learns the new port and exhausts all
+                    // Poll timed out — no incoming data.  Flush any deferred ACKs
+                    // so the peer can retire in-flight data (zerortt 0-RTT burst).
+                    self.flushDeferredAck();
+                    self.flushSendBatch();
+                    // Send a PING so the server can see our current source port.
+                    // This is critical for the rebind-port test: after a NAT rebind
+                    // the server's FIN retransmits go to the old (dead) port.  Without
+                    // this PING the server never learns the new port and exhausts all
                     // retransmits, stalling the download.
                     if (self.conn.has_app_keys) {
                         // PING (0x01) + PADDING (0x00 × 7) — minimum 4 bytes of
@@ -11066,6 +11106,7 @@ pub const Client = struct {
                 // This replaces N individual ACKs with a single packet, reducing
                 // the combined burst (ACK + next GET batch) to ≤ 21 packets.
                 self.flushDeferredAck();
+                self.flushSendBatch();
             }
 
             batch_start = batch_end;

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1108,6 +1108,11 @@ fn enqueuePendingStreamSend(
 ) bool {
     const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
     if (data.len == 0 and !fin) return true;
+    if (data.len > 0 and sbuf.coversRange(offset, data.len)) {
+        if (fin) sbuf.append(allocator, offset, &.{}, fin) catch return false;
+        conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
+        return true;
+    }
     const projected = streamSendQueuedBytes(conn) + data.len;
     if (projected > pending_stream_send_bytes_cap) return false;
     sbuf.append(allocator, offset, data, fin) catch return false;
@@ -1134,6 +1139,11 @@ fn enqueuePendingStreamSendOwned(
 ) bool {
     if (owned.len == 0) return true;
     const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
+    if (sbuf.coversRange(offset, owned.len)) {
+        allocator.free(owned);
+        conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
+        return true;
+    }
     if (streamSendQueuedBytes(conn) + owned.len > pending_stream_send_bytes_cap) return false;
     sbuf.append(allocator, offset, owned, fin) catch return false;
     allocator.free(owned);
@@ -5852,7 +5862,6 @@ pub const Server = struct {
             .has_length = true,
         };
         const old_offset = slot.stream_offset;
-        slot.stream_offset += @intCast(n);
         var frame_buf: [path_mtu_mod.max_app_stream_chunk_cap + 64]u8 = undefined;
         const frame_len = sf_out.serialize(&frame_buf) catch |err| {
             dbg("io: http09 stream_id={} serialize error at offset {}: {}\n", .{ slot.stream_id, old_offset, err });
@@ -5863,15 +5872,14 @@ pub const Server = struct {
         };
         dbg("io: http09 stream_id={} chunk: bytes={} offset={} fin={} frame_len={}\n", .{ slot.stream_id, n, old_offset, fin, frame_len });
         const fc_before = conn.fc_bytes_sent;
-        _ = self.sendRawStreamDataInner(conn, slot.stream_id, old_offset, file_buf[0..n], fin, null);
-        if (conn.fc_bytes_sent <= fc_before) {
-            // FC blocked (DATA_BLOCKED) or send failed — rewind and retry later.
-            slot.stream_offset -= @intCast(n);
-            slot.file.seekTo(slot.stream_offset) catch |err| {
-                dbg("io: http09 seekTo rewind failed stream_id={}: {}\n", .{ slot.stream_id, err });
-            };
+        const enqueued = self.sendRawStreamDataInner(conn, slot.stream_id, old_offset, file_buf[0..n], fin, null);
+        if (enqueued == 0) return;
+        if (fin and conn.fc_bytes_sent <= fc_before) {
+            // FIN chunk buffered but not on the wire yet — retry without advancing
+            // the file cursor (SendBuffer already holds these bytes).
             return;
         }
+        slot.stream_offset += @intCast(n);
         if (fin) {
             if (conn.http09_active_count > 0) conn.http09_active_count -= 1;
             slot.file.close();

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -5186,6 +5186,14 @@ pub const Server = struct {
                     if (slot.awaiting_fin_ack and slot.fin_pkt_pn <= largest_ack) {
                         dbg("io: stream_id={} FIN ACKed (fin_pn={} <= largest_ack={})\n", .{ slot.stream_id, slot.fin_pkt_pn, largest_ack });
                         slot.awaiting_fin_ack = false;
+                        // The stream is fully delivered.  Release the
+                        // per-stream `SendBuffer` slot so the 64-slot
+                        // `stream_send_slots` table doesn't accumulate
+                        // dead entries (the interop `multiplexing` test
+                        // serves >64 files on the same connection and
+                        // otherwise wedges with `pending-stream-send
+                        // queue full (64 streams, 0 bytes)`).
+                        send_buffer_mod.releaseStreamSendSlot(conn.stream_send_slots[0..], self.allocator, slot.stream_id);
                     }
                 }
                 self.drainHttp09Pending(conn);
@@ -5481,6 +5489,7 @@ pub const Server = struct {
                     if (slot.active and slot.stream_id == r.frame.stream_id) {
                         if (conn.http09_active_count > 0) conn.http09_active_count -= 1;
                         slot.close();
+                        send_buffer_mod.releaseStreamSendSlot(conn.stream_send_slots[0..], self.allocator, slot.stream_id);
                     }
                 }
                 for (&conn.http3_slots) |*slot| {

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1081,6 +1081,17 @@ fn applyStreamAcks(
             buf.onAck(allocator, a.offset, a.len);
         }
     }
+    // Reap fully-completed slots — every byte appended has been acked AND a
+    // FIN was set + acked.  Without this, the bounded `stream_send_slots`
+    // table accumulates dead entries from each completed HTTP/0.9 response
+    // (the path does not have an embedder release call), and the interop
+    // `multiplexing` test wedges with `queue full (… 0 bytes)`.
+    for (&conn.stream_send_slots) |*slot| {
+        if (slot.active and slot.buf.isComplete()) {
+            slot.buf.deinit(allocator);
+            slot.* = .{};
+        }
+    }
     conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
 }
 

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1150,6 +1150,14 @@ fn enqueuePendingStreamSendOwned(
     const sbuf = send_buffer_mod.getOrCreateStreamSendSlot(conn.stream_send_slots[0..], stream_id) orelse return false;
     if (sbuf.coversRange(offset, owned.len)) {
         allocator.free(owned);
+        if (fin) {
+            const fa = offset + owned.len;
+            if (sbuf.fin_at) |cur| {
+                sbuf.fin_at = @max(cur, fa);
+            } else {
+                sbuf.fin_at = fa;
+            }
+        }
         conn.pending_stream_send_bytes = streamSendQueuedBytes(conn);
         return true;
     }
@@ -5427,6 +5435,7 @@ pub const Server = struct {
                         }
                     }
                 }
+                send_buffer_mod.releaseIdleStreamSendSlots(conn.stream_send_slots[0..], self.allocator);
                 // ACK received — reset PTO backoff counter and record timestamp
                 // (RFC 9002 §6.2.1: PTO resets when an ACK is received).
                 noteConnAckInSpace(conn, .application, compat.milliTimestamp());
@@ -8947,6 +8956,13 @@ pub const Client = struct {
             }
             self.processPacket(recv_buf[0..n]);
 
+            // Send the next 0-RTT batch once the link has drained (batch 2 is
+            // normally triggered from processInitialPacket; this covers the case
+            // where the server Initial is delayed or already processed).
+            if (self.early_km != null and self.zerortt_count < self.active_urls.len) {
+                self.send0RttRequests(server_addr) catch {};
+            }
+
             // Connection migration: after the handshake, rebind to a new local
             // UDP port.  Sending any 1-RTT packet from the new address causes
             // the server to detect the address change and send a PATH_CHALLENGE;
@@ -9950,6 +9966,7 @@ pub const Client = struct {
                         _ = self.sendRawStreamDataInner(lp.stream_id, lp.stream_offset, &[_]u8{}, true, null);
                     }
                 }
+                send_buffer_mod.releaseIdleStreamSendSlots(self.conn.stream_send_slots[0..], self.allocator);
                 // ACK received — reset PTO backoff counter and record timestamp
                 // (RFC 9002 §6.2.1: PTO resets when an ACK is received).
                 // Mirrors the server-side bookkeeping at the matching ACK arm.
@@ -10900,6 +10917,42 @@ pub const Client = struct {
 
         self.flushDeferredAck();
         self.flushSendBatch();
+
+        // All GETs were already sent as 0-RTT — only wait for responses.
+        if (self.zerortt_count >= self.active_urls.len and self.active_urls.len > 0) {
+            const dl_deadline = compat.milliTimestamp() + 120_000;
+            var dl_iter: u32 = 0;
+            while (self.streams_done < self.active_urls.len) {
+                dl_iter += 1;
+                const now = compat.milliTimestamp();
+                const remaining = dl_deadline - now;
+                if (remaining <= 0) {
+                    dbg("io: downloadUrls 0-RTT-only DEADLINE streams_done={}/{}\n", .{ self.streams_done, self.active_urls.len });
+                    break;
+                }
+                if (dl_iter % 100 == 0) {
+                    dbg("io: downloadUrls 0-RTT-only iter {} streams_done={}/{}\n", .{ dl_iter, self.streams_done, self.active_urls.len });
+                }
+                var fds = [1]std.posix.pollfd{.{ .fd = self.sock, .events = std.posix.POLL.IN, .revents = 0 }};
+                const poll_timeout: i32 = @intCast(@min(200, @max(0, remaining)));
+                const ready = std.posix.poll(&fds, poll_timeout) catch 0;
+                if (ready == 0) {
+                    self.flushDeferredAck();
+                    self.flushSendBatch();
+                    continue;
+                }
+                if (fds[0].revents & std.posix.POLL.IN == 0) continue;
+                var rb = batch_io.RecvBatch{};
+                const n_recv = rb.recv(self.sock, true);
+                for (rb.entries[0..n_recv]) |*e| {
+                    self.processPacket(e.buf[0..e.len]);
+                }
+                self.flushDeferredAck();
+                self.flushSendBatch();
+            }
+            dbg("io: downloadUrls done streams_done={}/{}\n", .{ self.streams_done, self.active_urls.len });
+            return;
+        }
 
         // Process downloads in batches to stay within NS3 network simulator limits.
         // The NS3 DropTail queue is 25 packets; sending more than ~20 packets at

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -229,26 +229,26 @@ const AppAckTracker = struct {
         if (pn > self.largest) self.largest = pn;
         if (self.range_count > 0) {
             for (self.ranges[0..self.range_count]) |*r| {
-                if (pn >= r[0] and pn <= r[1]) return self.range_count >= 48;
+                if (pn >= r[0] and pn <= r[1]) return self.range_count >= 16;
                 if (pn + 1 == r[0]) {
                     r[0] = pn;
-                    return self.range_count >= 48;
+                    return self.range_count >= 16;
                 }
                 if (pn == r[1] + 1) {
                     r[1] = pn;
-                    return self.range_count >= 48;
+                    return self.range_count >= 16;
                 }
             }
         }
         if (self.range_count == 0) {
             self.ranges[0] = .{ pn, pn };
             self.range_count = 1;
-            return self.range_count >= 48;
+            return self.range_count >= 16;
         }
         if (self.range_count < self.ranges.len) {
             self.ranges[self.range_count] = .{ pn, pn };
             self.range_count += 1;
-            return self.range_count >= 48;
+            return self.range_count >= 16;
         }
         return true;
     }
@@ -5241,7 +5241,7 @@ pub const Server = struct {
                 // SendBuffer.onAck never pruned those ranges → drain re-emitted
                 // bytes that the peer already had → CC stuck in recovery,
                 // transfer timed out at 168 s on the post-fix interop run.
-                var acked_stream_buf: [1024]recovery.StreamAck = undefined;
+                var acked_stream_buf: [2048]recovery.StreamAck = undefined;
                 const ld_result = conn.ld.onAck(
                     .application,
                     largest_ack,
@@ -9874,7 +9874,7 @@ pub const Client = struct {
                 // SendBuffer.onAck never pruned those ranges → drain re-emitted
                 // bytes that the peer already had → CC stuck in recovery,
                 // transfer timed out at 168 s on the post-fix interop run.
-                var acked_stream_buf: [1024]recovery.StreamAck = undefined;
+                var acked_stream_buf: [2048]recovery.StreamAck = undefined;
                 const ld_result = self.conn.ld.onAck(
                     .application,
                     largest_ack,
@@ -10226,11 +10226,11 @@ pub const Client = struct {
             return;
         }
 
-        // Defer ACK until after the recv drain loop in downloadUrls.
-        if (self.app_ack.observe(decompressed_pn)) {
-            self.flushDeferredAck();
-            _ = self.app_ack.observe(decompressed_pn);
-        }
+        // Flush ACKs promptly so the server's CC window opens during 0-RTT
+        // response bursts (zerortt / multiplexing); deferring until 48 PNs
+        // stalled the peer when fewer than 48 responses were in flight.
+        _ = self.app_ack.observe(decompressed_pn);
+        self.flushDeferredAck();
     }
 
     /// Send a CONNECTION_CLOSE frame (QUIC layer, type 0x1c) and enter draining.

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -150,7 +150,14 @@ pub const SendBuffer = struct {
                     @memcpy(grown[last.data.len..][0..data.len], data);
                     last.data = grown;
                     self.queued_bytes += data.len;
-                    if (fin) self.fin_at = offset + data.len;
+                    if (fin) {
+                        const fa = offset + data.len;
+                        if (self.fin_at) |cur| {
+                            self.fin_at = @max(cur, fa);
+                        } else {
+                            self.fin_at = fa;
+                        }
+                    }
                     return;
                 }
             }
@@ -302,6 +309,19 @@ pub const SendBuffer = struct {
         return false;
     }
 
+    /// True when all enqueued bytes are sent and contiguously ACKed (safe to
+    /// drop the per-stream slot).  Stricter than `hasWork`: sent-but-unacked
+    /// data with a leading gap must not be released before loss recovery runs.
+    pub fn isSendComplete(self: *const SendBuffer) bool {
+        if (self.lost.items.len > 0) return false;
+        for (self.segments.items) |seg| {
+            if (seg.sent < seg.data.len) return false;
+            if (contiguousAckedEnd(seg.acked_ranges.items) < seg.data.len) return false;
+        }
+        if (self.fin_at != null and !self.fin_sent) return false;
+        return true;
+    }
+
     /// Next range to put on the wire (lost ranges first, then unsent tail).
     pub fn pollTransmit(self: *SendBuffer, max_len: usize) ?PollResult {
         if (max_len == 0) return null;
@@ -426,6 +446,19 @@ pub fn releaseStreamSendSlot(slots: []StreamSendSlot, allocator: std.mem.Allocat
             slot.buf.deinit(allocator);
             slot.* = .{};
             return;
+        }
+    }
+}
+
+/// Free per-stream send slots whose `SendBuffer` has no unsent or unacked work.
+/// HTTP/0.9 immediate responses (multiplexing / zerortt) only need a slot until
+/// the peer ACKs; without this the 64-slot table is exhausted after ~64 streams.
+pub fn releaseIdleStreamSendSlots(slots: []StreamSendSlot, allocator: std.mem.Allocator) void {
+    for (slots) |*slot| {
+        if (!slot.active) continue;
+        if (slot.buf.isSendComplete()) {
+            slot.buf.deinit(allocator);
+            slot.* = .{};
         }
     }
 }
@@ -574,4 +607,21 @@ test "send_buffer: non-contiguous ack retains gap for retransmit (#221)" {
     buf.onAck(testing.allocator, 0, 1436);
     try testing.expectEqual(@as(usize, 0), buf.segments.items.len);
     try testing.expectEqual(@as(usize, 0), buf.queued_bytes);
+}
+
+test "send_buffer: releaseIdleStreamSendSlots frees acked slots" {
+    const testing = std.testing;
+    var slots: [stream_send_slot_max]StreamSendSlot = [_]StreamSendSlot{.{}} ** stream_send_slot_max;
+
+    const s0 = getOrCreateStreamSendSlot(&slots, 0) orelse return error.TestUnexpectedNull;
+    try s0.append(testing.allocator, 0, "ok", true);
+    const p = s0.pollTransmit(2).?;
+    s0.onSent(p.offset, p.data.len);
+    s0.onAck(testing.allocator, 0, 2);
+    s0.onAck(testing.allocator, 2, 0);
+    try testing.expect(s0.isSendComplete());
+
+    releaseIdleStreamSendSlots(&slots, testing.allocator);
+    try testing.expect(!slots[0].active);
+    try testing.expect(getOrCreateStreamSendSlot(&slots, 4) != null);
 }

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -232,8 +232,11 @@ pub const SendBuffer = struct {
     /// Mark `[offset, offset+len)` as ACKed by the peer.
     pub fn onAck(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) void {
         if (len == 0) {
-            if (self.fin_at == offset) self.fin_sent = false;
-            self.fin_at = null;
+            if (self.fin_at) |fa| {
+                if (offset != fa) return;
+                self.fin_sent = false;
+                self.fin_at = null;
+            }
             return;
         }
         const end = offset + len;
@@ -411,7 +414,7 @@ pub const SendBuffer = struct {
     }
 };
 
-pub const stream_send_slot_max: usize = 64;
+pub const stream_send_slot_max: usize = 256;
 
 pub const StreamSendSlot = struct {
     active: bool = false,
@@ -452,7 +455,7 @@ pub fn releaseStreamSendSlot(slots: []StreamSendSlot, allocator: std.mem.Allocat
 
 /// Free per-stream send slots whose `SendBuffer` has no unsent or unacked work.
 /// HTTP/0.9 immediate responses (multiplexing / zerortt) only need a slot until
-/// the peer ACKs; without this the 64-slot table is exhausted after ~64 streams.
+/// the peer ACKs; without this the slot table is exhausted after ~slot_max streams.
 pub fn releaseIdleStreamSendSlots(slots: []StreamSendSlot, allocator: std.mem.Allocator) void {
     for (slots) |*slot| {
         if (!slot.active) continue;
@@ -624,4 +627,17 @@ test "send_buffer: releaseIdleStreamSendSlots frees acked slots" {
     releaseIdleStreamSendSlots(&slots, testing.allocator);
     try testing.expect(!slots[0].active);
     try testing.expect(getOrCreateStreamSendSlot(&slots, 4) != null);
+}
+
+test "send_buffer: onAck len=0 at wrong offset does not clear fin_at" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 0, "data", true);
+    const p = buf.pollTransmit(4).?;
+    buf.onSent(p.offset, p.data.len);
+    try testing.expectEqual(@as(?u64, 4), buf.fin_at);
+    buf.onAck(testing.allocator, 0, 0);
+    try testing.expectEqual(@as(?u64, 4), buf.fin_at);
 }

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -159,7 +159,22 @@ pub const SendBuffer = struct {
             self.queued_bytes += data.len;
         }
         if (fin) {
-            self.fin_at = if (data.len > 0) offset + data.len else offset;
+            const fa: u64 = if (data.len > 0) offset + data.len else blk: {
+                var end = offset;
+                for (self.segments.items) |seg| {
+                    const seg_end = seg.offset + seg.data.len;
+                    if (offset >= seg.offset and offset < seg_end) {
+                        end = seg_end;
+                        break;
+                    }
+                }
+                break :blk end;
+            };
+            if (self.fin_at) |cur| {
+                self.fin_at = @max(cur, fa);
+            } else {
+                self.fin_at = fa;
+            }
         }
     }
 
@@ -494,6 +509,21 @@ test "send_buffer: overlapping onLoss calls coalesce (regression for infinite-re
     try buf.onLoss(testing.allocator, 6, 2);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
     try testing.expectEqual(@as(usize, 8), buf.lost.items[0].len);
+}
+
+test "send_buffer: duplicate fin enqueue does not clobber fin_at (#221)" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    var data: [32]u8 = undefined;
+    @memset(&data, 0xAB);
+    try buf.append(testing.allocator, 0, &data, true);
+    try testing.expectEqual(@as(?u64, 32), buf.fin_at);
+
+    // coversRange retry must not reset fin_at to offset 0.
+    try buf.append(testing.allocator, 0, &.{}, true);
+    try testing.expectEqual(@as(?u64, 32), buf.fin_at);
 }
 
 test "send_buffer: coversRange skips duplicate enqueue" {

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -36,6 +36,10 @@ pub const SendBuffer = struct {
     /// Stream end offset when FIN was queued (exclusive).
     fin_at: ?u64 = null,
     fin_sent: bool = false,
+    /// True from the moment the app calls `append(.., fin=true)`.  Stays true
+    /// even after `fin_at` is cleared on FIN ACK — needed by `isComplete()`
+    /// to distinguish "FIN-obligation acked" from "no FIN obligation set yet".
+    fin_was_set: bool = false,
     queued_bytes: usize = 0,
 
     pub fn deinit(self: *SendBuffer, allocator: std.mem.Allocator) void {
@@ -68,7 +72,10 @@ pub const SendBuffer = struct {
                     @memcpy(grown[last.data.len..][0..data.len], data);
                     last.data = grown;
                     self.queued_bytes += data.len;
-                    if (fin) self.fin_at = offset + data.len;
+                    if (fin) {
+                        self.fin_at = offset + data.len;
+                        self.fin_was_set = true;
+                    }
                     return;
                 }
             }
@@ -78,7 +85,34 @@ pub const SendBuffer = struct {
         }
         if (fin) {
             self.fin_at = if (data.len > 0) offset + data.len else offset;
+            self.fin_was_set = true;
         }
+    }
+
+    /// True once every byte the app has appended has been acked AND a FIN
+    /// has been set + delivered.  Stays false for streams the app hasn't
+    /// FIN'd (those are still legitimately open and may receive more
+    /// `append`s).  Also stays false for the brief window between
+    /// `append(_, empty, fin=true)` and the wire emit — segments is empty
+    /// there too but the FIN obligation hasn't been discharged yet.
+    ///
+    /// The caller (`applyStreamAcks` in io.zig) checks this after every
+    /// ACK-processing cycle and releases the slot when true so the bounded
+    /// `stream_send_slots` table doesn't accumulate completed streams.
+    pub fn isComplete(self: *const SendBuffer) bool {
+        if (!self.fin_was_set) return false;
+        if (self.segments.items.len != 0) return false;
+        if (self.lost.items.len != 0) return false;
+        // FIN must have been transmitted.  Two completion paths:
+        //   - piggyback: `onSent` set `fin_sent=true` when a non-zero send
+        //     reached `fin_at`; the data ACK then pruned the segment.
+        //   - separate-empty-FIN: `onAck(fin_at, 0)` cleared `fin_at` to
+        //     null and reset `fin_sent` to false.
+        // The remaining state — `fin_at != null AND !fin_sent` — is the
+        // post-`append(., empty, fin=true)` / pre-wire-emit window; do NOT
+        // release there or the FIN frame is never put on the wire.
+        if (self.fin_at != null and !self.fin_sent) return false;
+        return true;
     }
 
     fn pruneAcked(self: *SendBuffer, allocator: std.mem.Allocator) void {

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -119,6 +119,18 @@ pub const SendBuffer = struct {
         return self.queued_bytes;
     }
 
+    /// True when `[offset, offset+len)` is already held in a segment (embedder
+    /// retry after backpressure must not duplicate into `queued_bytes`).
+    pub fn coversRange(self: *const SendBuffer, offset: u64, len: usize) bool {
+        if (len == 0) return false;
+        const end = offset + len;
+        for (self.segments.items) |seg| {
+            const seg_end = seg.offset + seg.data.len;
+            if (offset >= seg.offset and end <= seg_end) return true;
+        }
+        return false;
+    }
+
     /// Append `data` at `offset`.  Coalesces with the tail segment when contiguous.
     pub fn append(
         self: *SendBuffer,
@@ -482,6 +494,17 @@ test "send_buffer: overlapping onLoss calls coalesce (regression for infinite-re
     try buf.onLoss(testing.allocator, 6, 2);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
     try testing.expectEqual(@as(usize, 8), buf.lost.items[0].len);
+}
+
+test "send_buffer: coversRange skips duplicate enqueue" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    try buf.append(testing.allocator, 0, "hello", false);
+    try testing.expect(buf.coversRange(0, 5));
+    try testing.expect(!buf.coversRange(0, 6));
+    try testing.expect(!buf.coversRange(5, 1));
 }
 
 test "send_buffer: non-contiguous ack retains gap for retransmit (#221)" {

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -321,7 +321,7 @@ pub const SendBuffer = struct {
     }
 };
 
-pub const stream_send_slot_max: usize = 64;
+pub const stream_send_slot_max: usize = 512;
 
 pub const StreamSendSlot = struct {
     active: bool = false,

--- a/src/transport/send_buffer.zig
+++ b/src/transport/send_buffer.zig
@@ -12,14 +12,20 @@ pub const Range = struct {
     len: usize,
 };
 
+/// Byte range relative to the start of a segment's `data` buffer.
+const RelRange = struct {
+    off: usize,
+    len: usize,
+};
+
 const Segment = struct {
     offset: u64,
     data: []u8,
     /// Bytes from the start of this segment that have been put on the wire and
     /// are not yet ACKed (includes in-flight and lost ranges).
     sent: usize = 0,
-    /// Bytes from the start of this segment that the peer has ACKed.
-    acked: usize = 0,
+    /// Non-overlapping ACKed ranges relative to `offset` (quinn-style).
+    acked_ranges: std.ArrayList(RelRange) = .empty,
 };
 
 pub const PollResult = struct {
@@ -30,6 +36,67 @@ pub const PollResult = struct {
     retransmit: bool = false,
 };
 
+fn totalAckedBytes(ranges: []const RelRange) usize {
+    var sum: usize = 0;
+    for (ranges) |r| sum += r.len;
+    return sum;
+}
+
+/// Contiguous ACK prefix from the segment start (0).  Zero when the first
+/// acked range does not begin at 0 — gaps before it are still in flight.
+fn contiguousAckedEnd(ranges: []const RelRange) usize {
+    if (ranges.len == 0 or ranges[0].off != 0) return 0;
+    return ranges[0].len;
+}
+
+fn mergeAckedRange(
+    ranges: *std.ArrayList(RelRange),
+    allocator: std.mem.Allocator,
+    off: usize,
+    len: usize,
+) !usize {
+    if (len == 0) return 0;
+    const old_total = totalAckedBytes(ranges.items);
+    const end = off + len;
+
+    var new_off = off;
+    var new_end = end;
+    var i: usize = 0;
+    while (i < ranges.items.len) {
+        const r = ranges.items[i];
+        const r_end = r.off + r.len;
+        if (new_end <= r.off or new_off >= r_end) {
+            i += 1;
+            continue;
+        }
+        new_off = @min(new_off, r.off);
+        new_end = @max(new_end, r_end);
+        _ = ranges.orderedRemove(i);
+    }
+    try ranges.append(allocator, .{ .off = new_off, .len = new_end - new_off });
+
+    std.mem.sort(RelRange, ranges.items, {}, struct {
+        fn less(_: void, a: RelRange, b: RelRange) bool {
+            return a.off < b.off;
+        }
+    }.less);
+
+    i = 0;
+    while (i + 1 < ranges.items.len) {
+        const a = &ranges.items[i];
+        const b = &ranges.items[i + 1];
+        if (a.off + a.len >= b.off) {
+            const merged_end = @max(a.off + a.len, b.off + b.len);
+            a.len = merged_end - a.off;
+            _ = ranges.orderedRemove(i + 1);
+            continue;
+        }
+        i += 1;
+    }
+
+    return totalAckedBytes(ranges.items) - old_total;
+}
+
 pub const SendBuffer = struct {
     segments: std.ArrayList(Segment) = .empty,
     lost: std.ArrayList(Range) = .empty,
@@ -39,7 +106,10 @@ pub const SendBuffer = struct {
     queued_bytes: usize = 0,
 
     pub fn deinit(self: *SendBuffer, allocator: std.mem.Allocator) void {
-        for (self.segments.items) |seg| allocator.free(seg.data);
+        for (self.segments.items) |*seg| {
+            seg.acked_ranges.deinit(allocator);
+            allocator.free(seg.data);
+        }
         self.segments.deinit(allocator);
         self.lost.deinit(allocator);
         self.* = .{};
@@ -84,25 +154,21 @@ pub const SendBuffer = struct {
     fn pruneAcked(self: *SendBuffer, allocator: std.mem.Allocator) void {
         while (self.segments.items.len > 0) {
             const seg = &self.segments.items[0];
-            if (seg.acked < seg.data.len) break;
+            if (contiguousAckedEnd(seg.acked_ranges.items) < seg.data.len) break;
+            seg.acked_ranges.deinit(allocator);
             allocator.free(seg.data);
             _ = self.segments.orderedRemove(0);
         }
-        // Drop lost ranges that no longer have a backing segment.  When ALL
-        // segments are pruned (entire stream fully acked), every remaining
-        // lost range is orphaned and `pollTransmit` will return null
-        // forever for it — `hasWork()` stays true → drain stalls in an
-        // infinite no-op loop.  The previous loop's `if (.. == 0) break`
-        // exited without clearing those orphans; clear them explicitly.
         if (self.segments.items.len == 0) {
             self.lost.clearRetainingCapacity();
             return;
         }
         const head = self.segments.items[0];
+        const head_cont = contiguousAckedEnd(head.acked_ranges.items);
         var i: usize = 0;
         while (i < self.lost.items.len) {
             const r = self.lost.items[i];
-            if (r.offset + r.len <= head.offset + head.acked) {
+            if (r.offset + r.len <= head.offset + head_cont) {
                 _ = self.lost.orderedRemove(i);
                 continue;
             }
@@ -112,13 +178,6 @@ pub const SendBuffer = struct {
 
     fn mergeLost(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) !void {
         if (len == 0) return;
-        // Walk once, absorbing every overlapping / adjacent range into a single
-        // accumulator. The previous version recursed with the ORIGINAL
-        // (offset, len) after each merge — since the merged range still overlaps
-        // with those args, the recursion never terminated (release builds TCO'd
-        // it into a CPU spin, which is exactly the symptom the post-rebase
-        // interop hit: transfer stalled with `pending_stream_sends` drained but
-        // CC stuck in recovery and bif > cwnd).
         var new_off = offset;
         var new_end = offset + len;
         var i: usize = 0;
@@ -132,7 +191,6 @@ pub const SendBuffer = struct {
             new_off = @min(new_off, r.offset);
             new_end = @max(new_end, r_end);
             _ = self.lost.orderedRemove(i);
-            // Don't increment i — the shifted-down entry takes this slot.
         }
         try self.lost.append(allocator, .{ .offset = new_off, .len = @intCast(new_end - new_off) });
     }
@@ -161,12 +219,13 @@ pub const SendBuffer = struct {
         for (self.segments.items) |*seg| {
             const seg_end = seg.offset + seg.data.len;
             if (end <= seg.offset or offset >= seg_end) continue;
-            const rel_end: usize = @intCast(@min(end, seg_end) - seg.offset);
-            if (rel_end > seg.acked) {
-                const delta = rel_end - seg.acked;
-                seg.acked = rel_end;
-                self.queued_bytes -|= delta;
-            }
+            const ix_start = @max(offset, seg.offset);
+            const ix_end = @min(end, seg_end);
+            const rel_off: usize = @intCast(ix_start - seg.offset);
+            const rel_len: usize = @intCast(ix_end - ix_start);
+            const delta = mergeAckedRange(&seg.acked_ranges, allocator, rel_off, rel_len) catch continue;
+            self.queued_bytes -|= delta;
+            const rel_end = rel_off + rel_len;
             if (rel_end > seg.sent) seg.sent = rel_end;
         }
         self.pruneAcked(allocator);
@@ -175,11 +234,6 @@ pub const SendBuffer = struct {
     /// Mark `[offset, offset+len)` as lost — eligible for `pollTransmit`.
     pub fn onLoss(self: *SendBuffer, allocator: std.mem.Allocator, offset: u64, len: usize) !void {
         if (len == 0) return;
-        // If no segment backs any byte of this range — typically a spurious
-        // loss declared after every byte was acked + the segment pruned —
-        // don't create a phantom lost range that `pollTransmit` will never be
-        // able to serve.  Without this gate, `hasWork()` returns true forever
-        // for the orphan and the drain spins.
         const end = offset + len;
         var has_backing = false;
         for (self.segments.items) |seg| {
@@ -284,17 +338,6 @@ pub const SendBuffer = struct {
             const rel_end: usize = @intCast(offset + len - seg.offset);
             if (rel_end > seg.sent) seg.sent = rel_end;
         }
-        // Data + FIN piggyback: `pollTransmit` attaches `fin=true` to the last
-        // unsent data frame when it ends exactly at `fin_at`.  Without marking
-        // `fin_sent` here, `hasWork()` keeps returning true → drain emits an
-        // EXTRA empty-FIN frame at the same offset.  If the data frame is then
-        // lost but the empty-FIN reaches the peer, the peer ACKs the empty FIN
-        // → `onAck(fin_at, 0)` clears `fin_at` → the data retransmit's lost-
-        // branch sees `fin_at == null` and re-emits the data without FIN.
-        // Receiver still has the empty FIN sitting in out-of-order and never
-        // delivers the (still missing) tail data.  Net effect: a permanent
-        // stall at the very end of large transfers (the post-rebase #219
-        // interop `transfer` / `zerortt` symptom).
         if (self.fin_at) |fa| {
             if (offset + len >= fa) self.fin_sent = true;
         }
@@ -428,19 +471,54 @@ test "send_buffer: overlapping onLoss calls coalesce (regression for infinite-re
     _ = buf.pollTransmit(10);
     buf.onSent(0, 10);
 
-    // First lost range; alone, append-only path is exercised.
     try buf.onLoss(testing.allocator, 0, 4);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
 
-    // Second lost range overlapping the first — previously triggered
-    // mergeLost's terminal-recurse-with-original-args spin.
     try buf.onLoss(testing.allocator, 2, 4);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
     try testing.expectEqual(@as(u64, 0), buf.lost.items[0].offset);
     try testing.expectEqual(@as(usize, 6), buf.lost.items[0].len);
 
-    // Third lost range adjacent to the merged range — also merges.
     try buf.onLoss(testing.allocator, 6, 2);
     try testing.expectEqual(@as(usize, 1), buf.lost.items.len);
     try testing.expectEqual(@as(usize, 8), buf.lost.items[0].len);
+}
+
+test "send_buffer: non-contiguous ack retains gap for retransmit (#221)" {
+    const testing = std.testing;
+    var buf: SendBuffer = .{};
+    defer buf.deinit(testing.allocator);
+
+    var data: [1632]u8 = undefined;
+    for (&data, 0..) |*b, i| b.* = @intCast(i % 256);
+
+    try buf.append(testing.allocator, 0, &data, false);
+    try testing.expectEqual(@as(usize, 1632), buf.queued_bytes);
+
+    const p1 = buf.pollTransmit(1436).?;
+    try testing.expectEqual(@as(u64, 0), p1.offset);
+    try testing.expectEqual(@as(usize, 1436), p1.data.len);
+    buf.onSent(p1.offset, p1.data.len);
+
+    const p2 = buf.pollTransmit(196).?;
+    try testing.expectEqual(@as(u64, 1436), p2.offset);
+    try testing.expectEqual(@as(usize, 196), p2.data.len);
+    buf.onSent(p2.offset, p2.data.len);
+
+    // ACK only the tail packet — must not treat the leading gap as acked.
+    buf.onAck(testing.allocator, 1436, 196);
+    try testing.expectEqual(@as(usize, 1), buf.segments.items.len);
+    try testing.expectEqual(@as(usize, 1436), buf.queued_bytes);
+    try testing.expectEqual(@as(usize, 0), contiguousAckedEnd(buf.segments.items[0].acked_ranges.items));
+
+    try buf.onLoss(testing.allocator, 0, 1436);
+    const rtx = buf.pollTransmit(1436).?;
+    try testing.expectEqual(@as(u64, 0), rtx.offset);
+    try testing.expectEqual(@as(usize, 1436), rtx.data.len);
+    try testing.expectEqualSlices(u8, data[0..1436], rtx.data);
+
+    buf.onSent(rtx.offset, rtx.data.len);
+    buf.onAck(testing.allocator, 0, 1436);
+    try testing.expectEqual(@as(usize, 0), buf.segments.items.len);
+    try testing.expectEqual(@as(usize, 0), buf.queued_bytes);
 }


### PR DESCRIPTION
## Summary

Fixes [#221](https://github.com/ch4r10t33r/zquic/issues/221): replace the single `seg.acked` watermark with quinn-style per-segment `acked_ranges` (sorted, non-overlapping, relative to segment offset).

A non-contiguous ACK (e.g. tail packet acked while an earlier PN is still in flight/lost) no longer:
- phantom-acks the gap and decrements `queued_bytes` incorrectly
- prunes the segment before all bytes are contiguously confirmed
- leaves `onLoss` with no backing segment to retransmit from

Also stacks the three SendBuffer workarounds from `9c2a571` (orphan-lost clear, phantom-lost gate, piggyback-FIN tracking) and the `mergeLost` infinite-recurse fix.

## Test plan

- [x] `zig build test` — 263/263 pass locally
- [x] New regression: `send_buffer: non-contiguous ack retains gap for retransmit (#221)` reproduces the issue #221 PN sequence
- [ ] Interop transfer-with-loss (NS3 drop-every-7th pattern)