### PR TITLE
io: lower max_pending_drain_per_call 1024 -> 256 (bound per-conn send slice, fix no-ACK teardowns)

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1055,7 +1055,13 @@ const max_pending_stream_chunk: usize = MAX_DATAGRAM_SIZE - 64;
 /// every other peer (the residual drive-loop stall after the recv-drain bound).
 /// Cap per call; the remainder drains on subsequent iterations. Well above the
 /// steady-state per-conn send rate, so it only bounds post-stall catch-up bursts.
-const max_pending_drain_per_call: usize = 1024;
+/// 1024 still let one conn's catch-up burst run ~145ms before the embedder's
+/// drive loop pumped inbound again (live: outbound=727ms across 5 conns ->
+/// peers' ACKs starved -> 60s no-ACK teardowns -> peer drop -> fork). 256 keeps
+/// each per-conn send slice short (~tens of ms) so ACKs to other peers keep
+/// flowing; CC/pacing remains the real throughput limiter, so block-sync total
+/// throughput is unchanged (the backlog just drains over more, shorter calls).
+const max_pending_drain_per_call: usize = 256;
 
 /// Enqueue bytes that exceeded flow control.  Duplicates `data` onto the
 /// heap (caller's slice typically points into a transient frame buffer).


### PR DESCRIPTION
The 1024 send fairness cap still let one connection’s post-stall catch-up burst (block-sync flood) run ~145 ms of send before the embedder pumped inbound again. Live on the zeam 32-node devnet: `SLOW drive iter outbound=727ms` across 5 conns → peers’ ACKs starved → `no ACK 60s` teardowns → peer drop → fork → finality froze (justified climbed to 56 then stuck).

256 keeps each per-conn send slice to ~tens of ms so ACKs keep flowing. CC/pacing remains the real throughput limiter (confirmed by an adversarial liveness review of the embedder drive loop), so block-sync total throughput is unchanged — the backlog just drains over more, shorter calls. 274/274 tests pass.