### PR TITLE
io(client): re-allocate loss detector on resumption/0-RTT reconnect

### DIFF
--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -9584,6 +9584,13 @@ pub const Client = struct {
         self.conn.app_stream_chunk = pm.app_stream_chunk;
         self.conn.plpmtu = path_mtu_mod.PlPmtuState.init(pm.max_udp_payload);
         self.conn.init_keys = InitialSecrets.derive(dcid.slice());
+        // Re-allocate the loss detector: the fresh ConnState above reset `ld` to
+        // its empty default (its heap `sent` ring was freed by the
+        // `freeConnStateRawAppBuffers` call above), so the second connection would
+        // index a zero-length `sent` buffer on its first packet — the
+        // resumption/0-RTT reconnect panic. Mirrors the `LossDetector.init` in
+        // `initInPlace`.
+        self.conn.ld = try recovery.LossDetector.init(self.allocator);
 
         // Fresh TLS handshake state.
         self.tls = ClientHandshake.init();
@@ -13927,4 +13934,28 @@ test "raw-app credit invariant: MAX_DATA applies even when same-packet STREAM by
 
     // (b) The MAX_DATA credit was applied in the SAME drive despite the deferral.
     try std.testing.expectEqual(new_max_data, conn.fc_send_max);
+}
+
+test "resetForReconnect re-allocates the loss detector (resumption/0-RTT reconnect panic)" {
+    const allocator = std.testing.allocator;
+    const client = try allocator.create(Client);
+    defer allocator.destroy(client);
+
+    try Client.initInPlace(allocator, .{
+        .host = "127.0.0.1",
+        .port = 4433,
+        .urls = &.{},
+    }, client);
+    defer client.deinit();
+
+    // The initial connection allocates the loss-detector `sent` ring.
+    try std.testing.expect(client.conn.ld.sent.len > 0);
+
+    // The resumption / 0-RTT second connection reconnects to the same server.
+    // Before the fix this left `conn.ld.sent` empty (len 0), so the first packet
+    // sent on the new connection panicked with an index-out-of-bounds in
+    // `recovery.onPacketSent`. The ring must be re-allocated.
+    const server_addr = try compat.Address.parseIp4("127.0.0.1", 4433);
+    try client.resetForReconnect(server_addr);
+    try std.testing.expect(client.conn.ld.sent.len > 0);
 }


### PR DESCRIPTION
Fixes the long-standing `resumption` and `zerortt` (zquic→zquic) interop failures — they've been red for 6+ days (each timing out at the docker limit).

## Root cause
The interop client makes **two** connections for resumption/0-RTT: connection 1 downloads a URL and stores a `NewSessionTicket`; connection 2 reconnects using TLS 1.3 PSK (+ 0-RTT early data). `Client.resetForReconnect` overwrites `self.conn` with a fresh `ConnState` (whose `ld` defaults to an **empty** loss detector — the heap `sent` ring was freed by the preceding `freeConnStateRawAppBuffers`) and re-initialises `cc` / `plpmtu` / `init_keys` / `tls`, but **never re-`init`s the loss detector**.

So the first packet sent on the second connection (the PSK ClientHello) does:
```
recovery.zig:431:  self.sent[self.head + self.sent_count] = pkt;   // sent.len == 0 → panic
```
```
thread panic: index out of bounds: index 0, len 0
  recovery.onPacketSent → recordAckElicitingSent → sendClientHello → runEventLoop → run
```

## Fix
Re-allocate the loss detector in `resetForReconnect`, mirroring the `LossDetector.init` in `initInPlace` (one line + comment).

## Verification
- **End-to-end with the actual interop binaries** (`zquic-client` ↔ `zquic-server`, `--http09`): both `--resumption` and `--early-data` now download all requested URLs with **zero panics** (before: client panicked on connection 2, downloaded only the first file).
- Adds a regression test (`resetForReconnect re-allocates the loss detector …`) — a negative control confirmed it fails without the fix (index-out-of-bounds) and passes with it.
- Full `zig build test` green.