### PR TITLE
loss/io: heap-allocate LossDetector.sent (cap 16384→32768, #233) + recv round-robin resume (#231)

### DIFF
--- a/src/loss/recovery.zig
+++ b/src/loss/recovery.zig
@@ -271,13 +271,15 @@ fn classifyAck(
 
 /// Loss detection state for one packet number space.
 pub const LossDetector = struct {
-    /// High-BDP paths can hold thousands of in-flight packets; 16 KiB slots
-    /// covers ~10 GbE × 100 ms RTT without silent loss-detection blind spots.
-    /// NOTE: this is a fixed inline `[N]SentPacket` array, so it cannot be raised
-    /// without overflowing the stack of on-stack LossDetector allocations (32768
-    /// crashed 25 tests). Raising it for very-high-BDP conns requires
-    /// heap-allocating the deque first — tracked as a follow-up.
-    pub const max_tracked_packets: usize = 16_384;
+    /// High-BDP paths can hold thousands of in-flight packets. At 32768 slots a
+    /// full 32 MB cwnd (≈27k MTU-sized packets) fits without ever hitting the
+    /// in-flight tracking cap — i.e. without sending packets that loss detection
+    /// cannot see (a loss-detection blind spot under high cwnd).
+    /// `sent` is now a HEAP-allocated slice (see `init`/`deinit`), so raising
+    /// this only grows heap memory (~+2 MB/conn at 64 B/SentPacket) and never
+    /// the stack of on-stack LossDetector allocations — the constraint that
+    /// previously pinned this at 16384 (#233).
+    pub const max_tracked_packets: usize = 32_768;
     const max_tracked = max_tracked_packets;
 
     /// In-flight packets form a DEQUE inside `sent`: the logical packets are
@@ -288,10 +290,16 @@ pub const LossDetector = struct {
     /// fallback, `abandonSpace`) preserves send order, so within each PN space
     /// the packets stay ascending by pn — the invariant the front-pop relies on.
     /// This replaced an unsorted flat array + swap-remove whose onAck rescanned
-    /// ALL in-flight packets (O(sent_count), up to the 16384 cap) on every ACK —
+    /// ALL in-flight packets (O(sent_count), up to the cap) on every ACK —
     /// the per-packet cost that saturated the single drive thread under a full
     /// 31-peer mesh (#184 / drive-loop stall).
-    sent: [max_tracked]SentPacket = undefined,
+    ///
+    /// HEAP-allocated (#233): a length-`max_tracked` slice owned by this
+    /// detector. The default `&.{}` is an empty placeholder so a `.{}`-built
+    /// LossDetector is inert until `init` allocates the real backing; `deinit`
+    /// frees it. The deque indexing below treats `sent` exactly as it treated
+    /// the former inline array — `sent.len == max_tracked` once `init` ran.
+    sent: []SentPacket = &.{},
     sent_count: usize = 0,
     /// Physical index of the deque front (logical packet 0). See `sent`.
     head: usize = 0,
@@ -308,6 +316,31 @@ pub const LossDetector = struct {
 
     fn spaceIdx(space: PacketNumberSpace) usize {
         return @intFromEnum(space);
+    }
+
+    /// Allocate the heap-backed `sent` deque (length `max_tracked`). Every other
+    /// field keeps its struct default. Callers must pair this with `deinit` so
+    /// the slice is freed. The backing memory is `undefined` until written by
+    /// `onPacketSent` — only `sent[head .. head + sent_count]` is ever read.
+    pub fn init(allocator: std.mem.Allocator) std.mem.Allocator.Error!LossDetector {
+        var self = LossDetector{};
+        self.sent = try allocator.alloc(SentPacket, max_tracked);
+        return self;
+    }
+
+    /// Clear the deque in place WITHOUT freeing the backing slice (RFC 9002 §9.4
+    /// path-change reset). Frees any in-flight retransmit buffers first so the
+    /// reset does not leak `stream_data`, then rewinds the deque and per-space
+    /// state. The slice stays allocated and reusable.
+    pub fn reset(self: *LossDetector, allocator: std.mem.Allocator) void {
+        for (self.sent[self.head .. self.head + self.sent_count]) |*p| {
+            if (p.stream_data) |sd| _ = freeStreamDataChecked(allocator, sd, p.pn, p.stream_id);
+            p.stream_data = null;
+        }
+        self.sent_count = 0;
+        self.head = 0;
+        self.largest_acked = [_]u64{0} ** pn_space_count;
+        self.loss_time_ms = .{null} ** pn_space_count;
     }
 
     /// True when this PN space still has ack-eliciting packets in flight.
@@ -352,8 +385,12 @@ pub const LossDetector = struct {
         self.loss_time_ms[sidx] = null;
     }
 
-    /// Free any heap-owned retransmit buffers attached to in-flight packets.
-    /// Caller passes the same allocator used when populating `stream_data`.
+    /// Free any heap-owned retransmit buffers attached to in-flight packets AND
+    /// the heap-backed `sent` slice itself (#233). Caller passes the same
+    /// allocator used to `init` the detector and to populate `stream_data`.
+    /// Idempotent: after this `sent` is the empty placeholder again, so a second
+    /// call (or a call on a `.{}`-built detector that was never `init`ed) is a
+    /// no-op.
     pub fn deinit(self: *LossDetector, allocator: std.mem.Allocator) void {
         for (self.sent[self.head .. self.head + self.sent_count]) |*p| {
             if (p.stream_data) |sd| _ = freeStreamDataChecked(allocator, sd, p.pn, p.stream_id);
@@ -361,6 +398,10 @@ pub const LossDetector = struct {
         }
         self.sent_count = 0;
         self.head = 0;
+        if (self.sent.len != 0) {
+            allocator.free(self.sent);
+            self.sent = &.{};
+        }
     }
 
     /// True when another in-flight packet can be tracked (quinn always
@@ -592,7 +633,8 @@ test "rtt: pto increases with backoff" {
 
 test "loss: packet threshold detection" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
 
     // Send packets 0..5
@@ -617,7 +659,8 @@ test "loss: packet threshold detection" {
 
 test "loss: rejects invalid first_ack_range > largest_acked" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
     var lost_buf: [4]SentPacket = undefined;
     // largest_acked=5, first_ack_range=10 → would underflow.
@@ -629,7 +672,8 @@ test "loss: rejects invalid first_ack_range > largest_acked" {
 
 test "loss: time-threshold declares old packet lost when gap < k_packet_threshold" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
     // Establish an RTT sample so loss_delay is bounded and deterministic.
     rtt.update(50, 0);
@@ -652,7 +696,8 @@ test "loss: time-threshold declares old packet lost when gap < k_packet_threshol
 
 test "loss: persistent congestion across spread-out losses" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
     // Pin a small SRTT so the PC threshold is small and easy to exceed.
     rtt.update(10, 0);
@@ -683,7 +728,8 @@ test "loss: persistent congestion across spread-out losses" {
 
 test "loss: no persistent congestion when ack proves path is delivering" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
     rtt.update(10, 0);
     const pc_dur = rtt.persistent_congestion_duration_ms(k_max_ack_delay_ms);
@@ -723,7 +769,7 @@ test "loss: persistent_congestion_duration falls back to initial RTT before firs
 test "loss: stream_data is freed on ack and transferred on loss" {
     const testing = std.testing;
     const a = testing.allocator;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(a);
     defer ld.deinit(a);
     var rtt = RttEstimator{};
 
@@ -809,7 +855,7 @@ test "loss: streamDataLooksFreeable rejects corrupt lengths, accepts sane ones" 
 
 test "loss: stream_data ownership survives adversarial send/ack/retransmit churn at cap" {
     // Reproduces the io.zig client retransmit ownership protocol under heavy
-    // load near the 2048-packet cap:
+    // load near the in-flight tracking cap:
     //   - onPacketSent with a heap-owned stream_data slice (dup'd here, like
     //     clientSendRawStreamFrame's `dupe`).  On `false` (LD full) the caller
     //     owns the slice and must free it (io.zig:7571).
@@ -821,7 +867,7 @@ test "loss: stream_data ownership survives adversarial send/ack/retransmit churn
     // testing.allocator flags any double-free / use-after-free / leak.
     const testing = std.testing;
     const a = testing.allocator;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(a);
     defer ld.deinit(a);
     var rtt = RttEstimator{};
 
@@ -906,7 +952,8 @@ test "loss: stream_data ownership survives adversarial send/ack/retransmit churn
 
 test "loss: per-PN-space ACK only affects matching space" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
 
     _ = ld.onPacketSent(.{ .pn = 0, .send_time_ms = 190, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .handshake });
@@ -923,7 +970,8 @@ test "loss: per-PN-space ACK only affects matching space" {
 
 test "loss: abandonSpace drops only the targeted PN space" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     _ = ld.onPacketSent(.{ .pn = 0, .send_time_ms = 100, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .initial });
     _ = ld.onPacketSent(.{ .pn = 1, .send_time_ms = 110, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .handshake });
     _ = ld.onPacketSent(.{ .pn = 2, .send_time_ms = 120, .size = 50, .ack_eliciting = true, .in_flight = true, .space = .application });
@@ -939,7 +987,8 @@ test "loss: abandonSpace drops only the targeted PN space" {
 
 test "deque: contiguous front ack pops front, higher-pn suffix preserved in order" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
     var pn: u64 = 0;
     while (pn < 10) : (pn += 1) {
@@ -963,7 +1012,8 @@ test "deque: contiguous front ack pops front, higher-pn suffix preserved in orde
 
 test "deque: fully acked resets head to 0 and stays usable" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
     var pn: u64 = 0;
     while (pn < 3) : (pn += 1) {
@@ -980,7 +1030,8 @@ test "deque: fully acked resets head to 0 and stays usable" {
 
 test "deque: reorder gap — front losses popped, gap-keepers retained, acked-behind processed via fallback" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
     var pn: u64 = 0;
     while (pn < 5) : (pn += 1) {
@@ -1001,7 +1052,8 @@ test "deque: reorder gap — front losses popped, gap-keepers retained, acked-be
 
 test "deque: head-wrap compaction preserves a sliding in-flight window" {
     const testing = std.testing;
-    var ld = LossDetector{};
+    var ld = try LossDetector.init(testing.allocator);
+    defer ld.deinit(testing.allocator);
     var rtt = RttEstimator{};
     var lost_buf: [4]SentPacket = undefined;
     const win: u64 = 4;

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -1871,6 +1871,12 @@ pub const ConnState = struct {
     /// decrypted, parsed, ACKed and flow-control-credited — only the app
     /// hand-off is paced. See `raw_app_stream.max_raw_app_delivery_per_drive`.
     raw_app_delivery_budget: raw_app_stream.DeliveryBudget = .{},
+    /// Round-robin start cursor for draining `deferred` backlogs across
+    /// `raw_app_streams` (#231). `resetDriveSendBudget(s)` resumes deferred
+    /// streams starting from this index and advances it by one per drive, so a
+    /// low-index stream with a large backlog cannot perennially consume the
+    /// shared `raw_app_delivery_budget` before higher-index slots get a turn.
+    raw_app_resume_cursor: u16 = 0,
     /// Rate-limit `pending-stream-send queue full` warnings (ms).
     pending_stream_send_queue_full_warn_ms: i64 = 0,
     /// Rate-limit for [`maybeLogPendingStreamStall`].
@@ -3238,11 +3244,19 @@ pub const Server = struct {
                 // then bleed any backlog deferred by a prior heavy drive into the
                 // embedder-visible buffers under that allotment.
                 conn.raw_app_delivery_budget = .{};
-                for (&conn.raw_app_streams) |*slot| {
+                // Round-robin (#231): start the resume sweep at a rotating slot
+                // so a low-index backlog can't starve higher-index slots of the
+                // shared delivery budget. Advance the cursor one slot per drive.
+                const n = conn.raw_app_streams.len;
+                const start = conn.raw_app_resume_cursor % n;
+                var off: usize = 0;
+                while (off < n) : (off += 1) {
+                    const slot = &conn.raw_app_streams[(start + off) % n];
                     if (slot.active and slot.deferred.items.len > 0) {
                         raw_app_stream.resumeDeferred(self.allocator, slot, &conn.raw_app_delivery_budget) catch {};
                     }
                 }
+                conn.raw_app_resume_cursor = @intCast((start + 1) % n);
             }
         }
     }
@@ -3958,6 +3972,13 @@ pub const Server = struct {
                     .use_v2 = is_v2,
                     .next_local_uni_stream_id = 3,
                     .next_local_bidi_stream_id = 1,
+                };
+                // Heap-allocate the loss detector's in-flight deque (#233). On
+                // OOM, free the half-built ConnState and refuse the connection
+                // (same failure mode as the `create` above).
+                conn.ld = recovery.LossDetector.init(self.allocator) catch {
+                    self.allocator.destroy(conn);
+                    return null;
                 };
                 slot.* = conn;
                 const pm = path_mtu_mod.initFromConfig(self.config.max_udp_payload);
@@ -5463,7 +5484,9 @@ pub const Server = struct {
                 .cubic => congestion.CongestionController.init(.cubic),
             };
             conn.rtt = .{};
-            conn.ld = .{};
+            // Clear in-flight tracking in place (keeps the heap-backed deque
+            // allocated; frees any attached retransmit buffers) — #233.
+            conn.ld.reset(self.allocator);
         }
 
         var pos: usize = 0;
@@ -8243,10 +8266,11 @@ pub const Client = struct {
     /// stacks after the http/0.9 server arrays grew in v1.6.7).
     fn configureNewConn(
         conn: *ConnState,
+        allocator: std.mem.Allocator,
         config: ClientConfig,
         dcid: ConnectionId,
         scid: ConnectionId,
-    ) void {
+    ) !void {
         conn.* = .{
             .local_cid = scid,
             .remote_cid = dcid,
@@ -8259,6 +8283,8 @@ pub const Client = struct {
             .next_local_uni_stream_id = 2,
             .next_local_bidi_stream_id = 0,
         };
+        // Heap-allocate the loss detector's in-flight deque (#233).
+        conn.ld = try recovery.LossDetector.init(allocator);
         if (config.cubic) {
             conn.cc = congestion.CongestionController.init(.cubic);
         }
@@ -8310,7 +8336,8 @@ pub const Client = struct {
         out.tls = ClientHandshake.init();
         out.active_urls = config.urls;
         out.owns_socket = true;
-        configureNewConn(&out.conn, config, dcid, scid);
+        try configureNewConn(&out.conn, allocator, config, dcid, scid);
+        errdefer out.conn.ld.deinit(allocator);
 
         var client_cert_der: []u8 = &.{};
         var client_cert_owned: bool = false;
@@ -8365,7 +8392,8 @@ pub const Client = struct {
         out.tls = ClientHandshake.init();
         out.active_urls = config.urls;
         out.owns_socket = false;
-        configureNewConn(&out.conn, config, dcid, scid);
+        try configureNewConn(&out.conn, allocator, config, dcid, scid);
+        errdefer out.conn.ld.deinit(allocator);
 
         var client_cert_der: []u8 = &.{};
         var client_cert_owned: bool = false;
@@ -8418,7 +8446,8 @@ pub const Client = struct {
         out.tls = ClientHandshake.init();
         out.active_urls = config.urls;
         out.owns_socket = take_ownership;
-        configureNewConn(&out.conn, config, dcid, scid);
+        try configureNewConn(&out.conn, allocator, config, dcid, scid);
+        errdefer out.conn.ld.deinit(allocator);
 
         var client_cert_der: []u8 = &.{};
         var client_cert_owned: bool = false;
@@ -8512,11 +8541,19 @@ pub const Client = struct {
         // embedder-visible buffers under that allotment. See
         // `raw_app_stream.max_raw_app_delivery_per_drive`.
         self.conn.raw_app_delivery_budget = .{};
-        for (&self.raw_app_recv) |*slot| {
+        // Round-robin (#231): start the resume sweep at a rotating slot so a
+        // low-index backlog can't starve higher-index slots of the shared
+        // delivery budget. Advance the cursor one slot per drive.
+        const n = self.raw_app_recv.len;
+        const start = self.conn.raw_app_resume_cursor % n;
+        var off: usize = 0;
+        while (off < n) : (off += 1) {
+            const slot = &self.raw_app_recv[(start + off) % n];
             if (slot.active and slot.deferred.items.len > 0) {
                 raw_app_stream.resumeDeferred(self.allocator, slot, &self.conn.raw_app_delivery_budget) catch {};
             }
         }
+        self.conn.raw_app_resume_cursor = @intCast((start + 1) % n);
     }
 
     /// Try to put all deferred STREAM bytes on the wire (quinn `poll_transmit`).
@@ -12479,6 +12516,10 @@ test "localCidCount: seq 0 plus pool entries" {
 
 test "client 1-RTT send: loss detector and CC bytes_in_flight stay coupled" {
     var conn = makeConnForStreamTest();
+    // This test exercises the loss detector, so give it a real heap-backed
+    // in-flight deque (#233); the shared helper leaves `ld` inert by default.
+    conn.ld = try recovery.LossDetector.init(std.testing.allocator);
+    defer conn.ld.deinit(std.testing.allocator);
     const pkt_len: usize = 1200;
     const pn: u64 = 7;
     const recorded = conn.ld.onPacketSent(.{
@@ -13688,4 +13729,68 @@ test "raw-app server-initiated bidi: retransmitted frame after release does NOT 
         .has_length = false,
     }, lb.server_addr);
     try std.testing.expectEqual(@as(usize, 0), serverActive(conn));
+}
+
+test "raw-app credit invariant: MAX_DATA applies even when same-packet STREAM bytes are deferred (#231)" {
+    // Structural guarantee hardened in v1.7.63: a packet that carries BOTH a
+    // flow-control credit frame (MAX_DATA / MAX_STREAM_DATA) and a STREAM frame
+    // whose bytes get DEFERRED by the per-drive delivery budget must still apply
+    // the credit in the same drive. `processAppFrames` parses frames in wire
+    // order and the credit handlers are independent of STREAM delivery, so a
+    // deferral of STREAM bytes must NOT skip the credit update. We exhaust the
+    // delivery budget so the STREAM frame is forced to defer, then feed
+    // [STREAM][MAX_DATA] (credit AFTER the deferred STREAM — the meaningful case)
+    // and assert: (a) the STREAM bytes were deferred, AND (b) fc_send_max rose.
+    const allocator = std.testing.allocator;
+    const client = try allocator.create(Client);
+    defer allocator.destroy(client);
+
+    const lb = try rawSetupLoopback(allocator, client);
+    defer lb.server.deinit();
+    defer lb.client.deinit();
+
+    const conn = rawServerConnectedConn(lb.server).?;
+
+    // Exhaust this drive's recv-side delivery budget so any STREAM bytes are
+    // deferred rather than delivered into the embedder-visible buffer.
+    conn.raw_app_delivery_budget.spent = raw_app_stream.max_raw_app_delivery_per_drive;
+
+    const before_fc_send_max = conn.fc_send_max;
+    const new_max_data: u64 = before_fc_send_max + 1_000_000;
+    const sid: u64 = 0; // fresh client-initiated bidi → auto-registers a slot
+
+    // Build one app-frame payload: STREAM(sid=0, "payload", no FIN) then
+    // MAX_DATA(new_max_data).
+    var frames_buf: [128]u8 = undefined;
+    var fp: usize = 0;
+    const sframe = stream_frame_mod.StreamFrame{
+        .stream_id = sid,
+        .offset = 0,
+        .data = "payload-bytes",
+        .fin = false,
+        .has_length = true,
+    };
+    fp += try sframe.serialize(frames_buf[fp..]);
+    // MAX_DATA (0x10) + varint(new_max_data).
+    frames_buf[fp] = 0x10;
+    fp += 1;
+    const enc = try varint.encode(frames_buf[fp..], new_max_data);
+    fp += enc.len;
+
+    lb.server.processAppFrames(conn, frames_buf[0..fp], lb.server_addr);
+
+    // (a) The STREAM bytes were deferred (budget was exhausted), not delivered.
+    var slot_ptr: ?*RawAppStreamSlot = null;
+    for (&conn.raw_app_streams) |*s| {
+        if (s.active and s.stream_id == sid) {
+            slot_ptr = s;
+            break;
+        }
+    }
+    const slot = slot_ptr orelse return error.SlotNotRegistered;
+    try std.testing.expect(slot.deferred.items.len > 0); // bytes parked, not lost
+    try std.testing.expectEqual(@as(usize, 0), slot.buf.items.len); // none delivered
+
+    // (b) The MAX_DATA credit was applied in the SAME drive despite the deferral.
+    try std.testing.expectEqual(new_max_data, conn.fc_send_max);
 }


### PR DESCRIPTION
## Summary

Two filed zquic follow-ups, shipped together (v1.7.64 → v1.7.65).

### #233 — heap-allocate `LossDetector.sent` so the in-flight cap can rise (HIGH)

`LossDetector.sent` was a fixed inline `[max_tracked_packets]SentPacket` array, so `max_tracked_packets` could not be raised: 32768 doubled the on-stack `LossDetector` to ~2 MB and overflowed the stack of on-stack allocations (25 test crashes). Live, connections hit `in-flight tracking cap (16384) reached — packet not tracked`, sending packets **without** loss tracking — a loss-detection blind spot under high cwnd.

- `sent` is now a heap-allocated `[]SentPacket` of length `max_tracked_packets`.
- `LossDetector.init(allocator)` allocates the slice; `deinit` frees `stream_data` **and** the slice (idempotent); new `reset(allocator)` clears the deque in place (RFC 9002 §9.4 path-change) **without** freeing the backing.
- The deque head/tail/wrap logic is **unchanged** — every `sent` access keys off the `max_tracked` constant and `sent.len == max_tracked` after `init`, so the semantics are byte-for-byte identical to the array (same deque invariants).
- Wired into `ConnState`: server `newConn` (OOM → refuse conn), client `configureNewConn` (now `!void`; callers `try` + `errdefer deinit`), server path-change reset (`conn.ld = .{}` → `conn.ld.reset`). Every destroy path already funnels through `freeConnStateRawAppBuffers` → `ld.deinit`, so the slice is freed on conn reap / migration / shutdown with no leak / double-free (verified by `testing.allocator` on the loopback suite).
- Raised `max_tracked_packets` **16384 → 32768** (covers a full 32 MB cwnd ≈ 27k MTU-sized packets); ~+2 MB/conn heap, not stack.

### #231 — recv-side round-robin resume + credit-invariant test (LOWER)

`resetDriveSendBudget(s)` drained `deferred` backlogs in fixed slot order, so a low-index stream sustaining >512 KiB/drive could consume the shared per-drive delivery budget and starve higher-index slots. Added a per-conn round-robin start cursor (`raw_app_resume_cursor`, mirroring the existing `http09_slot_cursor`) so the resume sweep rotates one slot per drive — applied symmetrically on both the `Server` and `Client` resume paths.

Added one unit test asserting the v1.7.63 structural guarantee: a packet carrying a `MAX_DATA` frame **and** a `STREAM` frame whose bytes are deferred by the delivery budget still applies its flow-control credit in the same drive (driven through `processAppFrames` with an exhausted budget).

## Verification

- `zig build` — clean
- `zig build test --summary all` — **278 passed, 1 skipped** (baseline 277/1; +1 from the new credit-invariant test)
- `.version` bumped 1.7.64 → 1.7.65

Do **not** merge/tag — for review.