### PR TITLE
io: raise per-drive send budget 256->2048 (un-throttle sends below cwnd)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zquic,
     .fingerprint = 0x947d823dd45c34db,
-    .version = "1.7.63",
+    .version = "1.7.64",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zig_varint = .{

--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -271,9 +271,14 @@ fn classifyAck(
 
 /// Loss detection state for one packet number space.
 pub const LossDetector = struct {
-    /// High-BDP paths can hold thousands of in-flight packets; 16 KiB slots
-    /// covers ~10 GbE × 100 ms RTT without silent loss-detection blind spots.
-    pub const max_tracked_packets: usize = 16_384;
+    /// High-BDP paths can hold thousands of in-flight packets. RAISED 16384 ->
+    /// 32768: live, conns with a large cwnd (up to the 32 MB pending cap ≈ 27k
+    /// MTU packets) AND inflated RTT under load hit the 16384 cap ("in-flight
+    /// tracking cap reached — packet not tracked"), which sends packets WITHOUT
+    /// loss tracking → silent loss-detection blind spot → possible stream stall.
+    /// 32768 covers a full 32 MB cwnd; cost is one fixed `[N]SentPacket` array
+    /// per LossDetector (~+1 MB/conn), acceptable on the 32 GB devnet hosts.
+    pub const max_tracked_packets: usize = 32_768;
     const max_tracked = max_tracked_packets;
 
     /// In-flight packets form a DEQUE inside `sent`: the logical packets are

--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -271,14 +271,13 @@ fn classifyAck(
 
 /// Loss detection state for one packet number space.
 pub const LossDetector = struct {
-    /// High-BDP paths can hold thousands of in-flight packets. RAISED 16384 ->
-    /// 32768: live, conns with a large cwnd (up to the 32 MB pending cap ≈ 27k
-    /// MTU packets) AND inflated RTT under load hit the 16384 cap ("in-flight
-    /// tracking cap reached — packet not tracked"), which sends packets WITHOUT
-    /// loss tracking → silent loss-detection blind spot → possible stream stall.
-    /// 32768 covers a full 32 MB cwnd; cost is one fixed `[N]SentPacket` array
-    /// per LossDetector (~+1 MB/conn), acceptable on the 32 GB devnet hosts.
-    pub const max_tracked_packets: usize = 32_768;
+    /// High-BDP paths can hold thousands of in-flight packets; 16 KiB slots
+    /// covers ~10 GbE × 100 ms RTT without silent loss-detection blind spots.
+    /// NOTE: this is a fixed inline `[N]SentPacket` array, so it cannot be raised
+    /// without overflowing the stack of on-stack LossDetector allocations (32768
+    /// crashed 25 tests). Raising it for very-high-BDP conns requires
+    /// heap-allocating the deque first — tracked as a follow-up.
+    pub const max_tracked_packets: usize = 16_384;
     const max_tracked = max_tracked_packets;
 
     /// In-flight packets form a DEQUE inside `sent`: the logical packets are

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1061,7 +1061,15 @@ const max_pending_stream_chunk: usize = MAX_DATAGRAM_SIZE - 64;
 /// each per-conn send slice short (~tens of ms) so ACKs to other peers keep
 /// flowing; CC/pacing remains the real throughput limiter, so block-sync total
 /// throughput is unchanged (the backlog just drains over more, shorter calls).
-const max_pending_drain_per_call: usize = 64;
+// RAISED 64 -> 512: with 64 a single non-re-entrant drain emitted only ~77 KB
+// even when cwnd allowed MUCH more — live: a healthy conn (cwnd=14MB, srtt=22ms,
+// bif=900KB ≪ cwnd) had a FULL 32 MB pending queue because this cap, not CC, was
+// the limiter → gossip pending backed up → priority outbox dropped attestations.
+// The drive lap is now wall-clock-bounded (50ms outbound phase budget in the
+// embedder) so the packet-count cap no longer needs to be the single-conn bound;
+// 512 lets a fast conn track its cwnd while the wall-clock budget keeps the lap
+// short. CC/pacing is once again the real throughput limiter.
+const max_pending_drain_per_call: usize = 512;
 
 /// Per-`drive()` send budget shared across ALL re-entrant `drainPendingStreamSends`
 /// calls for one connection. `drainPendingStreamSends` is re-invoked synchronously
@@ -1076,7 +1084,14 @@ const max_pending_drain_per_call: usize = 64;
 /// worth total per drive); the remainder flushes on the next drive. ACKs are
 /// unaffected — they flush separately via `flushSendBatch` / `flushDeferredAck`,
 /// not through this STREAM-data path.
-const max_sends_per_drive: usize = 256;
+// RAISED 256 -> 2048: 256 packets (~300 KB) per drive throttled a healthy conn
+// BELOW its cwnd (live: cwnd=14MB/srtt=22ms wants ~640 KB-2.4 MB/drive to stay
+// CC-limited; 300 KB starved it → 32 MB pending full → attestation drops). The
+// 1156ms single-conn starvation this cap originally bounded is now bounded by the
+// embedder's 50ms wall-clock outbound phase budget (per-lap, across conns) — so
+// 2048 (~2.4 MB, a few ms of encrypt) lets CC/pacing be the throughput limiter
+// again while a single drive() still stays well under the wall-clock budget.
+const max_sends_per_drive: usize = 2048;
 
 /// Enqueue bytes that exceeded flow control.  Duplicates `data` onto the
 /// heap (caller's slice typically points into a transient frame buffer).


### PR DESCRIPTION
Live CC trace: a healthy conn (`cwnd=14MB, srtt=22ms, bif=900KB ≪ cwnd`) had a **full 32 MB** pending-stream-send queue on the gossip stream — the send was throttled below what CC allowed by the per-drive packet-count caps (256 send / 64 drain), not by congestion control. Backed-up gossip pending → priority outbox overflow → attestation drops → finality stall.

These caps bounded a 1156ms single-conn starvation back when there was no wall-clock lap bound. That bound now exists (the embedder 50ms per-lap outbound budget), so raise the caps (256→2048, 64→512) so CC/pacing is the real throughput limiter again. A single drive() stays well under the 50ms wall-clock budget.