### PR TITLE
diag: capture inbound Initial outcome (interop dial diagnosis) + v1.7.69

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zquic,
     .fingerprint = 0x947d823dd45c34db,
-    .version = "1.7.68",
+    .version = "1.7.69",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zig_varint = .{

--- a/src/transport/io.zig
+++ b/src/transport/io.zig
@@ -4087,8 +4087,20 @@ pub const Server = struct {
         buf: []const u8,
         src: compat.Address,
     ) void {
+        // ── Inbound-Initial capture (interop diagnosis) ──────────────────────
+        // Log every inbound Initial + the outcome so a capture can tell, per
+        // source, whether we (a) never received it, (b) dropped it (parse /
+        // AEAD / conn-table-full), or (c) decrypted it and are responding (→ a
+        // later failure is the peer rejecting our server cert / transport
+        // params, not us dropping). `.zquic`-scope warn: surfaced only under
+        // DEBUG_QUIC, so it costs nothing in normal operation.
+        const cap_ip = src.any.data[2..6];
+        log.warn("zquic: CAPTURE inbound Initial src={d}.{d}.{d}.{d} buf_len={d} version=0x{x:0>8}", .{
+            cap_ip[0],                                                                                                       cap_ip[1], cap_ip[2], cap_ip[3], buf.len,
+            if (buf.len >= 5) (@as(u32, buf[1]) << 24) | (@as(u32, buf[2]) << 16) | (@as(u32, buf[3]) << 8) | buf[4] else 0,
+        });
         const ip = packet_mod.parseInitial(buf) catch |err| {
-            log.warn("zquic: server Initial parseInitial failed: {s} buf_len={d} first={x:0>2}", .{ @errorName(err), buf.len, if (buf.len > 0) buf[0] else 0 });
+            log.warn("zquic: CAPTURE inbound Initial DROP parseInitial src={d}.{d}.{d}.{d}: {s} buf_len={d} first={x:0>2}", .{ cap_ip[0], cap_ip[1], cap_ip[2], cap_ip[3], @errorName(err), buf.len, if (buf.len > 0) buf[0] else 0 });
             return;
         };
         // Detect QUIC version from raw packet (already validated in processPacket).
@@ -4154,7 +4166,10 @@ pub const Server = struct {
 
             // Truly new connection (new DCID from this peer = new handshake
             // attempt).
-            const c = self.newConn(ip.dcid, ip.scid, src, is_v2_conn) orelse return;
+            const c = self.newConn(ip.dcid, ip.scid, src, is_v2_conn) orelse {
+                log.warn("zquic: CAPTURE inbound Initial DROP newConn-full src={d}.{d}.{d}.{d} (conn table at capacity)", .{ cap_ip[0], cap_ip[1], cap_ip[2], cap_ip[3] });
+                return;
+            };
             break :blk c;
         };
 
@@ -4186,13 +4201,18 @@ pub const Server = struct {
             &init_km.client,
             conn.init_recv_pn,
         ) catch |err| {
-            log.warn("zquic: server Initial AEAD/header-protection failed: {s} dcid_len={d} pn_start={d} payload_len={d}", .{
-                @errorName(err), ip.dcid.len, pn_start, ip.payload_len,
+            log.warn("zquic: CAPTURE inbound Initial DROP AEAD/header-protection src={d}.{d}.{d}.{d}: {s} dcid_len={d} pn_start={d} payload_len={d}", .{
+                cap_ip[0], cap_ip[1], cap_ip[2], cap_ip[3], @errorName(err), ip.dcid.len, pn_start, ip.payload_len,
             });
             return;
         };
         const pt_len = dec.pt_len;
         conn.init_ecn_ect0_recv += 1;
+        // Decrypt succeeded → we accept this Initial and will send our server
+        // flight (Initial + Handshake w/ cert). If the peer's dial still fails
+        // after this, it rejected OUR response (cert / transport params / ALPN),
+        // NOT a drop on our side.
+        log.warn("zquic: CAPTURE inbound Initial decrypted OK src={d}.{d}.{d}.{d} — sending server flight (cert)", .{ cap_ip[0], cap_ip[1], cap_ip[2], cap_ip[3] });
 
         // Compatible version negotiation (RFC 9368): if the server is configured
         // for QUIC v2 but the client sent a v1 Initial, upgrade the connection to


### PR DESCRIPTION
Listener-side capture of every inbound Initial + outcome (entry / parseInitial-drop / AEAD-drop / newConn-full-drop / decrypt-OK), tagged with source IP, to diagnose why rust peer lantern can dial every other client but its QUIC dial to zeam's zquic listener fails (transport timeout, no completion). Distinguishes 'we dropped it' vs 'we answered + peer rejected our cert/transport-params'. .zquic-scope warn (DEBUG_QUIC-gated); log-only. Builds clean.